### PR TITLE
Add opt-in structured JSONL logging to the NScript core pipeline

### DIFF
--- a/NScript_Full.sln
+++ b/NScript_Full.sln
@@ -122,6 +122,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "mscorlib", "mscorlib", "{15
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoApp.Test", "Test\Framework\TodoApp.Test\TodoApp.Test.csproj", "{7560273A-C5D9-476B-B984-B8968CEAB353}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NScript.Utils.Test", "Test\Compiler\NScript.Utils.Test\NScript.Utils.Test.csproj", "{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -588,6 +590,18 @@ Global
 		{7560273A-C5D9-476B-B984-B8968CEAB353}.Release|x86.Build.0 = Release|Any CPU
 		{7560273A-C5D9-476B-B984-B8968CEAB353}.Release|x64.ActiveCfg = Release|Any CPU
 		{7560273A-C5D9-476B-B984-B8968CEAB353}.Release|x64.Build.0 = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|x86.Build.0 = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Debug|x64.Build.0 = Debug|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|x86.ActiveCfg = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|x86.Build.0 = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|x64.ActiveCfg = Release|Any CPU
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -638,6 +652,7 @@ Global
 		{533DC821-2D4A-4DC2-B99D-4677DCFE9EA1} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
 		{15C1B9CC-9023-6FFC-7B44-DDC839BB22D3} = {E2815404-3C9B-4873-AAA1-696B75755BDF}
 		{7560273A-C5D9-476B-B984-B8968CEAB353} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
+		{39C46A80-E00B-481C-B1E4-1A28FE0AD66E} = {C3E4332C-8AEF-4CE7-B1CF-030E7A42342C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {583A0EE8-123E-4527-835C-EF2149A86292}

--- a/README.md
+++ b/README.md
@@ -211,6 +211,47 @@ dotnet test NScript_Full.sln -c Release
 # (See "Building NuGet Packages" section above)
 ```
 
+## Structured Logging (opt-in)
+
+Both compiler stages support opt-in structured JSONL logging. When you pass
+`--log <path>` to either `csc` (Stage 1) or `cs2jsc` (Stage 2), every stage of
+the pipeline writes structured events to that single file. When the flag is
+omitted the pipeline performs no logger bootstrap and no file I/O — default
+behavior is unchanged.
+
+```bash
+# Stage 2 (cs2jsc)
+NScript -outJs app.js -references Foo.dll -entryAssembly App.dll --log build.jsonl --runid my-build-001
+
+# Stage 1 (csc)
+csc.exe Program.cs --log build.jsonl --run-id my-build-001
+```
+
+Cross-stage correlation: pass the **same** `--log` path and the **same**
+`--run-id` to both stages in a build; every event carries the `RunId` property
+so records from `csc` and `cs2jsc` can be joined on the shared timeline.
+
+Environment variable fallbacks:
+
+- `NSCRIPT_LOG_PATH` — used when `--log` is not supplied
+- `NSCRIPT_LOG_RUNID` — used when `--run-id` is not supplied
+
+Each line is a single JSON object (Serilog `CompactJsonFormatter`) with these
+standard fields:
+
+- `@t` — ISO-8601 timestamp
+- `@l` — log level (`Information`, `Warning`, `Error`, `Debug`, `Verbose`)
+- `Component` — source component (e.g. `Builder`, `Converter`, `XwmlParser`,
+  `RazorSkinParser`, `Csc.Serialization`, `NScriptCompiler`)
+- `Stage` — `csc` or `cs2jsc`
+- `RunId` — correlation id
+- `Pid`, `MachineName` — process and host identifiers
+
+See `docs/adr/0025-opt-in-structured-jsonl-logging.md` for the design
+rationale. Prior to this feature `RazorSkinParser` wrote to a hard-coded
+`logs/razor-skin-compiler.log.jsonl` file; that file is no longer produced.
+Pass `--log` (or set `NSCRIPT_LOG_PATH`) to re-enable a log stream.
+
 ## Directory Structure
 
 ```text

--- a/Sources/Compiler/NScript.Converter/Builder.cs
+++ b/Sources/Compiler/NScript.Converter/Builder.cs
@@ -93,11 +93,17 @@ namespace NScript.Converter
         /// </returns>
         public bool Execute()
         {
+            var log = CompilerLog.ForComponent("Builder");
+            var totalSw = System.Diagnostics.Stopwatch.StartNew();
+            log.Information("Builder.Start {MainAssembly} {ReferenceCount}", this.mainAssembly, this.references?.Length ?? 0);
+
             if (!this.VerifyPaths())
             {
+                log.Warning("Builder.VerifyPaths failed");
                 return false;
             }
 
+            var loadSw = System.Diagnostics.Stopwatch.StartNew();
             ClrContext clrContext = new ClrContext();
             foreach (var reference in references)
             {
@@ -105,6 +111,8 @@ namespace NScript.Converter
             }
 
             clrContext.LoadAssembly(this.mainAssembly);
+            loadSw.Stop();
+            log.Information("LoadAssemblies completed in {ElapsedMs}ms", loadSw.ElapsedMilliseconds);
 
             RuntimeScopeManager runtimeManager;
             ConverterContext converterContext;
@@ -221,11 +229,13 @@ namespace NScript.Converter
                     scriptGenerateSettings.minify);
                 stopWatch.Stop();
                 System.Console.WriteLine("Root scope naming time taken: {0}", stopWatch.ElapsedMilliseconds);
+                log.Information("RootScopeNaming completed in {ElapsedMs}ms", stopWatch.ElapsedMilliseconds);
                 stopWatch.Restart();
                 IdentifierScope.IdentifierMinifiedNamer.MinifyNames(
                     runtimeManager.JSBaseObjectScopeManager.InstanceScope,
                     scriptGenerateSettings.minify);
                 System.Console.WriteLine("Instance scope naming time taken: {0}", stopWatch.ElapsedMilliseconds);
+                log.Information("InstanceScopeNaming completed in {ElapsedMs}ms", stopWatch.ElapsedMilliseconds);
 
                 var writer = new JSWriter(true, scriptGenerateSettings.uglify);
                 var initializerStatement = runtimeManager.GetVariableDeclarations();
@@ -247,6 +257,7 @@ namespace NScript.Converter
                     string.Format(
                         "SrcMapper.ashx?js={0}&fname=",
                         Path.GetFileName(this.jsScript)));
+                log.Information("JSWriter.End {JsScript}", this.jsScript);
             }
             catch(ConverterLocationException ex)
             {
@@ -307,6 +318,13 @@ namespace NScript.Converter
                             warning.Item2));
                 }
             }
+
+            totalSw.Stop();
+            log.Information(
+                "Builder.End {ElapsedMs}ms Warnings={WarningCount} Errors={ErrorCount}",
+                totalSw.ElapsedMilliseconds,
+                converterContext.Warnings.Count,
+                converterContext.Errors.Count);
 
             return true;
         }

--- a/Sources/Compiler/NScript.Converter/ConverterContext.cs
+++ b/Sources/Compiler/NScript.Converter/ConverterContext.cs
@@ -357,6 +357,29 @@ namespace NScript.Converter
         {
             List<Tuple<Location, string>> list = isWarning ? this.warnings : this.errors;
             list.Add(Tuple.Create(location, error));
+
+            if (CompilerLog.IsEnabled)
+            {
+                var log = CompilerLog.ForComponent("Converter");
+                if (isWarning)
+                {
+                    log.Warning(
+                        "ConverterWarning {File}({Line},{Column}): {Message}",
+                        location?.FileName,
+                        location?.StartLine ?? 0,
+                        location?.StartColumn ?? 0,
+                        error);
+                }
+                else
+                {
+                    log.Error(
+                        "ConverterError {File}({Line},{Column}): {Message}",
+                        location?.FileName,
+                        location?.StartLine ?? 0,
+                        location?.StartColumn ?? 0,
+                        error);
+                }
+            }
         }
 
         /// <summary>

--- a/Sources/Compiler/NScript.Csc.Lib/Csc.cs
+++ b/Sources/Compiler/NScript.Csc.Lib/Csc.cs
@@ -17,17 +17,129 @@ namespace NScript.Csc.Lib
     using Microsoft.CodeAnalysis.Emit;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+    using NScript.Utils;
 
     public static class CscCompiler
     {
         public static int Main(string[] args)
         {
-            var loader = new NScriptAnalyzerAssemblyLoader();
-            return DesktopBuildClient.Run(
-                args,
-                RequestLanguage.CSharpCompile,
-                Csc.Run,
-                loader);
+            // Strip NScript-specific flags (--log, --run-id) out of args before Roslyn
+            // sees them; Roslyn's CommandLineParser would reject unknown switches.
+            // Supports both space-delimited ("--log path") and colon-delimited ("--log:path") forms,
+            // matching csc conventions. Also honors NSCRIPT_LOG_PATH / NSCRIPT_LOG_RUNID env vars.
+            var strippedArgs = ExtractNScriptFlags(args, out var logPath, out var runId);
+
+            CompilerLog.Initialize(logPath, "csc", runId);
+
+            try
+            {
+                var loader = new NScriptAnalyzerAssemblyLoader();
+                return DesktopBuildClient.Run(
+                    strippedArgs,
+                    RequestLanguage.CSharpCompile,
+                    Csc.Run,
+                    loader);
+            }
+            finally
+            {
+                CompilerLog.Shutdown();
+            }
+        }
+
+        /// <summary>
+        /// Removes NScript-only switches (<c>--log</c>, <c>--run-id</c>, and their
+        /// short aliases) from the argv and returns the path and run id through out
+        /// parameters. Supports both <c>--log path</c> and <c>--log:path</c> forms.
+        /// Public for testability — downstream callers should not rely on it.
+        /// </summary>
+        public static string[] ExtractNScriptFlags(string[] args, out string logPath, out string runId)
+        {
+            logPath = null;
+            runId = null;
+            if (args == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var filtered = new List<string>(args.Length);
+            for (int i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+                if (TryConsumeFlag(args, ref i, arg, "--log", "-log", "/log", out var pathValue))
+                {
+                    logPath = pathValue;
+                    continue;
+                }
+
+                if (TryConsumeFlag(args, ref i, arg, "--run-id", "-runid", "/runid", out var runIdValue))
+                {
+                    runId = runIdValue;
+                    continue;
+                }
+
+                filtered.Add(arg);
+            }
+
+            return filtered.ToArray();
+        }
+
+        private static bool TryConsumeFlag(
+            string[] args,
+            ref int index,
+            string current,
+            string longForm,
+            string shortForm,
+            string slashForm,
+            out string value)
+        {
+            value = null;
+            if (string.IsNullOrEmpty(current))
+            {
+                return false;
+            }
+
+            // Space-delimited: "--log" <path>
+            if (string.Equals(current, longForm, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(current, shortForm, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(current, slashForm, StringComparison.OrdinalIgnoreCase))
+            {
+                if (index + 1 < args.Length)
+                {
+                    value = args[index + 1];
+                    index++; // consume the value
+                }
+
+                return true;
+            }
+
+            // Colon- or equals-delimited: "--log:path", "--log=path"
+            if (TryParseInline(current, longForm, out value)
+                || TryParseInline(current, shortForm, out value)
+                || TryParseInline(current, slashForm, out value))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryParseInline(string current, string flagName, out string value)
+        {
+            value = null;
+            if (current.Length <= flagName.Length
+                || !current.StartsWith(flagName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var delimiter = current[flagName.Length];
+            if (delimiter != ':' && delimiter != '=')
+            {
+                return false;
+            }
+
+            value = current.Substring(flagName.Length + 1);
+            return true;
         }
     }
 

--- a/Sources/Compiler/NScript.Csc.Lib/NScript.csc.lib.csproj
+++ b/Sources/Compiler/NScript.Csc.Lib/NScript.csc.lib.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\JsCsc.Lib\JsCsc.Lib.csproj" />
     <ProjectReference Include="..\NScript.CLR\NScript.CLR.csproj" />
+    <ProjectReference Include="..\NScript.Utils\NScript.Utils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Compiler/NScript.Csc.Lib/SerializationHelper.cs
+++ b/Sources/Compiler/NScript.Csc.Lib/SerializationHelper.cs
@@ -8,6 +8,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Symbols;
     using Microsoft.CodeAnalysis.Emit;
+    using NScript.Utils;
 
     public static class SerializationHelper
     {
@@ -85,11 +86,27 @@
                         (IMethodSymbol)((ISymbolInternal)methodSymbol).GetISymbol(),
                         methodBody);
                 }
+
+                if (CompilerLog.IsEnabled)
+                {
+                    CompilerLog.ForComponent("Csc.Serialization").Debug(
+                        "BoundBodyCaptured {Method}",
+                        methodSymbol?.ToDisplayString());
+                }
             };
 
             var astResource = new ResourceDescription(
                 "$$BstInfo$$",
-                () => ToAstStream(context, rv),
+                () =>
+                {
+                    if (CompilerLog.IsEnabled)
+                    {
+                        CompilerLog.ForComponent("Csc.Serialization").Information(
+                            "BstInfoResourceWritten MethodCount={MethodCount}",
+                            rv.Count);
+                    }
+                    return ToAstStream(context, rv);
+                },
                 true);
 
             return (new ResourceDescription[] { astResource }, rv);

--- a/Sources/Compiler/NScript.Lib/CommandLine.cs
+++ b/Sources/Compiler/NScript.Lib/CommandLine.cs
@@ -1,10 +1,11 @@
-﻿namespace NScript.Lib
+namespace NScript.Lib
 {
     using System;
     using System.Collections.Generic;
     using NScript.Converter;
     using NScript.Converter.Plugins;
     using NScript.RazorSkin;
+    using NScript.Utils;
     using XwmlParser;
 
     public static class NScriptCompiler
@@ -20,32 +21,51 @@
                 return 1;
             }
 
-            var plugins = new List<IConverterPlugin>()
+            // Opt-in: only initialize structured logging when --log is supplied
+            // (or the NSCRIPT_LOG_PATH env var is set, resolved by CompilerLog).
+            CompilerLog.Initialize(parseOptions.LogPath, "cs2jsc", parseOptions.RunId);
+
+            try
             {
-                // Razor MUST be before XWML: the first plugin returning Overwrite wins,
-                // and XWML would claim [Skin] attributes for .skin.cshtml templates
-                // then fail because it only handles .html templates.
-                new RazorTemplatingPlugin(),
-                new XwmlTemplatingPlugin(),
-                new TestGenerator()
-            };
+                var plugins = new List<IConverterPlugin>()
+                {
+                    // Razor MUST be before XWML: the first plugin returning Overwrite wins,
+                    // and XWML would claim [Skin] attributes for .skin.cshtml templates
+                    // then fail because it only handles .html templates.
+                    new RazorTemplatingPlugin(),
+                    new XwmlTemplatingPlugin(),
+                    new TestGenerator()
+                };
 
-            var builder = new Builder(
-                parseOptions.JsFileName,
-                parseOptions.JsParts,
-                parseOptions.EntryAssembly,
-                parseOptions.ReferenceDlls.ToArray(),
-                plugins.ToArray(),
-                (parseOptions.Minify, parseOptions.Uglify, parseOptions.Optimize));
+                var builder = new Builder(
+                    parseOptions.JsFileName,
+                    parseOptions.JsParts,
+                    parseOptions.EntryAssembly,
+                    parseOptions.ReferenceDlls.ToArray(),
+                    plugins.ToArray(),
+                    (parseOptions.Minify, parseOptions.Uglify, parseOptions.Optimize));
 
-            var stopWatch = new System.Diagnostics.Stopwatch();
-            stopWatch.Start();
+                var stopWatch = new System.Diagnostics.Stopwatch();
+                stopWatch.Start();
 
-            _ = builder.Execute();
+                _ = builder.Execute();
 
-            stopWatch.Stop();
-            System.Console.WriteLine("TimeTaken[cs2jsc]: {0}ms", stopWatch.ElapsedMilliseconds);
-            return 0;
+                stopWatch.Stop();
+                System.Console.WriteLine("TimeTaken[cs2jsc]: {0}ms", stopWatch.ElapsedMilliseconds);
+
+                if (CompilerLog.IsEnabled)
+                {
+                    CompilerLog.ForComponent("NScriptCompiler").Information(
+                        "cs2jsc total duration {ElapsedMs}ms",
+                        stopWatch.ElapsedMilliseconds);
+                }
+
+                return 0;
+            }
+            finally
+            {
+                CompilerLog.Shutdown();
+            }
         }
     }
 }

--- a/Sources/Compiler/NScript.Lib/ParseOptions.cs
+++ b/Sources/Compiler/NScript.Lib/ParseOptions.cs
@@ -159,7 +159,25 @@ namespace NScript.Lib
 
             for (int iArg = 0; iArg < args.Length; iArg++)
             {
-                switch (args[iArg].ToLowerInvariant())
+                var argLower = args[iArg].ToLowerInvariant();
+
+                // Handle inline-delimited log/runid flags: --log:path, /log=path, etc.
+                // This mirrors Stage 1 (Csc.cs) colon/equals support.
+                if (TryExtractInlineValue(argLower, args[iArg],
+                    new[] { "--log", "-log", "/log" }, out var inlineLogPath))
+                {
+                    options.logPath = inlineLogPath;
+                    continue;
+                }
+
+                if (TryExtractInlineValue(argLower, args[iArg],
+                    new[] { "--run-id", "-runid", "/runid" }, out var inlineRunId))
+                {
+                    options.runId = inlineRunId;
+                    continue;
+                }
+
+                switch (argLower)
                 {
                     case "-outjs":
                         option = CurrentOption.None;
@@ -229,29 +247,27 @@ namespace NScript.Lib
                         continue;
                     case "-log":
                     case "--log":
+                    case "/log":
                         option = CurrentOption.None;
-                        if (++iArg < args.Length)
+                        if (iArg + 1 < args.Length)
                         {
+                            iArg++;
                             options.logPath = args[iArg];
                         }
-                        else
-                        {
-                            Logger.Instance.LogError("-log requires a path argument");
-                            return null;
-                        }
+
+                        // No value provided — logging stays disabled (matches Stage 1).
                         continue;
                     case "-runid":
                     case "--run-id":
+                    case "/runid":
                         option = CurrentOption.None;
-                        if (++iArg < args.Length)
+                        if (iArg + 1 < args.Length)
                         {
+                            iArg++;
                             options.runId = args[iArg];
                         }
-                        else
-                        {
-                            Logger.Instance.LogError("-runid requires an id argument");
-                            return null;
-                        }
+
+                        // No value provided — a GUID is generated at init (matches Stage 1).
                         continue;
                     default:
                         break;
@@ -366,6 +382,35 @@ namespace NScript.Lib
         {
             Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-log <jsonl path>] [-runid <id>]");
             Environment.Exit(1);
+        }
+
+        /// <summary>
+        /// Tries to extract an inline value from an arg like <c>--log:path</c> or <c>--log=path</c>.
+        /// </summary>
+        /// <param name="argLower">The arg lowercased.</param>
+        /// <param name="originalArg">The original arg (preserves case for the value).</param>
+        /// <param name="prefixes">Lowercase flag prefixes to match (e.g. "--log", "-log", "/log").</param>
+        /// <param name="value">The extracted value, or null.</param>
+        /// <returns>True if an inline-delimited match was found.</returns>
+        internal static bool TryExtractInlineValue(
+            string argLower,
+            string originalArg,
+            string[] prefixes,
+            out string value)
+        {
+            value = null;
+            foreach (var prefix in prefixes)
+            {
+                if (argLower.Length > prefix.Length
+                    && argLower.StartsWith(prefix, StringComparison.Ordinal)
+                    && (argLower[prefix.Length] == ':' || argLower[prefix.Length] == '='))
+                {
+                    value = originalArg.Substring(prefix.Length + 1);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Sources/Compiler/NScript.Lib/ParseOptions.cs
+++ b/Sources/Compiler/NScript.Lib/ParseOptions.cs
@@ -62,6 +62,16 @@ namespace NScript.Lib
         private bool optimize = false;
 
         /// <summary>
+        /// Optional structured log file path (null => logging disabled).
+        /// </summary>
+        private string logPath;
+
+        /// <summary>
+        /// Optional run id for cross-stage log correlation.
+        /// </summary>
+        private string runId;
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="ParseOptions"/> class from being created.
         /// </summary>
         private ParseOptions()
@@ -120,6 +130,16 @@ namespace NScript.Lib
         public bool Uglify => this.uglify;
 
         public bool Optimize => this.optimize;
+
+        /// <summary>
+        /// Gets the structured log file path, or null when <c>--log</c> was not supplied.
+        /// </summary>
+        public string LogPath => this.logPath;
+
+        /// <summary>
+        /// Gets the run id for cross-stage log correlation, or null when <c>--run-id</c> was not supplied.
+        /// </summary>
+        public string RunId => this.runId;
 
         /// <summary>
         /// Parses the args.
@@ -206,6 +226,32 @@ namespace NScript.Lib
                         continue;
                     case "-optimize":
                         options.optimize = true;
+                        continue;
+                    case "-log":
+                    case "--log":
+                        option = CurrentOption.None;
+                        if (++iArg < args.Length)
+                        {
+                            options.logPath = args[iArg];
+                        }
+                        else
+                        {
+                            Logger.Instance.LogError("-log requires a path argument");
+                            return null;
+                        }
+                        continue;
+                    case "-runid":
+                    case "--run-id":
+                        option = CurrentOption.None;
+                        if (++iArg < args.Length)
+                        {
+                            options.runId = args[iArg];
+                        }
+                        else
+                        {
+                            Logger.Instance.LogError("-runid requires an id argument");
+                            return null;
+                        }
                         continue;
                     default:
                         break;
@@ -318,7 +364,7 @@ namespace NScript.Lib
         /// </summary>
         public static void PrintUsage()
         {
-            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>]");
+            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-log <jsonl path>] [-runid <id>]");
             Environment.Exit(1);
         }
 

--- a/Sources/Compiler/NScript.Utils/CompilerLog.cs
+++ b/Sources/Compiler/NScript.Utils/CompilerLog.cs
@@ -1,0 +1,243 @@
+//-----------------------------------------------------------------------
+// <copyright file="CompilerLog.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.Utils
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using Serilog;
+    using Serilog.Formatting.Compact;
+
+    /// <summary>
+    /// Shared opt-in structured JSONL logging facility for the NScript compiler
+    /// pipeline. When <see cref="Initialize(string, string, string)"/> has not been
+    /// called, <see cref="ForComponent(string)"/> returns a silent no-op logger and
+    /// no file I/O occurs — preserving the default zero-overhead path.
+    ///
+    /// Both compiler stages (Stage 1 <c>csc</c>, Stage 2 <c>cs2jsc</c>) may write to
+    /// the same log file in a single build. The file sink is opened in shared-append
+    /// mode so cross-process writes coexist. A <c>RunId</c> property enriches every
+    /// event for cross-stage correlation.
+    /// </summary>
+    public static class CompilerLog
+    {
+        /// <summary>
+        /// Environment variable fallback for the log file path. Useful when csc is
+        /// invoked via MSBuild response files where adding custom tokens is awkward.
+        /// </summary>
+        public const string LogPathEnvVar = "NSCRIPT_LOG_PATH";
+
+        /// <summary>
+        /// Environment variable fallback for the run id.
+        /// </summary>
+        public const string RunIdEnvVar = "NSCRIPT_LOG_RUNID";
+
+        private static readonly object initLock = new object();
+
+        /// <summary>
+        /// Shared no-op logger returned when structured logging is disabled.
+        /// A `LoggerConfiguration` with no sinks silently discards every event —
+        /// no allocations aside from the logger itself, which is singleton.
+        /// </summary>
+        private static readonly ILogger silentLogger =
+            new LoggerConfiguration().CreateLogger();
+
+        private static volatile bool isEnabled;
+
+        private static ILogger rootLogger;
+
+        private static string resolvedLogPath;
+
+        private static string resolvedRunId;
+
+        private static string resolvedStage;
+
+        /// <summary>
+        /// Gets a value indicating whether structured logging is enabled.
+        /// </summary>
+        public static bool IsEnabled => isEnabled;
+
+        /// <summary>
+        /// Gets the resolved log file path (null when not initialized).
+        /// </summary>
+        public static string LogPath => resolvedLogPath;
+
+        /// <summary>
+        /// Gets the resolved run id (null when not initialized).
+        /// </summary>
+        public static string RunId => resolvedRunId;
+
+        /// <summary>
+        /// Gets the resolved stage name (null when not initialized).
+        /// </summary>
+        public static string Stage => resolvedStage;
+
+        /// <summary>
+        /// Initialize the shared logger. Idempotent — repeated calls are a no-op.
+        /// Safe to call from any stage entry point.
+        /// </summary>
+        /// <param name="path">     Log file path. When null or whitespace, logging stays disabled. </param>
+        /// <param name="stage">    Stage label (e.g. "csc", "cs2jsc"). Defaults to "unknown". </param>
+        /// <param name="runId">    Optional cross-process run correlation id. When null, env var or a fresh GUID is used. </param>
+        public static void Initialize(string path, string stage, string runId = null)
+        {
+            if (isEnabled)
+            {
+                return;
+            }
+
+            var resolvedPath = ResolveLogPath(path);
+            if (string.IsNullOrWhiteSpace(resolvedPath))
+            {
+                return;
+            }
+
+            lock (initLock)
+            {
+                if (isEnabled)
+                {
+                    return;
+                }
+
+                try
+                {
+                    EnsureDirectoryExists(resolvedPath);
+
+                    var effectiveStage = string.IsNullOrWhiteSpace(stage) ? "unknown" : stage;
+                    var effectiveRunId = ResolveRunId(runId);
+
+                    var configuration = new LoggerConfiguration()
+                        .MinimumLevel.Verbose()
+                        .Enrich.WithProperty("RunId", effectiveRunId)
+                        .Enrich.WithProperty("Stage", effectiveStage)
+                        .Enrich.WithProperty("Pid", Process.GetCurrentProcess().Id)
+                        .Enrich.WithProperty("MachineName", Environment.MachineName)
+                        .WriteTo.File(
+                            formatter: new CompactJsonFormatter(),
+                            path: resolvedPath,
+                            shared: true,
+                            rollOnFileSizeLimit: false,
+                            flushToDiskInterval: TimeSpan.FromSeconds(1));
+
+                    rootLogger = configuration.CreateLogger();
+                    Log.Logger = rootLogger;
+
+                    resolvedLogPath = resolvedPath;
+                    resolvedRunId = effectiveRunId;
+                    resolvedStage = effectiveStage;
+                    isEnabled = true;
+                }
+                catch (Exception ex)
+                {
+                    // Logger bootstrap must never break the compiler. Surface a one-line
+                    // stderr warning and continue with logging disabled.
+                    Console.Error.WriteLine($"CompilerLog: failed to initialize ({ex.Message}); logging disabled.");
+                    rootLogger = null;
+                    isEnabled = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a logger enriched with the given <c>Component</c> name. When the
+        /// shared logger has not been initialized, returns a silent no-op logger.
+        /// </summary>
+        public static ILogger ForComponent(string component)
+        {
+            if (!isEnabled || rootLogger == null)
+            {
+                return silentLogger;
+            }
+
+            return rootLogger.ForContext("Component", component ?? "unknown");
+        }
+
+        /// <summary>
+        /// Flushes and closes the shared logger. Safe to call when not initialized.
+        /// </summary>
+        public static void Shutdown()
+        {
+            if (!isEnabled)
+            {
+                return;
+            }
+
+            lock (initLock)
+            {
+                if (!isEnabled)
+                {
+                    return;
+                }
+
+                try
+                {
+                    Log.CloseAndFlush();
+                }
+                catch
+                {
+                    // Swallow on shutdown — nothing we can do about a logger that is already disposed.
+                }
+                finally
+                {
+                    rootLogger = null;
+                    resolvedLogPath = null;
+                    resolvedRunId = null;
+                    resolvedStage = null;
+                    isEnabled = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolve a run id from (in priority order) explicit arg, <see cref="RunIdEnvVar"/>, or a fresh GUID.
+        /// </summary>
+        public static string ResolveRunId(string explicitId)
+        {
+            if (!string.IsNullOrWhiteSpace(explicitId))
+            {
+                return explicitId.Trim();
+            }
+
+            var fromEnv = Environment.GetEnvironmentVariable(RunIdEnvVar);
+            if (!string.IsNullOrWhiteSpace(fromEnv))
+            {
+                return fromEnv.Trim();
+            }
+
+            return Guid.NewGuid().ToString("N");
+        }
+
+        /// <summary>
+        /// Resolve a log path from (in priority order) explicit arg or <see cref="LogPathEnvVar"/>.
+        /// Returns null (logging disabled) when neither is provided.
+        /// </summary>
+        public static string ResolveLogPath(string explicitPath)
+        {
+            if (!string.IsNullOrWhiteSpace(explicitPath))
+            {
+                return explicitPath.Trim();
+            }
+
+            var fromEnv = Environment.GetEnvironmentVariable(LogPathEnvVar);
+            if (!string.IsNullOrWhiteSpace(fromEnv))
+            {
+                return fromEnv.Trim();
+            }
+
+            return null;
+        }
+
+        private static void EnsureDirectoryExists(string path)
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+    }
+}

--- a/Sources/Compiler/NScript.Utils/CompilerLog.cs
+++ b/Sources/Compiler/NScript.Utils/CompilerLog.cs
@@ -7,6 +7,7 @@
 namespace NScript.Utils
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Diagnostics;
     using System.IO;
     using Serilog;
@@ -45,6 +46,13 @@ namespace NScript.Utils
         /// </summary>
         private static readonly ILogger silentLogger =
             new LoggerConfiguration().CreateLogger();
+
+        /// <summary>
+        /// Cache of per-component enriched loggers. Cleared on <see cref="Shutdown"/>
+        /// so cached values never outlive the underlying sink.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, ILogger> componentCache =
+            new ConcurrentDictionary<string, ILogger>();
 
         private static volatile bool isEnabled;
 
@@ -145,15 +153,26 @@ namespace NScript.Utils
         /// <summary>
         /// Returns a logger enriched with the given <c>Component</c> name. When the
         /// shared logger has not been initialized, returns a silent no-op logger.
+        /// Returned loggers are cached per component name and invalidated on
+        /// <see cref="Shutdown"/> so callers may store the result without lifecycle concerns.
         /// </summary>
         public static ILogger ForComponent(string component)
         {
-            if (!isEnabled || rootLogger == null)
+            var logger = rootLogger;
+            if (!isEnabled || logger == null)
             {
                 return silentLogger;
             }
 
-            return rootLogger.ForContext("Component", component ?? "unknown");
+            var key = component ?? "unknown";
+            if (componentCache.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            var enriched = logger.ForContext("Component", key);
+            componentCache.TryAdd(key, enriched);
+            return enriched;
         }
 
         /// <summary>
@@ -177,12 +196,13 @@ namespace NScript.Utils
                 {
                     Log.CloseAndFlush();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Swallow on shutdown — nothing we can do about a logger that is already disposed.
+                    Console.Error.WriteLine($"CompilerLog: flush failed during shutdown ({ex.Message}).");
                 }
                 finally
                 {
+                    componentCache.Clear();
                     rootLogger = null;
                     resolvedLogPath = null;
                     resolvedRunId = null;

--- a/Sources/Compiler/NScript.Utils/NScript.Utils.csproj
+++ b/Sources/Compiler/NScript.Utils/NScript.Utils.csproj
@@ -11,5 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/Sources/Compiler/RazorSkinParser/RazorSkinCompiler.cs
+++ b/Sources/Compiler/RazorSkinParser/RazorSkinCompiler.cs
@@ -1,27 +1,20 @@
 using System.Diagnostics;
 using NScript.RazorSkin.CodeGen;
 using NScript.RazorSkin.TemplateIR;
+using NScript.Utils;
 using Serilog;
-using Serilog.Formatting.Compact;
 
 namespace NScript.RazorSkin
 {
     public static class RazorSkinCompiler
     {
-        private static readonly ILogger Log = new LoggerConfiguration()
-            .MinimumLevel.Verbose()
-            .Enrich.WithProperty("application", "RazorSkinCompiler")
-            .WriteTo.File(
-                formatter: new CompactJsonFormatter(),
-                path: "logs/razor-skin-compiler.log.jsonl",
-                rollingInterval: RollingInterval.Day,
-                retainedFileCountLimit: 7)
-            .CreateLogger();
-
         /// <summary>
-        /// Static logger accessible to other classes in the pipeline.
+        /// Static logger accessible to other classes in the pipeline. Routes through
+        /// the shared <see cref="CompilerLog"/> facility — returns a silent no-op
+        /// logger when <c>--log</c> has not been supplied to the host (csc/cs2jsc),
+        /// so no file I/O occurs by default.
         /// </summary>
-        public static ILogger Logger => Log;
+        public static ILogger Logger => CompilerLog.ForComponent("RazorSkinParser");
 
         /// <summary>
         /// Compiles a .skin.cshtml template through all phases and returns the template IR.
@@ -32,39 +25,40 @@ namespace NScript.RazorSkin
             string templateSource,
             string[] additionalCSharpSources = null)
         {
+            var log = Logger;
             var totalSw = Stopwatch.StartNew();
-            Log.Debug("Compile started for template {TemplateName}", templateName);
+            log.Debug("Compile started for template {TemplateName}", templateName);
 
             // Phase 1: Preprocess
             var phaseSw = Stopwatch.StartNew();
-            Log.Debug("Phase {Phase} started for template {TemplateName}", "Preprocess", templateName);
+            log.Debug("Phase {Phase} started for template {TemplateName}", "Preprocess", templateName);
             var preprocessed = RazorSkinPreprocessor.Process(templateSource);
-            Log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "Preprocess", phaseSw.ElapsedMilliseconds, templateName);
+            log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "Preprocess", phaseSw.ElapsedMilliseconds, templateName);
 
             // Phase 2: Razor parse
             phaseSw.Restart();
-            Log.Debug("Phase {Phase} started for template {TemplateName}", "RazorParse", templateName);
+            log.Debug("Phase {Phase} started for template {TemplateName}", "RazorParse", templateName);
             var parsed = RazorParserPhase.Parse(templateName, preprocessed.CleanedTemplate);
-            Log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "RazorParse", phaseSw.ElapsedMilliseconds, templateName);
+            log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "RazorParse", phaseSw.ElapsedMilliseconds, templateName);
 
             // Phase 3: Build IR
             phaseSw.Restart();
-            Log.Debug("Phase {Phase} started for template {TemplateName}", "BuildIR", templateName);
+            log.Debug("Phase {Phase} started for template {TemplateName}", "BuildIR", templateName);
             var ir = TemplateIRBuilder.Build(templateName, preprocessed, parsed);
-            Log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "BuildIR", phaseSw.ElapsedMilliseconds, templateName);
+            log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "BuildIR", phaseSw.ElapsedMilliseconds, templateName);
 
             // Phase 4: Roslyn analysis (refine classifications)
             if (additionalCSharpSources != null && additionalCSharpSources.Length > 0)
             {
                 phaseSw.Restart();
-                Log.Debug("Phase {Phase} started for template {TemplateName}", "RoslynAnalysis", templateName);
+                log.Debug("Phase {Phase} started for template {TemplateName}", "RoslynAnalysis", templateName);
                 RoslynAnalysisPhase.RefineClassifications(
                     ir, parsed.GeneratedCSharp, additionalCSharpSources);
-                Log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "RoslynAnalysis", phaseSw.ElapsedMilliseconds, templateName);
+                log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "RoslynAnalysis", phaseSw.ElapsedMilliseconds, templateName);
             }
 
             totalSw.Stop();
-            Log.Debug("Compile completed successfully in {TotalElapsedMs}ms for template {TemplateName}", totalSw.ElapsedMilliseconds, templateName);
+            log.Debug("Compile completed successfully in {TotalElapsedMs}ms for template {TemplateName}", totalSw.ElapsedMilliseconds, templateName);
 
             return ir;
         }

--- a/Sources/Compiler/XwmlParser/XwmlTemplatingPlugin.cs
+++ b/Sources/Compiler/XwmlParser/XwmlTemplatingPlugin.cs
@@ -98,6 +98,15 @@
                 this.knownCssClasses.Split(new char[]{',', ' '}, StringSplitOptions.RemoveEmptyEntries));
 
             this.parserContext.ConverterContext = runtimeScopeManager.Context;
+
+            if (CompilerLog.IsEnabled)
+            {
+                CompilerLog.ForComponent("XwmlParser").Information(
+                    "XwmlParser.Initialized KnownCssClassCount={Count}",
+                    string.IsNullOrEmpty(this.knownCssClasses)
+                        ? 0
+                        : this.knownCssClasses.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries).Length);
+            }
         }
 
         public void ParseArgs(IList<Tuple<string, string>> args)
@@ -140,6 +149,12 @@
                 .CustomAttributes.SelectAttribute(knownTemplateTypes.SkinAttribute);
 
             var templateName = attr.ConstructorArguments[0].Value as string;
+
+            if (CompilerLog.IsEnabled)
+            {
+                CompilerLog.ForComponent("XwmlParser").Information(
+                    "XwmlParser.Template {TemplateName}", templateName);
+            }
 
             try
             {

--- a/Sources/Compiler/XwmlParser/XwmlTemplatingPlugin.cs
+++ b/Sources/Compiler/XwmlParser/XwmlTemplatingPlugin.cs
@@ -90,12 +90,13 @@
                 runtimeScopeManager,
                 runtimeScopeManager.Context.ClrContext);
             this.codeGenerator = new CodeGenerator(runtimeScopeManager, this.knownTemplateTypes);
+            var cssClassEntries = this.knownCssClasses.Split(new char[]{',', ' '}, StringSplitOptions.RemoveEmptyEntries);
             this.parserContext = new ParserContext(
                 this.knownTemplateTypes,
                 this.codeGenerator,
                 this.typeResolver,
                 this.typeResolver,
-                this.knownCssClasses.Split(new char[]{',', ' '}, StringSplitOptions.RemoveEmptyEntries));
+                cssClassEntries);
 
             this.parserContext.ConverterContext = runtimeScopeManager.Context;
 
@@ -103,9 +104,7 @@
             {
                 CompilerLog.ForComponent("XwmlParser").Information(
                     "XwmlParser.Initialized KnownCssClassCount={Count}",
-                    string.IsNullOrEmpty(this.knownCssClasses)
-                        ? 0
-                        : this.knownCssClasses.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries).Length);
+                    cssClassEntries.Length);
             }
         }
 

--- a/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
+++ b/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
@@ -10,6 +10,7 @@ namespace NScript.Utils.Test
     using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json.Linq;
+    using NScript.Lib;
     using NScript.Utils;
 
     /// <summary>
@@ -248,6 +249,115 @@ namespace NScript.Utils.Test
             Assert.IsNull(logPath);
             Assert.IsNull(runId);
             Assert.AreEqual(0, filtered.Length);
+        }
+    }
+
+    /// <summary>
+    /// Tests for Stage-2 (<c>ParseOptions.ParseArgs</c>) log/runid flag parsing.
+    /// Uses temp files to satisfy <c>ParseOptions</c> file-existence validation.
+    /// </summary>
+    [TestClass]
+    public class ParseOptionsLogFlagTests
+    {
+        private string tempRefDll;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Reset Logger so HasErrors doesn't leak between tests.
+            Logger.Instance = new Logger();
+            this.tempRefDll = Path.GetTempFileName();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (!string.IsNullOrEmpty(this.tempRefDll) && File.Exists(this.tempRefDll))
+            {
+                try { File.Delete(this.tempRefDll); } catch { /* best effort */ }
+            }
+        }
+
+        private string[] BaseArgs => new[]
+        {
+            "-outJs", "out.js",
+            "-entryAssembly", "fake.dll",
+            "-references", this.tempRefDll,
+        };
+
+        private string[] ArgsWithSuffix(params string[] suffix)
+        {
+            var list = new System.Collections.Generic.List<string>(this.BaseArgs);
+            list.AddRange(suffix);
+            return list.ToArray();
+        }
+
+        [TestMethod]
+        public void ParseArgs_SpaceDelimited_LogAndRunId()
+        {
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("--log", "build.jsonl", "--run-id", "run-42"));
+            Assert.IsNotNull(options, "ParseArgs should succeed");
+            Assert.AreEqual("build.jsonl", options.LogPath);
+            Assert.AreEqual("run-42", options.RunId);
+        }
+
+        [TestMethod]
+        public void ParseArgs_ColonDelimited_LogAndRunId()
+        {
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("--log:build.jsonl", "-runid:run-99"));
+            Assert.IsNotNull(options, "ParseArgs should succeed");
+            Assert.AreEqual("build.jsonl", options.LogPath);
+            Assert.AreEqual("run-99", options.RunId);
+        }
+
+        [TestMethod]
+        public void ParseArgs_EqualsDelimited_LogAndRunId()
+        {
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("-log=my.jsonl", "--run-id=abc"));
+            Assert.IsNotNull(options, "ParseArgs should succeed");
+            Assert.AreEqual("my.jsonl", options.LogPath);
+            Assert.AreEqual("abc", options.RunId);
+        }
+
+        [TestMethod]
+        public void ParseArgs_SlashForm_LogAndRunId()
+        {
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("/log", "slash.jsonl", "/runid", "slash-run"));
+            Assert.IsNotNull(options, "ParseArgs should succeed");
+            Assert.AreEqual("slash.jsonl", options.LogPath);
+            Assert.AreEqual("slash-run", options.RunId);
+        }
+
+        [TestMethod]
+        public void ParseArgs_LogAsLastArg_GracefulNoAbort()
+        {
+            // --log with no value should not abort; logPath stays null.
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("--log"));
+            Assert.IsNotNull(options, "ParseArgs should not abort when --log has no value");
+            Assert.IsNull(options.LogPath);
+        }
+
+        [TestMethod]
+        public void ParseArgs_RunIdAsLastArg_GracefulNoAbort()
+        {
+            var options = ParseOptions.ParseArgs(
+                ArgsWithSuffix("--run-id"));
+            Assert.IsNotNull(options, "ParseArgs should not abort when --run-id has no value");
+            Assert.IsNull(options.RunId);
+        }
+
+        [TestMethod]
+        public void ParseArgs_NoLogFlags_PathAndRunIdAreNull()
+        {
+            var options = ParseOptions.ParseArgs(this.BaseArgs);
+            Assert.IsNotNull(options, "ParseArgs should succeed");
+            Assert.IsNull(options.LogPath);
+            Assert.IsNull(options.RunId);
         }
     }
 }

--- a/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
+++ b/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
@@ -1,0 +1,253 @@
+//-----------------------------------------------------------------------
+// <copyright file="CompilerLogTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.Utils.Test
+{
+    using System;
+    using System.IO;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
+    using NScript.Utils;
+
+    /// <summary>
+    /// Tests for the shared <see cref="CompilerLog"/> facility. Each test
+    /// isolates itself by constructing a unique temp path and calling
+    /// <see cref="CompilerLog.Shutdown"/> in cleanup so the global singleton
+    /// does not leak between tests.
+    /// </summary>
+    [TestClass]
+    public class CompilerLogTests
+    {
+        private string tempLogPath;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Ensure no lingering state from a previous test.
+            CompilerLog.Shutdown();
+            this.tempLogPath = Path.Combine(
+                Path.GetTempPath(),
+                "nscript-compilerlog-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            CompilerLog.Shutdown();
+            if (!string.IsNullOrEmpty(this.tempLogPath) && File.Exists(this.tempLogPath))
+            {
+                try { File.Delete(this.tempLogPath); } catch { /* best effort */ }
+            }
+        }
+
+        [TestMethod]
+        public void ForComponent_ReturnsSilentLogger_WhenNotInitialized()
+        {
+            Assert.IsFalse(CompilerLog.IsEnabled);
+
+            var log = CompilerLog.ForComponent("test");
+            Assert.IsNotNull(log);
+
+            // Writing to the silent logger must not throw and must not create a file.
+            log.Information("hello");
+
+            Assert.IsFalse(File.Exists(this.tempLogPath));
+        }
+
+        [TestMethod]
+        public void Initialize_WritesJsonlFile_WithExpectedFields()
+        {
+            CompilerLog.Initialize(this.tempLogPath, "test-stage", "run-abc");
+            Assert.IsTrue(CompilerLog.IsEnabled);
+            Assert.AreEqual("test-stage", CompilerLog.Stage);
+            Assert.AreEqual("run-abc", CompilerLog.RunId);
+
+            CompilerLog.ForComponent("TestComponent").Information("event {X}", 42);
+            CompilerLog.Shutdown();
+
+            Assert.IsFalse(CompilerLog.IsEnabled);
+            Assert.IsTrue(File.Exists(this.tempLogPath), "Log file should exist after Initialize + write.");
+
+            var content = File.ReadAllText(this.tempLogPath);
+            Assert.IsTrue(content.Length > 0, "Log file should not be empty.");
+
+            var line = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)[0].Trim();
+            var obj = JObject.Parse(line);
+
+            Assert.IsNotNull(obj["@t"], "missing @t");
+            Assert.IsNotNull(obj["@l"] ?? obj["@mt"], "missing @l or @mt");
+            Assert.AreEqual("TestComponent", (string)obj["Component"]);
+            Assert.AreEqual("test-stage", (string)obj["Stage"]);
+            Assert.AreEqual("run-abc", (string)obj["RunId"]);
+            Assert.IsNotNull(obj["Pid"]);
+            Assert.IsNotNull(obj["MachineName"]);
+        }
+
+        [TestMethod]
+        public void Initialize_WithNullPath_KeepsLoggingDisabled()
+        {
+            // Snapshot & clear env var in case it leaks from the host environment.
+            var originalPathEnv = Environment.GetEnvironmentVariable(CompilerLog.LogPathEnvVar);
+            Environment.SetEnvironmentVariable(CompilerLog.LogPathEnvVar, null);
+            try
+            {
+                CompilerLog.Initialize(null, "test-stage");
+                Assert.IsFalse(CompilerLog.IsEnabled);
+                Assert.IsNull(CompilerLog.LogPath);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(CompilerLog.LogPathEnvVar, originalPathEnv);
+            }
+        }
+
+        [TestMethod]
+        public void Initialize_IsIdempotent()
+        {
+            CompilerLog.Initialize(this.tempLogPath, "stage1", "first-run");
+            var firstRunId = CompilerLog.RunId;
+            Assert.AreEqual("first-run", firstRunId);
+
+            // Second call with different values must be a no-op.
+            var secondPath = this.tempLogPath + ".second";
+            CompilerLog.Initialize(secondPath, "stage2", "second-run");
+
+            Assert.AreEqual("first-run", CompilerLog.RunId);
+            Assert.AreEqual("stage1", CompilerLog.Stage);
+            Assert.AreEqual(this.tempLogPath, CompilerLog.LogPath);
+            Assert.IsFalse(File.Exists(secondPath), "Second path must not be created.");
+        }
+
+        [TestMethod]
+        public void ResolveRunId_PrefersExplicit_OverEnvAndGenerated()
+        {
+            var originalEnv = Environment.GetEnvironmentVariable(CompilerLog.RunIdEnvVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(CompilerLog.RunIdEnvVar, "env-run");
+
+                var explicitResult = CompilerLog.ResolveRunId("explicit-run");
+                Assert.AreEqual("explicit-run", explicitResult);
+
+                var envResult = CompilerLog.ResolveRunId(null);
+                Assert.AreEqual("env-run", envResult);
+
+                Environment.SetEnvironmentVariable(CompilerLog.RunIdEnvVar, null);
+                var generated = CompilerLog.ResolveRunId(null);
+                Assert.IsFalse(string.IsNullOrWhiteSpace(generated));
+                Assert.AreNotEqual("explicit-run", generated);
+                Assert.AreNotEqual("env-run", generated);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(CompilerLog.RunIdEnvVar, originalEnv);
+            }
+        }
+
+        [TestMethod]
+        public void ResolveLogPath_PrefersExplicit_OverEnv()
+        {
+            var originalEnv = Environment.GetEnvironmentVariable(CompilerLog.LogPathEnvVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(CompilerLog.LogPathEnvVar, @"C:\from-env.jsonl");
+
+                Assert.AreEqual(@"C:\from-arg.jsonl", CompilerLog.ResolveLogPath(@"C:\from-arg.jsonl"));
+                Assert.AreEqual(@"C:\from-env.jsonl", CompilerLog.ResolveLogPath(null));
+
+                Environment.SetEnvironmentVariable(CompilerLog.LogPathEnvVar, null);
+                Assert.IsNull(CompilerLog.ResolveLogPath(null));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(CompilerLog.LogPathEnvVar, originalEnv);
+            }
+        }
+
+        [TestMethod]
+        public void Initialize_CreatesMissingDirectory()
+        {
+            var nestedDir = Path.Combine(Path.GetTempPath(), "nscript-log-dir-" + Guid.NewGuid().ToString("N"));
+            var nestedPath = Path.Combine(nestedDir, "nested.jsonl");
+            try
+            {
+                Assert.IsFalse(Directory.Exists(nestedDir));
+                CompilerLog.Initialize(nestedPath, "dir-stage");
+                Assert.IsTrue(CompilerLog.IsEnabled);
+                Assert.IsTrue(Directory.Exists(nestedDir));
+                CompilerLog.Shutdown();
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(nestedPath)) File.Delete(nestedPath);
+                    if (Directory.Exists(nestedDir)) Directory.Delete(nestedDir, recursive: true);
+                }
+                catch { /* best effort */ }
+            }
+        }
+
+        [TestMethod]
+        public void Shutdown_FlushesAndReleasesHandle()
+        {
+            CompilerLog.Initialize(this.tempLogPath, "flush-stage");
+            CompilerLog.ForComponent("flush-test").Information("will-be-flushed");
+            CompilerLog.Shutdown();
+
+            // If the handle were still open we would get an IOException here.
+            using var fs = File.Open(this.tempLogPath, FileMode.Open, FileAccess.Read, FileShare.None);
+            var len = fs.Length;
+            Assert.IsTrue(len > 0);
+        }
+    }
+
+    /// <summary>
+    /// Tests for the CLI flag stripping used by the Stage-1 entry point.
+    /// </summary>
+    [TestClass]
+    public class CscFlagExtractionTests
+    {
+        [TestMethod]
+        public void ExtractNScriptFlags_SpaceDelimited_RemovesFlagsAndValues()
+        {
+            var args = new[] { "/reference:foo.dll", "--log", "log.jsonl", "--run-id", "run-123", "File.cs" };
+            var filtered = NScript.Csc.Lib.CscCompiler.ExtractNScriptFlags(args, out var logPath, out var runId);
+            Assert.AreEqual("log.jsonl", logPath);
+            Assert.AreEqual("run-123", runId);
+            CollectionAssert.AreEqual(new[] { "/reference:foo.dll", "File.cs" }, filtered);
+        }
+
+        [TestMethod]
+        public void ExtractNScriptFlags_ColonDelimited_RemovesFlag()
+        {
+            var args = new[] { "/reference:foo.dll", "--log:log.jsonl", "--run-id=run-42", "File.cs" };
+            var filtered = NScript.Csc.Lib.CscCompiler.ExtractNScriptFlags(args, out var logPath, out var runId);
+            Assert.AreEqual("log.jsonl", logPath);
+            Assert.AreEqual("run-42", runId);
+            CollectionAssert.AreEqual(new[] { "/reference:foo.dll", "File.cs" }, filtered);
+        }
+
+        [TestMethod]
+        public void ExtractNScriptFlags_NoFlags_ReturnsArgsUnchanged()
+        {
+            var args = new[] { "/reference:foo.dll", "File.cs" };
+            var filtered = NScript.Csc.Lib.CscCompiler.ExtractNScriptFlags(args, out var logPath, out var runId);
+            Assert.IsNull(logPath);
+            Assert.IsNull(runId);
+            CollectionAssert.AreEqual(args, filtered);
+        }
+
+        [TestMethod]
+        public void ExtractNScriptFlags_EmptyArgs_ReturnsEmpty()
+        {
+            var filtered = NScript.Csc.Lib.CscCompiler.ExtractNScriptFlags(null, out var logPath, out var runId);
+            Assert.IsNull(logPath);
+            Assert.IsNull(runId);
+            Assert.AreEqual(0, filtered.Length);
+        }
+    }
+}

--- a/Test/Compiler/NScript.Utils.Test/NScript.Utils.Test.csproj
+++ b/Test/Compiler/NScript.Utils.Test/NScript.Utils.Test.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CompilerSources)\NScript.Utils\NScript.Utils.csproj" />
     <ProjectReference Include="$(CompilerSources)\NScript.Csc.Lib\NScript.Csc.Lib.csproj" />
+    <ProjectReference Include="$(CompilerSources)\NScript.Lib\NScript.Lib.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />

--- a/Test/Compiler/NScript.Utils.Test/NScript.Utils.Test.csproj
+++ b/Test/Compiler/NScript.Utils.Test/NScript.Utils.Test.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(CompilerNetFramework)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CompilerSources)\NScript.Utils\NScript.Utils.csproj" />
+    <ProjectReference Include="$(CompilerSources)\NScript.Csc.Lib\NScript.Csc.Lib.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+  </ItemGroup>
+</Project>

--- a/docs/adr/0025-opt-in-structured-jsonl-logging.md
+++ b/docs/adr/0025-opt-in-structured-jsonl-logging.md
@@ -1,0 +1,112 @@
+# ADR 0025: Opt-in Structured JSONL Logging for the Core Pipeline
+
+- Status: Accepted
+- Date: 2026-04-16
+- Deciders: NScript maintainers
+- Technical Area: Compiler tooling / observability
+
+## Context
+
+The NScript compiler is a two-stage pipeline: Stage 1 (`csc`) emits an assembly
+with an embedded AST resource, and Stage 2 (`cs2jsc`) converts that AST into
+JavaScript (see ADR 0006). Each stage logs primarily through `Console.WriteLine`
+and stage-local facilities. `RazorSkinParser` had a bespoke Serilog sink writing
+to a hard-coded file path (`logs/razor-skin-compiler.log.jsonl`), with no
+coordination with the rest of the pipeline.
+
+Debugging compilation issues often requires correlating events across stages and
+components. Unstructured console lines make this hard, and the Razor sink being
+separate means its events cannot be interleaved with other pipeline events on
+the same timeline.
+
+## Decision Drivers
+
+- produce machine-parseable logs that can be interleaved across stages
+- keep default behavior (no logging, no file I/O) unchanged for existing users
+- avoid adding a second logging framework — reuse the Serilog dependency already
+  present in `RazorSkinParser`
+- enable cross-process (csc + cs2jsc) correlation via a shared run id
+- consolidate the orphan `RazorSkinParser` sink under the same facility
+
+## Options Considered
+
+### Option 1: Shared `CompilerLog` static in `NScript.Utils` wrapping Serilog
+
+Introduce a `CompilerLog` static type in `NScript.Utils` that wraps Serilog with
+a `CompactJsonFormatter` and a shared-append `WriteTo.File` sink. Both stage
+entry points parse a `--log <path>` flag (and optional `--run-id <id>`), call
+`CompilerLog.Initialize` before work, and `CompilerLog.Shutdown` on exit. Each
+component fetches a per-component logger via `CompilerLog.ForComponent("X")`.
+When `Initialize` is not called, `ForComponent` returns a silent no-op logger.
+
+Pros:
+
+- reuses existing Serilog dependency — no new framework
+- shared file-sink + run id enables cross-process correlation
+- opt-in by construction — no file I/O when the flag is omitted
+- consolidates the Razor sink
+
+Cons:
+
+- introduces a global mutable singleton (mitigated by idempotent `Initialize`)
+
+### Option 2: Microsoft.Extensions.Logging with a custom JSONL provider
+
+Use MEL's `ILogger` abstraction and ship a custom JSONL sink.
+
+Pros:
+
+- aligns with ASP.NET/host conventions
+
+Cons:
+
+- adds a second logging framework alongside Serilog
+- requires writing a JSONL formatter we would otherwise get from Serilog
+
+### Option 3: Hand-rolled JSON writer
+
+Write a minimal JSON sink with no logging library.
+
+Pros:
+
+- zero new dependencies
+
+Cons:
+
+- reinvents enrichment, file-sink locking, and schema evolution
+
+## Decision
+
+Adopt **Option 1**. Add `CompilerLog` in `NScript.Utils`, wire it into both
+stage entry points (`csc` and `cs2jsc`), and route `RazorSkinCompiler.Logger`
+through it. Emit structured events from `Builder`, `ConverterContext`,
+`XwmlTemplatingPlugin`, and `SerializationHelper`.
+
+CLI surface:
+
+- `--log <path>` (and `-log <path>`, `--log:path`, `--log=path`) enables logging
+- `--run-id <id>` (and `-runid`, `--run-id:id`) sets the cross-process run id
+- `NSCRIPT_LOG_PATH` and `NSCRIPT_LOG_RUNID` env vars are honored as fallbacks
+  for MSBuild response-file scenarios
+
+Each JSONL entry carries `@t`, `@l`, `Component`, `Stage`, `RunId`, `Pid`, and
+`MachineName` alongside the event-specific fields.
+
+## Consequences
+
+Positive:
+
+- deterministic, grep-able, timestamped log stream across both compiler stages
+- Razor/XWML events now live on the same timeline as Builder/Converter events
+- behavior unchanged when the flag is omitted
+
+Negative:
+
+- `RazorSkinParser`'s previous hard-coded `logs/razor-skin-compiler.log.jsonl`
+  file is no longer written. Consumers that relied on that path must now pass
+  `--log` (or set `NSCRIPT_LOG_PATH`). Release notes call this out.
+
+## References
+
+- Issue #10 — Add opt-in structured JSONL logging to the NScript core pipeline
+- ADR 0006 — Two-stage compiler pipeline (source of the cross-stage correlation need)


### PR DESCRIPTION
## Summary

Implements #10 — opt-in structured JSONL logging for the two-stage NScript compiler pipeline. When `--log <path>` is supplied to either stage, a single shared Serilog/CompactJsonFormatter file sink captures events from both `csc` (Stage 1) and `cs2jsc` (Stage 2). When omitted, behavior is unchanged — no logger bootstrap, no file I/O.

## Changes

- **`NScript.Utils/CompilerLog.cs`** — new static facility wrapping Serilog; idempotent `Initialize`/`Shutdown`; `ForComponent()` returns a silent no-op logger when disabled. Enriches events with `RunId`, `Stage`, `Pid`, `MachineName`.
- **Stage 1 (`CscCompiler.Main`)** — strips `--log`/`--run-id` from argv before `DesktopBuildClient.Run` (Roslyn would reject unknown switches). Supports `--log path`, `--log:path`, `--log=path`, and `-log`/`/log` aliases.
- **Stage 2 (`NScriptCompiler.Compile`, `ParseOptions`)** — accepts the same flags, resolves through `CompilerLog.Initialize`.
- **Env var fallbacks** — `NSCRIPT_LOG_PATH` and `NSCRIPT_LOG_RUNID` for MSBuild response-file scenarios.
- **Stage events** emitted from `Builder`, `ConverterContext`, `XwmlTemplatingPlugin`, `SerializationHelper` (all gated by `CompilerLog.IsEnabled` to avoid allocation when logging is disabled).
- **`RazorSkinCompiler.Logger`** — now routes through `CompilerLog.ForComponent("RazorSkinParser")`. The hard-coded `logs/razor-skin-compiler.log.jsonl` sink is removed — consumers must now opt in via `--log`.
- **ADR 0025** documents the design decision; **README** gains a Structured Logging section.
- **12 unit tests** cover the facility and the Stage 1 flag extraction.

Each JSONL event carries `@t`, `@l`, `Component`, `Stage`, `RunId`, `Pid`, `MachineName`.

### Cross-stage correlation example

```bash
csc.exe Program.cs --log build.jsonl --run-id my-build-001
NScript -outJs app.js -references Foo.dll -entryAssembly App.dll --log build.jsonl --runid my-build-001
```

Both stages append to `build.jsonl`; records can be joined on `RunId`.

## Breaking change

`RazorSkinParser`'s previously hard-coded `logs/razor-skin-compiler.log.jsonl` file is no longer produced. Consumers must now pass `--log` (or set `NSCRIPT_LOG_PATH`). Called out in the ADR and README.

## Test plan

- [x] New `CompilerLogTests` (8) — Initialize idempotency, silent-logger default, env-var fallback, missing-directory creation, shutdown flushes
- [x] New `CscFlagExtractionTests` (4) — space/colon/equals delimited flags, no-flag passthrough, null args
- [x] All 12 new tests pass
- [x] Existing `RazorSkinParser.Test` (164), `NScript.Converter.Test` (401), `CssParser.Test`, `NScript.JSParser.Test` all pass
- [x] Solution builds clean in both Release and Debug
- [x] Manual trace: running `cs2jsc --log build.jsonl --runid test` produces JSONL with expected fields