### PR TITLE
Add extensible structured client logging to the Sunlight framework

### DIFF
--- a/Sources/Framework/Sunlight.Framework/CallContext.cs
+++ b/Sources/Framework/Sunlight.Framework/CallContext.cs
@@ -124,6 +124,39 @@ namespace Sunlight.Framework
         }
 
         /// <summary>
+        /// Append this context's correlation fields — <c>actionId</c>,
+        /// <c>traceId</c>, <c>spanId</c>, <c>parentSpanId</c> (when non-null),
+        /// <c>depth</c> — to a JSON object currently being assembled in
+        /// <paramref name="sb"/>. The builder assumes a preceding key/value
+        /// has already been written and prefixes each field with a comma.
+        /// </summary>
+        /// <remarks>
+        /// Owning the correlation serialization contract here keeps
+        /// <see cref="LogJsonBuilder"/> and future sinks (e.g. WebSocket)
+        /// decoupled from the set of fields — adding a new correlation field
+        /// is a one-place change instead of a multi-sink sweep.
+        /// <paramref name="escape"/> is passed in because this type lives in
+        /// <c>Sunlight.Framework</c> and must not take a dependency on the
+        /// internal <see cref="LogJsonBuilder"/> JS-escape bridge.
+        /// </remarks>
+        public void AppendCorrelationJson(StringBuilder sb, Func<string, string> escape)
+        {
+            sb.Append(",\"actionId\":");
+            sb.Append(this.ActionId.ToString());
+            sb.Append(",\"traceId\":");
+            sb.Append(escape(this.TraceId));
+            sb.Append(",\"spanId\":");
+            sb.Append(escape(this.SpanId));
+            if (this.ParentSpanId != null)
+            {
+                sb.Append(",\"parentSpanId\":");
+                sb.Append(escape(this.ParentSpanId));
+            }
+            sb.Append(",\"depth\":");
+            sb.Append(this.Depth.ToString());
+        }
+
+        /// <summary>
         /// Compiler-inserted wrapper for external async calls: captures context
         /// before await, restores it when the promise resolves or rejects.
         /// Handles both Promise and Promise&lt;T&gt; (same type at JS runtime).

--- a/Sources/Framework/Sunlight.Framework/Logger.cs
+++ b/Sources/Framework/Sunlight.Framework/Logger.cs
@@ -216,10 +216,11 @@ namespace Sunlight.Framework
         /// caller, which may be an exception handler).
         /// </summary>
         /// <remarks>
-        /// Internal (not public) because the facade and <see cref="NamedLogger"/>
-        /// already apply the <see cref="MinLevel"/> check. External callers
-        /// should always go through the level-specific methods so level filters
-        /// and <c>[Conditional]</c> stripping are honored.
+        /// Internal (not public) because the static facade already applies the
+        /// <see cref="MinLevel"/> check; <see cref="NamedLogger"/> must apply it
+        /// too to match that contract. External callers should always go through
+        /// the level-specific methods so level filters and <c>[Conditional]</c>
+        /// stripping are honored.
         /// </remarks>
         internal static void DispatchInternal(
             LogLevel level,
@@ -261,6 +262,15 @@ namespace Sunlight.Framework
                     try { Logger.sinks[i].Handle(evt); }
                     catch { /* sink faults must not escape — protects exception-path callers */ }
                 }
+            }
+            catch
+            {
+                // Event construction failed (e.g. GetIsoTimestamp bridge threw,
+                // ConsoleSink allocation failed). Swallowing is the only safe
+                // action: Logger.Error() is called from inside TaskScheduler's
+                // catch blocks, so an escaping exception would bypass its
+                // finally cleanup (currentTask / CallContext restore) and
+                // produce cascading failures.
             }
             finally
             {

--- a/Sources/Framework/Sunlight.Framework/Logger.cs
+++ b/Sources/Framework/Sunlight.Framework/Logger.cs
@@ -7,24 +7,39 @@
 namespace Sunlight.Framework
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Runtime.CompilerServices;
 
-    public enum LogLevel
-    {
-        Debug = 0,
-        Info = 1,
-        Warn = 2,
-        Error = 3
-    }
-
     /// <summary>
-    /// Structured client-side logger. Every entry is auto-enriched with
-    /// CallContext IDs (actionId, traceId, spanId) for OTEL correlation.
-    /// Output goes to browser console as structured JSON.
+    /// Static entry point for structured client-side logging. Fans emitted
+    /// <see cref="LogEvent"/>s out to every registered <see cref="ILogSink"/>
+    /// after <see cref="MinLevel"/> filtering.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Backwards-compatible with the pre-WI-11 API: the static
+    /// <see cref="Debug"/> / <see cref="Info"/> / <see cref="Warn"/> /
+    /// <see cref="Error"/> methods still accept a single <c>string</c> message.
+    /// Pre-existing callers (e.g. <c>TaskScheduler</c>'s exception handlers) do
+    /// not need to change.
+    /// </para>
+    /// <para>
+    /// <see cref="Trace"/> and <see cref="Debug"/> are tagged with
+    /// <c>[Conditional("DEBUG")]</c>: their calls — including argument
+    /// evaluation — are stripped from the bound tree by Roslyn during Stage 1
+    /// of the NScript pipeline whenever the caller's compilation is built
+    /// without the <c>DEBUG</c> symbol (i.e. the Release config). This yields
+    /// zero runtime overhead for verbose logs in production builds.
+    /// </para>
+    /// </remarks>
     public static class Logger
     {
         private static LogLevel minLevel = LogLevel.Debug;
+        private static List<ILogSink> sinks;
+        private static StringDictionary<NamedLogger> categoryCache;
+        private static bool userConfigured;
+        private static bool dispatching;
 
         public static LogLevel MinLevel
         {
@@ -32,60 +47,233 @@ namespace Sunlight.Framework
             set { Logger.minLevel = value; }
         }
 
+        /// <summary>
+        /// Obtain (and cache) a category-scoped logger. Subsequent calls with
+        /// the same category string return the same instance so consumers can
+        /// hold a cached reference at static-init time without worrying about
+        /// allocations per call site.
+        /// </summary>
+        /// <remarks>
+        /// Return type is the concrete <see cref="NamedLogger"/>, not
+        /// <see cref="ILogger"/>: the <c>[Conditional("DEBUG")]</c> on Trace /
+        /// Debug only fires through the concrete type. See <see cref="ILogger"/>
+        /// for the full rationale.
+        /// </remarks>
+        public static NamedLogger ForCategory(string category)
+        {
+            if (category == null) { category = string.Empty; }
+            if (Logger.categoryCache == null)
+            {
+                Logger.categoryCache = new StringDictionary<NamedLogger>();
+            }
+
+            NamedLogger existing;
+            if (Logger.categoryCache.TryGetValue(category, out existing))
+            {
+                return existing;
+            }
+
+            var created = new NamedLogger(category);
+            Logger.categoryCache[category] = created;
+            return created;
+        }
+
+        public static void AddSink(ILogSink sink)
+        {
+            if (sink == null) { return; }
+            Logger.EnsureSinkList();
+            Logger.userConfigured = true;
+            Logger.sinks.Add(sink);
+        }
+
+        public static void RemoveSink(ILogSink sink)
+        {
+            if (sink == null || Logger.sinks == null) { return; }
+            if (Logger.sinks.Remove(sink))
+            {
+                try { sink.Detach(); }
+                catch { /* sink cleanup must not surface to caller */ }
+            }
+        }
+
+        /// <summary>
+        /// Remove every registered sink and detach its resources. After this
+        /// call no sinks are installed — the default lazy <see cref="ConsoleSink"/>
+        /// is suppressed until the caller explicitly adds one via
+        /// <see cref="AddSink"/>. This makes the silent-mode setup possible.
+        /// </summary>
+        public static void ClearSinks()
+        {
+            Logger.userConfigured = true;
+            if (Logger.sinks == null) { return; }
+            for (int i = 0; i < Logger.sinks.Count; i++)
+            {
+                try { Logger.sinks[i].Detach(); }
+                catch { /* sink cleanup must not surface to caller */ }
+            }
+            Logger.sinks.Clear();
+        }
+
+        /// <summary> Flush every registered sink. No-op for sinks without buffering. </summary>
+        public static void Flush()
+        {
+            if (Logger.sinks == null) { return; }
+            for (int i = 0; i < Logger.sinks.Count; i++)
+            {
+                try { Logger.sinks[i].Flush(); }
+                catch { /* flush failure must not surface to caller */ }
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void Trace(string message)
+        {
+            if (Logger.minLevel <= LogLevel.Trace)
+            {
+                Logger.DispatchInternal(LogLevel.Trace, string.Empty, message, null);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void Trace(string message, string[] properties)
+        {
+            if (Logger.minLevel <= LogLevel.Trace)
+            {
+                Logger.DispatchInternal(LogLevel.Trace, string.Empty, message, properties);
+            }
+        }
+
+        [Conditional("DEBUG")]
         public static void Debug(string message)
         {
             if (Logger.minLevel <= LogLevel.Debug)
-                Logger.Emit(LogLevel.Debug, message);
+            {
+                Logger.DispatchInternal(LogLevel.Debug, string.Empty, message, null);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void Debug(string message, string[] properties)
+        {
+            if (Logger.minLevel <= LogLevel.Debug)
+            {
+                Logger.DispatchInternal(LogLevel.Debug, string.Empty, message, properties);
+            }
         }
 
         public static void Info(string message)
         {
             if (Logger.minLevel <= LogLevel.Info)
-                Logger.Emit(LogLevel.Info, message);
+            {
+                Logger.DispatchInternal(LogLevel.Info, string.Empty, message, null);
+            }
+        }
+
+        public static void Info(string message, string[] properties)
+        {
+            if (Logger.minLevel <= LogLevel.Info)
+            {
+                Logger.DispatchInternal(LogLevel.Info, string.Empty, message, properties);
+            }
         }
 
         public static void Warn(string message)
         {
             if (Logger.minLevel <= LogLevel.Warn)
-                Logger.Emit(LogLevel.Warn, message);
+            {
+                Logger.DispatchInternal(LogLevel.Warn, string.Empty, message, null);
+            }
+        }
+
+        public static void Warn(string message, string[] properties)
+        {
+            if (Logger.minLevel <= LogLevel.Warn)
+            {
+                Logger.DispatchInternal(LogLevel.Warn, string.Empty, message, properties);
+            }
         }
 
         public static void Error(string message)
         {
             if (Logger.minLevel <= LogLevel.Error)
-                Logger.Emit(LogLevel.Error, message);
+            {
+                Logger.DispatchInternal(LogLevel.Error, string.Empty, message, null);
+            }
+        }
+
+        public static void Error(string message, string[] properties)
+        {
+            if (Logger.minLevel <= LogLevel.Error)
+            {
+                Logger.DispatchInternal(LogLevel.Error, string.Empty, message, properties);
+            }
         }
 
         /// <summary>
-        /// Emits a structured JSON log entry to the browser console, enriched
-        /// with CallContext IDs when an action context is active.
+        /// Shared dispatch path used by the static facade and <see cref="NamedLogger"/>.
+        /// Builds a <see cref="LogEvent"/> and fans out to every sink under a
+        /// try/catch so a single faulty sink cannot break the others (or the
+        /// caller, which may be an exception handler).
         /// </summary>
         /// <remarks>
-        /// [Script] is required here because this method uses JS-native APIs that
-        /// have no NScript C# facade: Date.now(), JSON.stringify(), console.log/warn/error,
-        /// and dynamic property assignment on an object literal (entry.actionId = ...).
-        /// None of these are expressible in NScript's C# subset.
+        /// Internal (not public) because the facade and <see cref="NamedLogger"/>
+        /// already apply the <see cref="MinLevel"/> check. External callers
+        /// should always go through the level-specific methods so level filters
+        /// and <c>[Conditional]</c> stripping are honored.
         /// </remarks>
-        [Script(@"
-            var entry = {
-                ts: Date.now(),
-                level: level === 0 ? 'DEBUG' : level === 1 ? 'INFO' : level === 2 ? 'WARN' : 'ERROR',
-                msg: message
-            };
-            var ctx = @{[Sunlight.Framework]Sunlight.Framework.CallContext::current};
-            if (ctx) {
-                entry.actionId = ctx.@{[Sunlight.Framework]Sunlight.Framework.CallContext::ActionId};
-                entry.traceId = ctx.@{[Sunlight.Framework]Sunlight.Framework.CallContext::TraceId};
-                entry.spanId = ctx.@{[Sunlight.Framework]Sunlight.Framework.CallContext::SpanId};
-                if (ctx.@{[Sunlight.Framework]Sunlight.Framework.CallContext::ParentSpanId}) {
-                    entry.parentSpanId = ctx.@{[Sunlight.Framework]Sunlight.Framework.CallContext::ParentSpanId};
+        internal static void DispatchInternal(
+            LogLevel level,
+            string category,
+            string message,
+            string[] properties)
+        {
+            if (level < Logger.minLevel) { return; }
+
+            // Re-entrancy guard protects against a misbehaving sink that calls
+            // back into Logger.* (which would otherwise re-enter and duplicate
+            // events). Dropping the nested call is preferable to deadlocking
+            // or unbounded recursion.
+            if (Logger.dispatching) { return; }
+
+            Logger.dispatching = true;
+            try
+            {
+                Logger.EnsureSinkList();
+                if (!Logger.userConfigured && Logger.sinks.Count == 0)
+                {
+                    // Lazy default: first log call installs a ConsoleSink so
+                    // existing callers get the old on-console behavior without
+                    // any wiring. Once the app opts in (AddSink/ClearSinks)
+                    // this branch never re-fires.
+                    Logger.sinks.Add(new ConsoleSink());
+                }
+
+                var evt = new LogEvent(
+                    Logger.GetIsoTimestamp(),
+                    level,
+                    category,
+                    message,
+                    properties,
+                    CallContext.Current);
+
+                for (int i = 0; i < Logger.sinks.Count; i++)
+                {
+                    try { Logger.sinks[i].Handle(evt); }
+                    catch { /* sink faults must not escape — protects exception-path callers */ }
                 }
             }
-            var str = @:JSON.stringify(entry);
-            if (level >= 3) console.error(str);
-            else if (level >= 2) console.warn(str);
-            else console.log(str);
-        ")]
-        private static extern void Emit(LogLevel level, string message);
+            finally
+            {
+                Logger.dispatching = false;
+            }
+        }
+
+        private static void EnsureSinkList()
+        {
+            if (Logger.sinks == null) { Logger.sinks = new List<ILogSink>(); }
+        }
+
+        [Script("return new Date().toISOString();")]
+        private static extern string GetIsoTimestamp();
     }
 }

--- a/Sources/Framework/Sunlight.Framework/Logging/ConsoleSink.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/ConsoleSink.cs
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------
+// <copyright file="ConsoleSink.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    using System;
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Default <see cref="ILogSink"/> — writes each event as a single-line
+    /// JSON string to the browser console, routed by severity to
+    /// <c>console.error</c> / <c>console.warn</c> / <c>console.log</c>.
+    /// </summary>
+    /// <remarks>
+    /// Preserves the pre-WI-11 on-console behavior: existing developers
+    /// tailing DevTools Console see the same JSON shape they always saw,
+    /// plus the new <c>cat</c> and <c>props</c> fields when set.
+    /// JSON construction lives in <see cref="LogJsonBuilder"/> (pure C#) so
+    /// that key names survive NScript minification without ceremony.
+    /// </remarks>
+    public class ConsoleSink : ILogSink
+    {
+        public void Handle(LogEvent evt)
+        {
+            string payload = LogJsonBuilder.BuildEvent(evt);
+            ConsoleSink.EmitToConsole((int)evt.Level, payload);
+        }
+
+        public void Flush()
+        {
+        }
+
+        public void Detach()
+        {
+        }
+
+        /// <summary>
+        /// Route a pre-serialized JSON payload to the appropriate console
+        /// method. Trace/Debug/Info → <c>console.log</c>, Warn →
+        /// <c>console.warn</c>, Error → <c>console.error</c>. Kept small and
+        /// flat so the NScript JS parser handles it predictably.
+        /// </summary>
+        [Script(@"
+            if (level >= 3) console.error(payload);
+            else if (level >= 2) console.warn(payload);
+            else console.log(payload);
+        ")]
+        private static extern void EmitToConsole(int level, string payload);
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
@@ -38,6 +38,8 @@ namespace Sunlight.Framework
         private readonly int maxQueueSize;
         private readonly IWindowTimer timer;
 
+        private readonly Action<string, string> transportOverride;
+
         private List<LogEvent> queue;
         private int droppedCount;
         private int timerHandle;
@@ -51,6 +53,24 @@ namespace Sunlight.Framework
             int flushIntervalMs,
             int maxQueueSize,
             IWindowTimer timer)
+            : this(endpoint, batchSize, flushIntervalMs, maxQueueSize, timer, null)
+        {
+        }
+
+        /// <summary>
+        /// Test-only constructor: <paramref name="transportOverride"/> replaces
+        /// both the XHR POST and <c>sendBeacon</c> paths, so unit tests can
+        /// capture the serialized envelope without touching the network. When
+        /// <paramref name="transportOverride"/> is <c>null</c> the production
+        /// transports are used.
+        /// </summary>
+        internal HttpLogSink(
+            string endpoint,
+            int batchSize,
+            int flushIntervalMs,
+            int maxQueueSize,
+            IWindowTimer timer,
+            Action<string, string> transportOverride)
         {
             if (endpoint == null) { throw new ArgumentNullException("endpoint"); }
             if (timer == null) { throw new ArgumentNullException("timer"); }
@@ -60,6 +80,7 @@ namespace Sunlight.Framework
             this.flushIntervalMs = flushIntervalMs;
             this.maxQueueSize = maxQueueSize;
             this.timer = timer;
+            this.transportOverride = transportOverride;
 
             this.queue = new List<LogEvent>();
             this.droppedCount = 0;
@@ -77,13 +98,24 @@ namespace Sunlight.Framework
         {
             if (this.detached) { return; }
 
-            // Overflow: drop oldest events, count the drops. We bias toward
-            // keeping the *most recent* entries because those are usually what
-            // the developer wants to see when triaging a crash.
-            while (this.queue.Count >= this.maxQueueSize)
+            // Overflow: drop the oldest events in one pass, count the drops.
+            // We bias toward keeping the *most recent* entries because those
+            // are usually what the developer wants to see when triaging a
+            // crash. A previous implementation used List<T>.RemoveAt(0) in a
+            // loop, which is O(n) per drop (Array.splice(0,1) shifts every
+            // remaining element); with maxQueueSize=500 under sustained
+            // overflow that compounds badly. Rebuilding the tail into a new
+            // list is a single O(n) pass instead.
+            if (this.queue.Count >= this.maxQueueSize)
             {
-                this.queue.RemoveAt(0);
-                this.droppedCount++;
+                int excess = this.queue.Count - this.maxQueueSize + 1;
+                this.droppedCount += excess;
+                var trimmed = new List<LogEvent>();
+                for (int i = excess; i < this.queue.Count; i++)
+                {
+                    trimmed.Add(this.queue[i]);
+                }
+                this.queue = trimmed;
             }
 
             this.queue.Add(evt);
@@ -105,14 +137,16 @@ namespace Sunlight.Framework
             this.flushing = true;
             try
             {
+                // Single protection boundary covering BOTH payload construction
+                // and transport. LogJsonBuilder.BuildEnvelope (called via
+                // ExtractBatchAsPayload) can throw on JSON serialization
+                // failure; the outer timer/unload callers cannot meaningfully
+                // react to any failure here. Lost batches are the documented
+                // fire-and-forget contract.
                 string payload = this.ExtractBatchAsPayload();
-                // Transport failures must not escape — callers include the
-                // timer tick and page-unload handler, neither of which can
-                // meaningfully react to a network error. Lost batches are the
-                // documented fire-and-forget contract.
-                try { HttpLogSink.PostPayload(this.endpoint, payload); }
-                catch { /* fire-and-forget transport */ }
+                this.SendPayload(payload, false);
             }
+            catch { /* fire-and-forget: payload build or transport failure */ }
             finally
             {
                 this.flushing = false;
@@ -134,21 +168,33 @@ namespace Sunlight.Framework
             this.unloadHandler = null;
 
             // Best-effort final flush — use sendBeacon because the normal XHR
-            // path cannot be trusted to complete once we stop listening.
+            // path cannot be trusted to complete once we stop listening. The
+            // try/catch covers ExtractBatchAsPayload too, because serialization
+            // failure after the destructive queue swap would otherwise escape
+            // through RemoveSink/ClearSinks up into arbitrary caller code.
             if (this.queue.Count > 0)
             {
-                string payload = this.ExtractBatchAsPayload();
-                try { HttpLogSink.SendBeacon(this.endpoint, payload); }
+                try
+                {
+                    string payload = this.ExtractBatchAsPayload();
+                    this.SendPayload(payload, true);
+                }
                 catch { /* fire-and-forget transport */ }
             }
         }
 
         private void OnTimerTick()
         {
+            // Runs directly on window.setInterval — OUTSIDE any application
+            // try/catch. An unhandled exception here would fire every
+            // flushIntervalMs for the lifetime of the page as an unhandled
+            // setInterval error, so the outer try/catch is mandatory even
+            // though Flush() is also internally guarded.
             if (this.detached) { return; }
             if (this.queue.Count > 0)
             {
-                this.Flush();
+                try { this.Flush(); }
+                catch { /* timer callback must not throw */ }
             }
         }
 
@@ -160,12 +206,36 @@ namespace Sunlight.Framework
 
         private void OnPageUnload()
         {
+            // beforeunload/pagehide dispatchers have no application-level
+            // protection, same rationale as OnTimerTick.
             if (this.detached) { return; }
             if (this.queue.Count == 0) { return; }
 
-            string payload = this.ExtractBatchAsPayload();
-            try { HttpLogSink.SendBeacon(this.endpoint, payload); }
+            try
+            {
+                string payload = this.ExtractBatchAsPayload();
+                this.SendPayload(payload, true);
+            }
             catch { /* fire-and-forget transport — unload path cannot react */ }
+        }
+
+        /// <summary>
+        /// Dispatch the serialized payload to the appropriate transport: the
+        /// XHR path for live flushes and the <c>sendBeacon</c> path for unload
+        /// / detach. Routed through <see cref="transportOverride"/> when the
+        /// test-only constructor injected one so unit tests can capture the
+        /// envelope without touching the network.
+        /// </summary>
+        private void SendPayload(string payload, bool isUnload)
+        {
+            if (this.transportOverride != null)
+            {
+                this.transportOverride(this.endpoint, payload);
+                return;
+            }
+
+            if (isUnload) { HttpLogSink.SendBeacon(this.endpoint, payload); }
+            else { HttpLogSink.PostPayload(this.endpoint, payload); }
         }
 
         /// <summary>

--- a/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
@@ -74,6 +74,16 @@ namespace Sunlight.Framework
         {
             if (endpoint == null) { throw new ArgumentNullException("endpoint"); }
             if (timer == null) { throw new ArgumentNullException("timer"); }
+            // Numeric guards: zero/negative values would make the sink silently
+            // pathological — a zero batchSize flushes on every event, zero
+            // flushIntervalMs makes setInterval a tight loop, and zero
+            // maxQueueSize means Handle() always drops. Fail fast at ctor time
+            // instead of producing confusing runtime behavior. NScript's
+            // mscorlib does not expose ArgumentOutOfRangeException, so we use
+            // ArgumentException with a descriptive parameter name.
+            if (batchSize < 1) { throw new ArgumentException("batchSize must be >= 1"); }
+            if (flushIntervalMs < 1) { throw new ArgumentException("flushIntervalMs must be >= 1"); }
+            if (maxQueueSize < 1) { throw new ArgumentException("maxQueueSize must be >= 1"); }
 
             this.endpoint = endpoint;
             this.batchSize = batchSize;
@@ -239,18 +249,25 @@ namespace Sunlight.Framework
         }
 
         /// <summary>
-        /// Atomically swap the queue + <c>droppedCount</c> out, reset both, and
-        /// return the JSON envelope. Shared by <see cref="Flush"/>,
+        /// Serialize the current queue + <c>droppedCount</c> into a JSON
+        /// envelope, then reset both. Shared by <see cref="Flush"/>,
         /// <see cref="Detach"/>, and <see cref="OnPageUnload"/> so the three
         /// paths stay in sync and cannot drift.
         /// </summary>
+        /// <remarks>
+        /// Serialization happens BEFORE the queue is reset so that a
+        /// <c>BuildEnvelope</c> throw leaves the buffered events in place for
+        /// the next flush attempt. Resetting first would silently drop an
+        /// entire batch on any JSON build failure.
+        /// </remarks>
         private string ExtractBatchAsPayload()
         {
             var batch = this.queue;
             int dropped = this.droppedCount;
+            string payload = LogJsonBuilder.BuildEnvelope(batch, dropped);
             this.queue = new List<LogEvent>();
             this.droppedCount = 0;
-            return LogJsonBuilder.BuildEnvelope(batch, dropped);
+            return payload;
         }
 
         /// <summary>

--- a/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/HttpLogSink.cs
@@ -1,0 +1,282 @@
+//-----------------------------------------------------------------------
+// <copyright file="HttpLogSink.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using System.Web;
+    using System.Web.Html;
+
+    /// <summary>
+    /// Batching HTTP transport sink. Queues <see cref="LogEvent"/>s in memory
+    /// and POSTs them to a configured endpoint when any of these triggers fire:
+    /// <list type="bullet">
+    ///   <item>queue length reaches <c>batchSize</c></item>
+    ///   <item>the injected <see cref="IWindowTimer"/> fires every <c>flushIntervalMs</c></item>
+    ///   <item><see cref="Flush"/> is called explicitly</item>
+    ///   <item>the page transitions to <c>beforeunload</c> / <c>pagehide</c>
+    ///         (uses <c>navigator.sendBeacon</c> for reliable unload delivery)</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// Overflow strategy: when the queue exceeds <c>maxQueueSize</c> the oldest
+    /// events are dropped, and a running dropped-count is stamped into the next
+    /// batch envelope (payload, not an HTTP header — sendBeacon cannot set
+    /// custom headers and custom headers would trigger CORS preflight on the
+    /// normal XHR path).
+    /// </remarks>
+    public class HttpLogSink : ILogSink
+    {
+        private readonly string endpoint;
+        private readonly int batchSize;
+        private readonly int flushIntervalMs;
+        private readonly int maxQueueSize;
+        private readonly IWindowTimer timer;
+
+        private List<LogEvent> queue;
+        private int droppedCount;
+        private int timerHandle;
+        private bool flushing;
+        private bool detached;
+        private Action unloadHandler;
+
+        public HttpLogSink(
+            string endpoint,
+            int batchSize,
+            int flushIntervalMs,
+            int maxQueueSize,
+            IWindowTimer timer)
+        {
+            if (endpoint == null) { throw new ArgumentNullException("endpoint"); }
+            if (timer == null) { throw new ArgumentNullException("timer"); }
+
+            this.endpoint = endpoint;
+            this.batchSize = batchSize;
+            this.flushIntervalMs = flushIntervalMs;
+            this.maxQueueSize = maxQueueSize;
+            this.timer = timer;
+
+            this.queue = new List<LogEvent>();
+            this.droppedCount = 0;
+            this.timerHandle = -1;
+            this.flushing = false;
+            this.detached = false;
+
+            // Schedule the periodic flush and install a best-effort unload hook
+            // so buffered events survive page navigation.
+            this.timerHandle = timer.SetInterval(this.OnTimerTick, flushIntervalMs);
+            this.InstallUnloadHandler();
+        }
+
+        public void Handle(LogEvent evt)
+        {
+            if (this.detached) { return; }
+
+            // Overflow: drop oldest events, count the drops. We bias toward
+            // keeping the *most recent* entries because those are usually what
+            // the developer wants to see when triaging a crash.
+            while (this.queue.Count >= this.maxQueueSize)
+            {
+                this.queue.RemoveAt(0);
+                this.droppedCount++;
+            }
+
+            this.queue.Add(evt);
+
+            if (this.queue.Count >= this.batchSize)
+            {
+                this.Flush();
+            }
+        }
+
+        public void Flush()
+        {
+            // Re-entrancy guard: if a downstream sink or the XHR OnBeforeSend
+            // hook triggers another log call that flushes, we would otherwise
+            // double-send the same events.
+            if (this.flushing) { return; }
+            if (this.queue.Count == 0) { return; }
+
+            this.flushing = true;
+            try
+            {
+                string payload = this.ExtractBatchAsPayload();
+                // Transport failures must not escape — callers include the
+                // timer tick and page-unload handler, neither of which can
+                // meaningfully react to a network error. Lost batches are the
+                // documented fire-and-forget contract.
+                try { HttpLogSink.PostPayload(this.endpoint, payload); }
+                catch { /* fire-and-forget transport */ }
+            }
+            finally
+            {
+                this.flushing = false;
+            }
+        }
+
+        public void Detach()
+        {
+            if (this.detached) { return; }
+            this.detached = true;
+
+            if (this.timerHandle >= 0)
+            {
+                this.timer.ClearInterval(this.timerHandle);
+                this.timerHandle = -1;
+            }
+
+            this.RemoveUnloadHandler(this.unloadHandler);
+            this.unloadHandler = null;
+
+            // Best-effort final flush — use sendBeacon because the normal XHR
+            // path cannot be trusted to complete once we stop listening.
+            if (this.queue.Count > 0)
+            {
+                string payload = this.ExtractBatchAsPayload();
+                try { HttpLogSink.SendBeacon(this.endpoint, payload); }
+                catch { /* fire-and-forget transport */ }
+            }
+        }
+
+        private void OnTimerTick()
+        {
+            if (this.detached) { return; }
+            if (this.queue.Count > 0)
+            {
+                this.Flush();
+            }
+        }
+
+        private void InstallUnloadHandler()
+        {
+            this.unloadHandler = this.OnPageUnload;
+            this.AddUnloadHandler(this.unloadHandler);
+        }
+
+        private void OnPageUnload()
+        {
+            if (this.detached) { return; }
+            if (this.queue.Count == 0) { return; }
+
+            string payload = this.ExtractBatchAsPayload();
+            try { HttpLogSink.SendBeacon(this.endpoint, payload); }
+            catch { /* fire-and-forget transport — unload path cannot react */ }
+        }
+
+        /// <summary>
+        /// Atomically swap the queue + <c>droppedCount</c> out, reset both, and
+        /// return the JSON envelope. Shared by <see cref="Flush"/>,
+        /// <see cref="Detach"/>, and <see cref="OnPageUnload"/> so the three
+        /// paths stay in sync and cannot drift.
+        /// </summary>
+        private string ExtractBatchAsPayload()
+        {
+            var batch = this.queue;
+            int dropped = this.droppedCount;
+            this.queue = new List<LogEvent>();
+            this.droppedCount = 0;
+            return LogJsonBuilder.BuildEnvelope(batch, dropped);
+        }
+
+        /// <summary>
+        /// Async XHR POST via the <see cref="XMLHttpRequest"/> facade. Implemented
+        /// in plain C# rather than a <c>[Script]</c> block because the NScript JS
+        /// parser rejects <c>new XMLHttpRequest()</c> inside inline scripts.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately uses the raw instance methods <c>Open</c> / <c>Send</c>,
+        /// not the static <c>GetRaw</c> / <c>PostRaw</c> helpers — those helpers
+        /// invoke <c>XMLHttpRequest.OnBeforeSend</c>, which in turn calls back
+        /// into <c>Logger.*</c> for traceparent injection. Routing log transport
+        /// through that hook would be a latent recursion risk. Fire-and-forget;
+        /// network errors surface asynchronously on <c>onerror</c>, which we do
+        /// not hook (logging errors about logging would recurse).
+        /// </remarks>
+        private static void PostPayload(string endpoint, string payload)
+        {
+            var xhr = new XMLHttpRequest();
+            xhr.Open("POST", endpoint, true);
+            xhr.SetRequestHeader("Content-Type", "application/json");
+            xhr.Send(payload);
+        }
+
+        /// <summary>
+        /// Best-effort send during page unload. Prefers <c>navigator.sendBeacon</c>
+        /// with a <c>Blob</c> of type <c>application/json</c> — sending a bare
+        /// string defaults to <c>text/plain</c>, which ingestion servers tend to
+        /// reject. Falls back to a synchronous XHR on browsers without
+        /// <c>sendBeacon</c> so buffered events still have a chance to ship.
+        /// </summary>
+        private static void SendBeacon(string endpoint, string payload)
+        {
+            var navigator = Window.Instance.Navigator;
+            if (navigator != null && navigator.HasSendBeaconApi)
+            {
+                var opts = new BlobCreateOptions();
+                opts.Type = "application/json";
+                var blob = new Blob(payload, opts);
+                HttpLogSink.NavigatorSendBeaconBlob(endpoint, blob);
+                return;
+            }
+
+            // Very old browsers: sync XHR is the last-resort unload path.
+            var xhr = new XMLHttpRequest();
+            xhr.Open("POST", endpoint, false);
+            xhr.SetRequestHeader("Content-Type", "application/json");
+            xhr.Send(payload);
+        }
+
+        /// <summary>
+        /// Single-expression <c>[Script]</c> bridge so we can pass a <c>Blob</c>
+        /// to <c>navigator.sendBeacon</c> — the <see cref="Navigator"/> facade
+        /// only exposes <c>string</c>/<c>FormData</c> overloads.
+        /// </summary>
+        [Script(@"window.navigator.sendBeacon(endpoint, blob);")]
+        private static extern void NavigatorSendBeaconBlob(string endpoint, Blob blob);
+
+        private void AddUnloadHandler(Action handler)
+        {
+            HttpLogSink.WindowAddUnloadHandler(handler);
+        }
+
+        private void RemoveUnloadHandler(Action handler)
+        {
+            if (handler == null) { return; }
+            HttpLogSink.WindowRemoveUnloadHandler(handler);
+        }
+
+        /// <summary>
+        /// Register <paramref name="handler"/> for both <c>pagehide</c> and
+        /// <c>beforeunload</c>. Separate single-statement <c>[Script]</c> shims
+        /// keep each body small and parseable by the NScript JS frontend.
+        /// </summary>
+        [Script(@"window.addEventListener('pagehide', handler, false);")]
+        private static extern void WindowAddPageHide(Action handler);
+
+        [Script(@"window.addEventListener('beforeunload', handler, false);")]
+        private static extern void WindowAddBeforeUnload(Action handler);
+
+        [Script(@"window.removeEventListener('pagehide', handler, false);")]
+        private static extern void WindowRemovePageHide(Action handler);
+
+        [Script(@"window.removeEventListener('beforeunload', handler, false);")]
+        private static extern void WindowRemoveBeforeUnload(Action handler);
+
+        private static void WindowAddUnloadHandler(Action handler)
+        {
+            HttpLogSink.WindowAddPageHide(handler);
+            HttpLogSink.WindowAddBeforeUnload(handler);
+        }
+
+        private static void WindowRemoveUnloadHandler(Action handler)
+        {
+            HttpLogSink.WindowRemovePageHide(handler);
+            HttpLogSink.WindowRemoveBeforeUnload(handler);
+        }
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/ILogSink.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/ILogSink.cs
@@ -1,0 +1,38 @@
+//-----------------------------------------------------------------------
+// <copyright file="ILogSink.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    /// <summary>
+    /// Destination for <see cref="LogEvent"/>s fanned out by <see cref="Logger"/>.
+    /// Sinks own their internal async buffering / batching — the dispatch call
+    /// from <see cref="Logger"/> is synchronous.
+    /// </summary>
+    public interface ILogSink
+    {
+        /// <summary>
+        /// Called for every emitted event that passes <see cref="Logger.MinLevel"/>.
+        /// Implementations must not throw — <see cref="Logger"/> does wrap calls in a
+        /// try/catch, but a throwing sink is still a bug because it hides useful
+        /// stack context from the developer.
+        /// </summary>
+        void Handle(LogEvent evt);
+
+        /// <summary>
+        /// Force any pending buffered events to flush to their destination.
+        /// Console / no-buffer sinks implement this as a no-op.
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Tear down any long-lived resources (timers, <c>beforeunload</c>
+        /// listeners, etc.). Called by <see cref="Logger.RemoveSink"/> and
+        /// <see cref="Logger.ClearSinks"/> so sinks can participate in clean
+        /// lifecycle management rather than linger as leaked handles.
+        /// </summary>
+        void Detach();
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/ILogger.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/ILogger.cs
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------
+// <copyright file="ILogger.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    /// <summary>
+    /// Category-scoped logger surface returned by <see cref="Logger.ForCategory"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only the "always-available" levels (Info / Warn / Error) are on the
+    /// interface. Trace and Debug live on <see cref="NamedLogger"/> directly —
+    /// those methods carry <see cref="System.Diagnostics.ConditionalAttribute"/>
+    /// which C# does not allow on interface members. Exposing Trace/Debug here
+    /// would silently bypass compile-time stripping when a caller accessed
+    /// the logger through this interface, so we keep them off to fail fast.
+    /// </para>
+    /// <para>
+    /// Callers that want compile-time stripping in Release builds should hold a
+    /// <see cref="NamedLogger"/> reference (the concrete return type of
+    /// <see cref="Logger.ForCategory"/>) rather than this interface.
+    /// </para>
+    /// </remarks>
+    public interface ILogger
+    {
+        string Category { get; }
+
+        void Info(string message);
+
+        void Info(string message, string[] properties);
+
+        void Warn(string message);
+
+        void Warn(string message, string[] properties);
+
+        void Error(string message);
+
+        void Error(string message, string[] properties);
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/LogEvent.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/LogEvent.cs
@@ -1,0 +1,70 @@
+//-----------------------------------------------------------------------
+// <copyright file="LogEvent.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    /// <summary>
+    /// Immutable snapshot of a single log invocation, fanned out to every
+    /// registered <see cref="ILogSink"/> by <see cref="Logger"/>.
+    /// </summary>
+    /// <remarks>
+    /// Fields are intentionally <c>readonly</c> so a batching sink can queue
+    /// events without worrying about mutation-after-queue from the caller.
+    /// </remarks>
+    public class LogEvent
+    {
+        /// <summary> ISO-8601 timestamp captured at emit time, e.g. "2026-04-17T18:00:00.000Z". </summary>
+        public readonly string TimestampIso;
+
+        /// <summary> Severity classification. </summary>
+        public readonly LogLevel Level;
+
+        /// <summary>
+        /// Category tag from <see cref="Logger.ForCategory"/>; empty string for
+        /// uncategorized calls through the static <see cref="Logger"/> facade.
+        /// </summary>
+        public readonly string Category;
+
+        /// <summary> Primary human-readable message. </summary>
+        public readonly string Message;
+
+        /// <summary>
+        /// Flat key-value property bag: <c>[k1, v1, k2, v2, ...]</c>. Null when
+        /// the caller passed no structured properties.
+        /// </summary>
+        /// <remarks>
+        /// <c>string[]</c> (not <c>object</c>) is intentional: NScript minifies
+        /// field names in generated JS, so a caller-supplied object would emit
+        /// with unreadable minified keys. The flat array encodes both keys and
+        /// values as plain strings that survive minification unchanged.
+        /// </remarks>
+        public readonly string[] Properties;
+
+        /// <summary>
+        /// Snapshot of <see cref="CallContext.Current"/> at emit time; <c>null</c>
+        /// when no ambient context is active. Sink serializers conditionally
+        /// include <c>traceId</c>, <c>spanId</c>, <c>parentSpanId</c>, <c>actionId</c>,
+        /// and <c>depth</c> based on this reference.
+        /// </summary>
+        public readonly CallContext Context;
+
+        public LogEvent(
+            string timestampIso,
+            LogLevel level,
+            string category,
+            string message,
+            string[] properties,
+            CallContext context)
+        {
+            this.TimestampIso = timestampIso;
+            this.Level = level;
+            this.Category = category;
+            this.Message = message;
+            this.Properties = properties;
+            this.Context = context;
+        }
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
@@ -76,6 +76,9 @@ namespace Sunlight.Framework
 
             // Flat [k,v,k,v,...] → {k:v,k:v,...}. Odd trailing element is
             // dropped: a key without a value is almost always a caller bug.
+            // Null keys are skipped (not emitted as "null":...) — a null key
+            // would produce invalid-looking JSON-object semantics and is
+            // almost certainly an accidental slot in the caller's string[].
             var props = evt.Properties;
             if (props != null && props.Length >= 2)
             {
@@ -85,9 +88,11 @@ namespace Sunlight.Framework
                 int i = 0;
                 while (i + 1 < n)
                 {
+                    string key = props[i];
+                    if (key == null) { i = i + 2; continue; }
                     if (!first) { sb.Append(","); }
                     first = false;
-                    sb.Append(LogJsonBuilder.JsonEscape(props[i]));
+                    sb.Append(LogJsonBuilder.JsonEscape(key));
                     sb.Append(":");
                     sb.Append(LogJsonBuilder.JsonEscape(props[i + 1]));
                     i = i + 2;

--- a/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
@@ -95,24 +95,17 @@ namespace Sunlight.Framework
                 sb.Append("}");
             }
 
-            // CallContext correlation block — emitted as a single group so the
-            // server can cleanly branch on its presence.
+            // Correlation fields are owned by CallContext itself so that
+            // adding/removing a field is a one-place change — this sink and
+            // any future ones (e.g. WebSocket) stay automatically in sync.
+            // Wrapped in a lambda (not passed as a method group) because
+            // JsonEscape is a [Script]-bodied extern and NScript's C#-to-JS
+            // converter is not guaranteed to synthesize a delegate for such
+            // methods safely.
             var ctx = evt.Context;
             if (ctx != null)
             {
-                sb.Append(",\"actionId\":");
-                sb.Append(ctx.ActionId.ToString());
-                sb.Append(",\"traceId\":");
-                sb.Append(LogJsonBuilder.JsonEscape(ctx.TraceId));
-                sb.Append(",\"spanId\":");
-                sb.Append(LogJsonBuilder.JsonEscape(ctx.SpanId));
-                if (ctx.ParentSpanId != null)
-                {
-                    sb.Append(",\"parentSpanId\":");
-                    sb.Append(LogJsonBuilder.JsonEscape(ctx.ParentSpanId));
-                }
-                sb.Append(",\"depth\":");
-                sb.Append(ctx.Depth.ToString());
+                ctx.AppendCorrelationJson(sb, s => LogJsonBuilder.JsonEscape(s));
             }
 
             sb.Append("}");

--- a/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/LogJsonBuilder.cs
@@ -1,0 +1,140 @@
+//-----------------------------------------------------------------------
+// <copyright file="LogJsonBuilder.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Builds the JSON envelope for <see cref="LogEvent"/>s in pure C# so that
+    /// field names are stable string literals (not minified). Defers only string
+    /// escaping to the browser's native <c>JSON.stringify</c>, which handles
+    /// quoting, control characters, and non-ASCII safely.
+    /// </summary>
+    /// <remarks>
+    /// The JSON is assembled through plain C# string concatenation rather than
+    /// inside a <c>[Script]</c> block because the NScript JavaScript parser does
+    /// not support <c>for (var i = 0; ...)</c> loops inside <c>[Script]</c>
+    /// blocks — assignment-inside-var-init produces an AST shape the parser
+    /// mishandles. Doing the iteration in ordinary C# sidesteps that limitation
+    /// while still producing identical output.
+    /// </remarks>
+    internal static class LogJsonBuilder
+    {
+        /// <summary> Serialize a single <see cref="LogEvent"/> as a JSON object string. </summary>
+        public static string BuildEvent(LogEvent evt)
+        {
+            var sb = new StringBuilder();
+            LogJsonBuilder.AppendEvent(sb, evt);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Serialize a batch of events as the HTTP envelope:
+        /// <c>{ "events": [...], "dropped": N }</c>. <c>dropped</c> is always
+        /// included so the ingestion handler can surface overflow.
+        /// </summary>
+        public static string BuildEnvelope(List<LogEvent> events, int dropped)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"events\":[");
+            for (int i = 0; i < events.Count; i++)
+            {
+                if (i > 0) { sb.Append(","); }
+                LogJsonBuilder.AppendEvent(sb, events[i]);
+            }
+            sb.Append("],\"dropped\":");
+            sb.Append(dropped.ToString());
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Append a single event object to <paramref name="sb"/>. Split out so
+        /// both the single-event and batch paths share one serialization code
+        /// path and stay in sync.
+        /// </summary>
+        private static void AppendEvent(StringBuilder sb, LogEvent evt)
+        {
+            sb.Append("{\"ts\":");
+            sb.Append(LogJsonBuilder.JsonEscape(evt.TimestampIso));
+            sb.Append(",\"level\":");
+            sb.Append(LogJsonBuilder.JsonEscape(LogJsonBuilder.LevelToString(evt.Level)));
+            sb.Append(",\"msg\":");
+            sb.Append(LogJsonBuilder.JsonEscape(evt.Message));
+
+            if (!string.IsNullOrEmpty(evt.Category))
+            {
+                sb.Append(",\"cat\":");
+                sb.Append(LogJsonBuilder.JsonEscape(evt.Category));
+            }
+
+            // Flat [k,v,k,v,...] → {k:v,k:v,...}. Odd trailing element is
+            // dropped: a key without a value is almost always a caller bug.
+            var props = evt.Properties;
+            if (props != null && props.Length >= 2)
+            {
+                sb.Append(",\"props\":{");
+                bool first = true;
+                int n = props.Length;
+                int i = 0;
+                while (i + 1 < n)
+                {
+                    if (!first) { sb.Append(","); }
+                    first = false;
+                    sb.Append(LogJsonBuilder.JsonEscape(props[i]));
+                    sb.Append(":");
+                    sb.Append(LogJsonBuilder.JsonEscape(props[i + 1]));
+                    i = i + 2;
+                }
+                sb.Append("}");
+            }
+
+            // CallContext correlation block — emitted as a single group so the
+            // server can cleanly branch on its presence.
+            var ctx = evt.Context;
+            if (ctx != null)
+            {
+                sb.Append(",\"actionId\":");
+                sb.Append(ctx.ActionId.ToString());
+                sb.Append(",\"traceId\":");
+                sb.Append(LogJsonBuilder.JsonEscape(ctx.TraceId));
+                sb.Append(",\"spanId\":");
+                sb.Append(LogJsonBuilder.JsonEscape(ctx.SpanId));
+                if (ctx.ParentSpanId != null)
+                {
+                    sb.Append(",\"parentSpanId\":");
+                    sb.Append(LogJsonBuilder.JsonEscape(ctx.ParentSpanId));
+                }
+                sb.Append(",\"depth\":");
+                sb.Append(ctx.Depth.ToString());
+            }
+
+            sb.Append("}");
+        }
+
+        private static string LevelToString(LogLevel level)
+        {
+            if (level == LogLevel.Trace) { return "TRACE"; }
+            if (level == LogLevel.Debug) { return "DEBUG"; }
+            if (level == LogLevel.Info) { return "INFO"; }
+            if (level == LogLevel.Warn) { return "WARN"; }
+            return "ERROR";
+        }
+
+        /// <summary>
+        /// Wrap <paramref name="s"/> as a JSON-safe quoted string via the
+        /// browser's native <c>JSON.stringify</c> — handles escape sequences,
+        /// embedded quotes, control characters, and non-ASCII code points.
+        /// Returns the literal <c>"null"</c> (without quotes) for null input,
+        /// matching <c>JSON.stringify(null)</c> semantics.
+        /// </summary>
+        [Script(@"return @:JSON.stringify(s);")]
+        private static extern string JsonEscape(string s);
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/LogLevel.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/LogLevel.cs
@@ -1,0 +1,25 @@
+//-----------------------------------------------------------------------
+// <copyright file="LogLevel.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    /// <summary>
+    /// Severity classification for <see cref="Logger"/> and <see cref="Sunlight.Framework.ILogger"/> entries.
+    /// </summary>
+    /// <remarks>
+    /// Values are stable and must not change — the numeric level is emitted to sinks
+    /// (ConsoleSink / HttpLogSink) as part of the structured payload.
+    /// Trace is -1 so Debug/Info/Warn/Error remain at their original 0..3 values.
+    /// </remarks>
+    public enum LogLevel
+    {
+        Trace = -1,
+        Debug = 0,
+        Info = 1,
+        Warn = 2,
+        Error = 3
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Logging/NamedLogger.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/NamedLogger.cs
@@ -33,58 +33,93 @@ namespace Sunlight.Framework
             get { return this.category; }
         }
 
+        // Each level applies the MinLevel gate *before* DispatchInternal so
+        // filtered call sites don't pay the function-call overhead — matching
+        // the static facade on Logger.* (see Logger.Info/Warn/Error). The check
+        // inside DispatchInternal is a defensive backstop, not the primary gate.
+
         [Conditional("DEBUG")]
         public void Trace(string message)
         {
-            Logger.DispatchInternal(LogLevel.Trace, this.category, message, null);
+            if (Logger.MinLevel <= LogLevel.Trace)
+            {
+                Logger.DispatchInternal(LogLevel.Trace, this.category, message, null);
+            }
         }
 
         [Conditional("DEBUG")]
         public void Trace(string message, string[] properties)
         {
-            Logger.DispatchInternal(LogLevel.Trace, this.category, message, properties);
+            if (Logger.MinLevel <= LogLevel.Trace)
+            {
+                Logger.DispatchInternal(LogLevel.Trace, this.category, message, properties);
+            }
         }
 
         [Conditional("DEBUG")]
         public void Debug(string message)
         {
-            Logger.DispatchInternal(LogLevel.Debug, this.category, message, null);
+            if (Logger.MinLevel <= LogLevel.Debug)
+            {
+                Logger.DispatchInternal(LogLevel.Debug, this.category, message, null);
+            }
         }
 
         [Conditional("DEBUG")]
         public void Debug(string message, string[] properties)
         {
-            Logger.DispatchInternal(LogLevel.Debug, this.category, message, properties);
+            if (Logger.MinLevel <= LogLevel.Debug)
+            {
+                Logger.DispatchInternal(LogLevel.Debug, this.category, message, properties);
+            }
         }
 
         public void Info(string message)
         {
-            Logger.DispatchInternal(LogLevel.Info, this.category, message, null);
+            if (Logger.MinLevel <= LogLevel.Info)
+            {
+                Logger.DispatchInternal(LogLevel.Info, this.category, message, null);
+            }
         }
 
         public void Info(string message, string[] properties)
         {
-            Logger.DispatchInternal(LogLevel.Info, this.category, message, properties);
+            if (Logger.MinLevel <= LogLevel.Info)
+            {
+                Logger.DispatchInternal(LogLevel.Info, this.category, message, properties);
+            }
         }
 
         public void Warn(string message)
         {
-            Logger.DispatchInternal(LogLevel.Warn, this.category, message, null);
+            if (Logger.MinLevel <= LogLevel.Warn)
+            {
+                Logger.DispatchInternal(LogLevel.Warn, this.category, message, null);
+            }
         }
 
         public void Warn(string message, string[] properties)
         {
-            Logger.DispatchInternal(LogLevel.Warn, this.category, message, properties);
+            if (Logger.MinLevel <= LogLevel.Warn)
+            {
+                Logger.DispatchInternal(LogLevel.Warn, this.category, message, properties);
+            }
         }
 
         public void Error(string message)
         {
-            Logger.DispatchInternal(LogLevel.Error, this.category, message, null);
+            if (Logger.MinLevel <= LogLevel.Error)
+            {
+                Logger.DispatchInternal(LogLevel.Error, this.category, message, null);
+            }
         }
 
         public void Error(string message, string[] properties)
         {
-            Logger.DispatchInternal(LogLevel.Error, this.category, message, properties);
+            if (Logger.MinLevel <= LogLevel.Error)
+            {
+                Logger.DispatchInternal(LogLevel.Error, this.category, message, properties);
+            }
         }
     }
 }

--- a/Sources/Framework/Sunlight.Framework/Logging/NamedLogger.cs
+++ b/Sources/Framework/Sunlight.Framework/Logging/NamedLogger.cs
@@ -1,0 +1,90 @@
+//-----------------------------------------------------------------------
+// <copyright file="NamedLogger.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework
+{
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Category-scoped logger returned by <see cref="Logger.ForCategory"/>.
+    /// Delegates every call to the <see cref="Logger"/> dispatch path, tagging
+    /// events with this instance's <see cref="Category"/>.
+    /// </summary>
+    /// <remarks>
+    /// Trace/Debug are declared directly on this concrete type (not on
+    /// <see cref="ILogger"/>) so <c>[Conditional("DEBUG")]</c> strips call sites
+    /// in Release builds. C# does not allow <c>[Conditional]</c> on interface
+    /// members — see <see cref="ILogger"/> for the rationale.
+    /// </remarks>
+    public class NamedLogger : ILogger
+    {
+        private readonly string category;
+
+        internal NamedLogger(string category)
+        {
+            this.category = category;
+        }
+
+        public string Category
+        {
+            get { return this.category; }
+        }
+
+        [Conditional("DEBUG")]
+        public void Trace(string message)
+        {
+            Logger.DispatchInternal(LogLevel.Trace, this.category, message, null);
+        }
+
+        [Conditional("DEBUG")]
+        public void Trace(string message, string[] properties)
+        {
+            Logger.DispatchInternal(LogLevel.Trace, this.category, message, properties);
+        }
+
+        [Conditional("DEBUG")]
+        public void Debug(string message)
+        {
+            Logger.DispatchInternal(LogLevel.Debug, this.category, message, null);
+        }
+
+        [Conditional("DEBUG")]
+        public void Debug(string message, string[] properties)
+        {
+            Logger.DispatchInternal(LogLevel.Debug, this.category, message, properties);
+        }
+
+        public void Info(string message)
+        {
+            Logger.DispatchInternal(LogLevel.Info, this.category, message, null);
+        }
+
+        public void Info(string message, string[] properties)
+        {
+            Logger.DispatchInternal(LogLevel.Info, this.category, message, properties);
+        }
+
+        public void Warn(string message)
+        {
+            Logger.DispatchInternal(LogLevel.Warn, this.category, message, null);
+        }
+
+        public void Warn(string message, string[] properties)
+        {
+            Logger.DispatchInternal(LogLevel.Warn, this.category, message, properties);
+        }
+
+        public void Error(string message)
+        {
+            Logger.DispatchInternal(LogLevel.Error, this.category, message, null);
+        }
+
+        public void Error(string message, string[] properties)
+        {
+            Logger.DispatchInternal(LogLevel.Error, this.category, message, properties);
+        }
+    }
+}

--- a/Sources/Framework/Sunlight.Framework/Properties/AssemblyInfo.cs
+++ b/Sources/Framework/Sunlight.Framework/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+// Exposes internals to the framework test assembly so unit tests can cover
+// JSON envelope serialization (LogJsonBuilder) and inject deterministic
+// transports into HttpLogSink via its internal test-only constructor. The
+// framework test DLL is the only consumer — no IVT to broader assemblies.
+[assembly: InternalsVisibleTo("Sunlight.Framework.Test")]

--- a/Sources/Framework/Sunlight.Framework/Sunlight.Framework.csproj
+++ b/Sources/Framework/Sunlight.Framework/Sunlight.Framework.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="../mscorlib/NScript.MsCorlib.csproj" />
     <ProjectReference Include="../System.Web/System.Web.csproj" />
+    <ProjectReference Include="../System.Web.Html/System.Web.Html.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Framework/mscorlib/Runtime/CompilerServices/InternalsVisibleToAttribute.cs
+++ b/Sources/Framework/mscorlib/Runtime/CompilerServices/InternalsVisibleToAttribute.cs
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------
+// <copyright file="InternalsVisibleToAttribute.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace System.Runtime.CompilerServices
+{
+    using System;
+
+    /// <summary>
+    /// Specifies that types that are ordinarily visible only within the current
+    /// assembly are visible to another specified assembly. The Roslyn compiler
+    /// recognizes this well-known attribute during semantic analysis to grant
+    /// <c>internal</c>-visibility access to the named friend assembly.
+    /// </summary>
+    /// <remarks>
+    /// NonScriptable because the attribute has no runtime representation in the
+    /// emitted JavaScript — it only affects C# compilation semantics.
+    /// </remarks>
+    [NonScriptable]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public sealed class InternalsVisibleToAttribute : Attribute
+    {
+        private readonly string assemblyName;
+
+        public InternalsVisibleToAttribute(string assemblyName)
+        {
+            this.assemblyName = assemblyName;
+        }
+
+        public string AssemblyName
+        {
+            get { return this.assemblyName; }
+        }
+
+        public bool AllInternalsVisible { get; set; }
+    }
+}

--- a/Test/Compiler/NScript.CLR.Test/LoggerStructureTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/LoggerStructureTests.cs
@@ -86,9 +86,13 @@ namespace NScript.CLR.Test
             // overload so pre-WI-11 call sites keep compiling untouched. (The
             // WI-11 refactor also adds (string, string[]) overloads — those are
             // verified separately by Logger_LogLevelMethodsHavePropertiesOverload.)
+            // Trace is included even though it's [Conditional("DEBUG")]:
+            // [Conditional] strips *call sites*, not the method definition, so
+            // the overload is still present in the Release DLL and must be
+            // protected against accidental removal.
             var loggerType = GetLoggerType();
 
-            foreach (var name in new[] { "Debug", "Info", "Warn", "Error" })
+            foreach (var name in new[] { "Trace", "Debug", "Info", "Warn", "Error" })
             {
                 var singleStringOverload = loggerType.Methods
                     .FirstOrDefault(m => m.Name == name
@@ -107,9 +111,12 @@ namespace NScript.CLR.Test
             // WI-11 adds a (string, string[]) overload on each level so callers
             // can attach structured key/value pairs without boxing. string[] is
             // used (rather than object) to survive NScript minification.
+            // Trace is included here for the same reason as in the single-
+            // string-overload test above: [Conditional] strips call sites, not
+            // the method definition.
             var loggerType = GetLoggerType();
 
-            foreach (var name in new[] { "Debug", "Info", "Warn", "Error" })
+            foreach (var name in new[] { "Trace", "Debug", "Info", "Warn", "Error" })
             {
                 var overload = loggerType.Methods
                     .FirstOrDefault(m => m.Name == name

--- a/Test/Compiler/NScript.CLR.Test/LoggerStructureTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/LoggerStructureTests.cs
@@ -50,17 +50,21 @@ namespace NScript.CLR.Test
         }
 
         [TestMethod]
-        public void Logger_EmitMethodHasScriptAttribute()
+        public void Logger_GetIsoTimestampHasScriptAttribute()
         {
+            // After WI-11, Logger dispatches through ILogSink instances rather than a
+            // private Emit method. The only remaining [Script]-bodied helper is the
+            // ISO timestamp bridge, which must stay private and carry the attribute
+            // so Stage 2 emits the inline JS body.
             var loggerType = GetLoggerType();
-            var emitMethod = loggerType.Methods.FirstOrDefault(m => m.Name == "Emit");
+            var tsMethod = loggerType.Methods.FirstOrDefault(m => m.Name == "GetIsoTimestamp");
 
-            Assert.IsNotNull(emitMethod, "Logger should have private Emit method");
-            Assert.IsTrue(emitMethod.IsPrivate, "Emit should be private");
+            Assert.IsNotNull(tsMethod, "Logger should have private GetIsoTimestamp method");
+            Assert.IsTrue(tsMethod.IsPrivate, "GetIsoTimestamp should be private");
 
-            var scriptAttr = emitMethod.CustomAttributes
+            var scriptAttr = tsMethod.CustomAttributes
                 .FirstOrDefault(a => a.AttributeType.Name == "ScriptAttribute");
-            Assert.IsNotNull(scriptAttr, "Emit method should have [Script] attribute for JS body");
+            Assert.IsNotNull(scriptAttr, "GetIsoTimestamp should have [Script] attribute for JS body");
         }
 
         [TestMethod]
@@ -78,16 +82,44 @@ namespace NScript.CLR.Test
         [TestMethod]
         public void Logger_LogLevelMethodsAcceptSingleStringParameter()
         {
+            // Back-compat guarantee: every level must retain the single-string
+            // overload so pre-WI-11 call sites keep compiling untouched. (The
+            // WI-11 refactor also adds (string, string[]) overloads — those are
+            // verified separately by Logger_LogLevelMethodsHavePropertiesOverload.)
             var loggerType = GetLoggerType();
 
             foreach (var name in new[] { "Debug", "Info", "Warn", "Error" })
             {
-                var method = loggerType.Methods.FirstOrDefault(m => m.Name == name);
-                Assert.IsNotNull(method, $"Logger should have {name} method");
-                Assert.AreEqual(1, method.Parameters.Count,
-                    $"Logger.{name} should accept exactly 1 parameter");
-                Assert.AreEqual("String", method.Parameters[0].ParameterType.Name,
-                    $"Logger.{name} parameter should be a string");
+                var singleStringOverload = loggerType.Methods
+                    .FirstOrDefault(m => m.Name == name
+                        && m.Parameters.Count == 1
+                        && m.Parameters[0].ParameterType.Name == "String");
+
+                Assert.IsNotNull(
+                    singleStringOverload,
+                    $"Logger.{name}(string) back-compat overload should exist");
+            }
+        }
+
+        [TestMethod]
+        public void Logger_LogLevelMethodsHavePropertiesOverload()
+        {
+            // WI-11 adds a (string, string[]) overload on each level so callers
+            // can attach structured key/value pairs without boxing. string[] is
+            // used (rather than object) to survive NScript minification.
+            var loggerType = GetLoggerType();
+
+            foreach (var name in new[] { "Debug", "Info", "Warn", "Error" })
+            {
+                var overload = loggerType.Methods
+                    .FirstOrDefault(m => m.Name == name
+                        && m.Parameters.Count == 2
+                        && m.Parameters[0].ParameterType.Name == "String"
+                        && m.Parameters[1].ParameterType.Name == "String[]");
+
+                Assert.IsNotNull(
+                    overload,
+                    $"Logger.{name}(string, string[]) properties overload should exist");
             }
         }
     }

--- a/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
+++ b/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
@@ -1,0 +1,379 @@
+//-----------------------------------------------------------------------
+// <copyright file="LoggerTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Sunlight.Framework.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using SunlightUnit;
+    using Sunlight.Framework;
+
+    /// <summary>
+    /// QUnit tests for the structured logging pipeline added in WI-11.
+    /// Each test resets <see cref="Logger"/> state at start via
+    /// <see cref="ResetLogger"/> because the facade is a process-wide singleton.
+    /// </summary>
+    [TestFixture]
+    public class LoggerTests
+    {
+        /// <summary>
+        /// Captures dispatched events in-memory for assertion.
+        /// </summary>
+        private class FakeSink : ILogSink
+        {
+            public readonly List<LogEvent> Events = new List<LogEvent>();
+            public int FlushCount;
+            public int DetachCount;
+
+            public void Handle(LogEvent evt)
+            {
+                this.Events.Add(evt);
+            }
+
+            public void Flush()
+            {
+                this.FlushCount++;
+            }
+
+            public void Detach()
+            {
+                this.DetachCount++;
+            }
+        }
+
+        /// <summary>
+        /// Sink that throws on Handle; used to verify fault isolation.
+        /// </summary>
+        private class ThrowingSink : ILogSink
+        {
+            public int HandleAttempts;
+
+            public void Handle(LogEvent evt)
+            {
+                this.HandleAttempts++;
+                throw new Exception("sink boom");
+            }
+
+            public void Flush() { }
+
+            public void Detach() { }
+        }
+
+        /// <summary>
+        /// Controllable timer for HttpLogSink tests. Captures the interval
+        /// callback so the test can trigger ticks deterministically.
+        /// </summary>
+        private class ControllableTimer : IWindowTimer
+        {
+            public Action IntervalCallback;
+            public int IntervalMs;
+            public int ClearedIntervalHandle = -1;
+
+            public int SetImmediate(Action action) { action(); return 0; }
+            public int SetTimeout(Action action, int timeoutTime) { action(); return 0; }
+
+            public int SetInterval(Action action, int intervalTime)
+            {
+                this.IntervalCallback = action;
+                this.IntervalMs = intervalTime;
+                return 42;
+            }
+
+            public void ClearTimeout(int timeoutHandle) { }
+
+            public void ClearInterval(int intervalHandle)
+            {
+                this.ClearedIntervalHandle = intervalHandle;
+                this.IntervalCallback = null;
+            }
+
+            public int RequestAnimationFrame(Action action) { action(); return 0; }
+
+            public void Tick()
+            {
+                if (this.IntervalCallback != null) { this.IntervalCallback(); }
+            }
+        }
+
+        private static void ResetLogger()
+        {
+            Logger.ClearSinks();
+            Logger.MinLevel = LogLevel.Debug;
+        }
+
+        [Test]
+        public static void TestLevelFilteringSkipsBelowMinLevel(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+            Logger.MinLevel = LogLevel.Warn;
+
+            Logger.Info("info-skipped");
+            Logger.Warn("warn-kept");
+            Logger.Error("error-kept");
+
+            assert.Equal(2, fake.Events.Count, "Only Warn and Error should pass MinLevel=Warn");
+            assert.Equal(LogLevel.Warn, fake.Events[0].Level, "First retained event is Warn");
+            assert.Equal(LogLevel.Error, fake.Events[1].Level, "Second retained event is Error");
+        }
+
+        [Test]
+        public static void TestFanoutDeliversToAllSinks(Assert assert)
+        {
+            ResetLogger();
+            var a = new FakeSink();
+            var b = new FakeSink();
+            Logger.AddSink(a);
+            Logger.AddSink(b);
+
+            Logger.Info("hello");
+
+            assert.Equal(1, a.Events.Count, "Sink A received event");
+            assert.Equal(1, b.Events.Count, "Sink B received event");
+            assert.Equal("hello", a.Events[0].Message, "Message preserved");
+        }
+
+        [Test]
+        public static void TestForCategoryCarriesCategory(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            var log = Logger.ForCategory("TodoApp.ListView");
+            log.Info("item added");
+
+            assert.Equal(1, fake.Events.Count, "One event dispatched");
+            assert.Equal("TodoApp.ListView", fake.Events[0].Category, "Category tagged on event");
+            assert.Equal("item added", fake.Events[0].Message, "Message preserved through category logger");
+        }
+
+        [Test]
+        public static void TestForCategoryCachesInstance(Assert assert)
+        {
+            ResetLogger();
+            var a = Logger.ForCategory("shared");
+            var b = Logger.ForCategory("shared");
+            assert.StrictEqual(b, a, "Same category returns same cached instance");
+        }
+
+        [Test]
+        public static void TestForCategoryNullNormalizesToEmpty(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            // A null category is normalized to empty string by Logger.ForCategory
+            // so downstream callers never have to null-check the category tag.
+            var log = Logger.ForCategory(null);
+            log.Info("null-cat");
+
+            assert.Equal(string.Empty, log.Category, "Null category normalized to empty string");
+            assert.Equal(1, fake.Events.Count, "Event dispatched through null-category logger");
+            assert.Equal(string.Empty, fake.Events[0].Category, "Event category is empty, not null");
+        }
+
+        [Test]
+        public static void TestUncategorizedStaticCallsEmptyCategory(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            Logger.Info("no-cat");
+
+            assert.Equal(1, fake.Events.Count, "Event dispatched");
+            assert.Equal(string.Empty, fake.Events[0].Category, "Static facade uses empty category");
+        }
+
+        [Test]
+        public static void TestCallContextEnrichment(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            var ctx = CallContext.StartRoot();
+            Logger.Info("enriched");
+            var captured = fake.Events[0].Context;
+
+            assert.StrictEqual(ctx, captured, "LogEvent.Context should be the active CallContext at emit");
+            assert.Equal(ctx.ActionId, captured.ActionId, "ActionId preserved on captured context");
+            assert.Equal(ctx.TraceId, captured.TraceId, "TraceId preserved on captured context");
+        }
+
+        [Test]
+        public static void TestPropertiesPreservedThroughDispatch(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            var props = new string[] { "itemId", "42", "source", "api" };
+            Logger.Info("with-props", props);
+
+            assert.StrictEqual(props, fake.Events[0].Properties, "Properties array passed through unchanged");
+        }
+
+        [Test]
+        public static void TestSinkFaultIsolation(Assert assert)
+        {
+            ResetLogger();
+            var bad = new ThrowingSink();
+            var good = new FakeSink();
+            Logger.AddSink(bad);
+            Logger.AddSink(good);
+
+            // Must not throw out of Logger.Info even though the first sink threw.
+            Logger.Info("hello");
+
+            assert.Equal(1, bad.HandleAttempts, "Throwing sink was called");
+            assert.Equal(1, good.Events.Count, "Subsequent sink still received event after prior one threw");
+        }
+
+        [Test]
+        public static void TestRemoveSinkDetachesAndStopsDelivery(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+            Logger.RemoveSink(fake);
+
+            Logger.Info("after-remove");
+
+            assert.Equal(0, fake.Events.Count, "Removed sink receives no further events");
+            assert.Equal(1, fake.DetachCount, "Removed sink had Detach called once");
+        }
+
+        [Test]
+        public static void TestClearSinksSuppressesLazyDefault(Assert assert)
+        {
+            ResetLogger();
+            // ClearSinks already called above. One more call with zero sinks should
+            // not re-install the default ConsoleSink when we log.
+            Logger.Info("no-sinks");
+
+            // Add a fake AFTER the log call above; it should only see new events.
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+            Logger.Info("after-add");
+
+            assert.Equal(1, fake.Events.Count, "Sink added after user-configured clear sees only subsequent events");
+        }
+
+        [Test]
+        public static void TestFlushFlushesEverySink(Assert assert)
+        {
+            ResetLogger();
+            var a = new FakeSink();
+            var b = new FakeSink();
+            Logger.AddSink(a);
+            Logger.AddSink(b);
+
+            Logger.Flush();
+
+            assert.Equal(1, a.FlushCount, "Sink A flushed once");
+            assert.Equal(1, b.FlushCount, "Sink B flushed once");
+        }
+
+        [Test]
+        public static void TestTraceDispatchesWhenMinLevelTrace(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+            Logger.MinLevel = LogLevel.Trace;
+
+            Logger.Trace("verbose");
+
+            // Tests compile under DEBUG so [Conditional("DEBUG")] keeps the call.
+            assert.Equal(1, fake.Events.Count, "Trace call dispatched under DEBUG compilation");
+            assert.Equal(LogLevel.Trace, fake.Events[0].Level, "Event level is Trace");
+        }
+
+        [Test]
+        public static void TestNamedLoggerTraceCarriesCategory(Assert assert)
+        {
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+            Logger.MinLevel = LogLevel.Trace;
+
+            var log = Logger.ForCategory("cat1");
+            log.Trace("nm-trace");
+
+            assert.Equal(1, fake.Events.Count, "NamedLogger.Trace dispatched");
+            assert.Equal("cat1", fake.Events[0].Category, "Category preserved");
+            assert.Equal(LogLevel.Trace, fake.Events[0].Level, "Level is Trace");
+        }
+
+        [Test]
+        public static void TestHttpLogSinkBatchesOnSize(Assert assert)
+        {
+            ResetLogger();
+            var timer = new ControllableTimer();
+            var sink = new HttpLogSink("/ClientLogs.ashx", 3, 5000, 500, timer);
+            Logger.AddSink(sink);
+
+            // Two events — under the batch size of 3, so no flush yet.
+            Logger.Info("one");
+            Logger.Info("two");
+            // We can't directly verify the XHR, but we can observe queue state
+            // indirectly: a third event triggers a flush and the queue resets.
+            // After flush we add a fourth event: the queue has one item, not four.
+            Logger.Info("three");
+            Logger.Info("four");
+
+            // Trigger timer tick — if the queue was flushed at size 3, only
+            // the fourth event remains and should flush now.
+            timer.Tick();
+
+            assert.IsTrue(true, "Batch size flush exercised without exceptions");
+
+            Logger.RemoveSink(sink);
+        }
+
+        [Test]
+        public static void TestHttpLogSinkTimerClearedOnDetach(Assert assert)
+        {
+            ResetLogger();
+            var timer = new ControllableTimer();
+            var sink = new HttpLogSink("/ClientLogs.ashx", 10, 1000, 500, timer);
+
+            assert.Equal(1000, timer.IntervalMs, "Interval installed at ctor with configured flushIntervalMs");
+
+            Logger.AddSink(sink);
+            Logger.RemoveSink(sink);
+
+            assert.Equal(42, timer.ClearedIntervalHandle, "Interval handle cleared on Detach");
+        }
+
+        [Test]
+        public static void TestHttpLogSinkOverflowDropsOldest(Assert assert)
+        {
+            ResetLogger();
+            var timer = new ControllableTimer();
+            // maxQueueSize=2, batchSize=100 so only overflow (not batch) triggers.
+            var sink = new HttpLogSink("/ClientLogs.ashx", 100, 5000, 2, timer);
+            Logger.AddSink(sink);
+
+            Logger.Info("a");
+            Logger.Info("b");
+            Logger.Info("c"); // Should push out "a"
+            Logger.Info("d"); // Should push out "b"
+
+            // No assertion on internal queue contents (private). Instead verify
+            // the flow survives bounded-queue pressure without throwing.
+            timer.Tick();
+
+            assert.IsTrue(true, "Overflow path exercised without exceptions");
+
+            Logger.RemoveSink(sink);
+        }
+    }
+}

--- a/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
+++ b/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
@@ -317,23 +317,34 @@ namespace Sunlight.Framework.Test
         {
             ResetLogger();
             var timer = new ControllableTimer();
-            var sink = new HttpLogSink("/ClientLogs.ashx", 3, 5000, 500, timer);
+            var payloads = new List<string>();
+            // Inject a transport override via the internal test-only constructor
+            // so we can observe the serialized envelopes and verify batch-size
+            // triggering behaviorally, not just "did not throw".
+            var sink = new HttpLogSink(
+                "/ClientLogs.ashx", 3, 5000, 500, timer,
+                (endpoint, payload) => payloads.Add(payload));
             Logger.AddSink(sink);
 
             // Two events — under the batch size of 3, so no flush yet.
             Logger.Info("one");
             Logger.Info("two");
-            // We can't directly verify the XHR, but we can observe queue state
-            // indirectly: a third event triggers a flush and the queue resets.
-            // After flush we add a fourth event: the queue has one item, not four.
+            assert.Equal(0, payloads.Count, "No flush before reaching batchSize");
+
+            // Third event crosses the batchSize threshold and triggers flush.
             Logger.Info("three");
+            assert.Equal(1, payloads.Count, "Batch flushed when queue reaches batchSize");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"one\"") >= 0, "First batch includes 'one'");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"three\"") >= 0, "First batch includes 'three'");
+
+            // Queue is drained; the next event should accumulate, not flush.
             Logger.Info("four");
+            assert.Equal(1, payloads.Count, "Queue reset after flush — no additional flush yet");
 
-            // Trigger timer tick — if the queue was flushed at size 3, only
-            // the fourth event remains and should flush now.
+            // Timer tick drains the residual event.
             timer.Tick();
-
-            assert.IsTrue(true, "Batch size flush exercised without exceptions");
+            assert.Equal(2, payloads.Count, "Timer tick flushes the residual event");
+            assert.IsTrue(payloads[1].IndexOf("\"msg\":\"four\"") >= 0, "Second batch contains 'four'");
 
             Logger.RemoveSink(sink);
         }
@@ -358,22 +369,197 @@ namespace Sunlight.Framework.Test
         {
             ResetLogger();
             var timer = new ControllableTimer();
+            var payloads = new List<string>();
             // maxQueueSize=2, batchSize=100 so only overflow (not batch) triggers.
-            var sink = new HttpLogSink("/ClientLogs.ashx", 100, 5000, 2, timer);
+            var sink = new HttpLogSink(
+                "/ClientLogs.ashx", 100, 5000, 2, timer,
+                (endpoint, payload) => payloads.Add(payload));
             Logger.AddSink(sink);
 
             Logger.Info("a");
             Logger.Info("b");
-            Logger.Info("c"); // Should push out "a"
-            Logger.Info("d"); // Should push out "b"
+            Logger.Info("c"); // Pushes out "a"
+            Logger.Info("d"); // Pushes out "b"
 
-            // No assertion on internal queue contents (private). Instead verify
-            // the flow survives bounded-queue pressure without throwing.
+            // Timer tick forces the current queue to be serialized so we can
+            // inspect the envelope's dropped count and retained messages.
             timer.Tick();
 
-            assert.IsTrue(true, "Overflow path exercised without exceptions");
+            assert.Equal(1, payloads.Count, "One batch produced on timer flush after overflow");
+            assert.IsTrue(payloads[0].IndexOf("\"dropped\":2") >= 0,
+                "Envelope reports the two overflow drops");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"c\"") >= 0, "Retained 'c'");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"d\"") >= 0, "Retained 'd'");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"a\"") < 0, "Dropped 'a'");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"b\"") < 0, "Dropped 'b'");
 
             Logger.RemoveSink(sink);
+        }
+
+        [Test]
+        public static void TestReentrancyGuardDropsNestedDispatch(Assert assert)
+        {
+            // Anchors the Logger.dispatching guard against accidental removal:
+            // a sink that logs from its own Handle() must not recursively
+            // fan-out the nested event to any sink (including itself).
+            ResetLogger();
+            var reentrant = new ReentrantSink();
+            var observer = new FakeSink();
+            Logger.AddSink(reentrant);
+            Logger.AddSink(observer);
+
+            Logger.Info("outer");
+
+            assert.Equal(1, reentrant.HandleCount,
+                "Re-entrant sink receives only the outer event; nested call is dropped");
+            assert.Equal(1, observer.Events.Count,
+                "Observer sink receives only the outer event");
+        }
+
+        /// <summary>
+        /// Sink whose Handle() re-enters <see cref="Logger"/>. Verifies the
+        /// dispatching guard short-circuits the nested call rather than
+        /// fanning it out (which would recurse indefinitely or duplicate
+        /// events).
+        /// </summary>
+        private class ReentrantSink : ILogSink
+        {
+            public int HandleCount;
+
+            public void Handle(LogEvent evt)
+            {
+                this.HandleCount++;
+                // Recursive call — guarded by Logger.dispatching.
+                Logger.Info("nested-from-sink");
+            }
+
+            public void Flush() { }
+
+            public void Detach() { }
+        }
+
+        // -----------------------------------------------------------------
+        // LogJsonBuilder direct tests
+        //
+        // LogJsonBuilder is internal; the Sunlight.Framework assembly grants
+        // InternalsVisibleTo this test assembly so the JSON wire format can
+        // be locked down with behavioral assertions. Field names ('ts',
+        // 'level', 'msg', 'cat', 'props', 'dropped') are contractual with
+        // the ingestion server and must not be changed by minification.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public static void TestLogJsonBuilderEventBasicShape(Assert assert)
+        {
+            var evt = new LogEvent(
+                "2026-04-17T00:00:00.000Z",
+                LogLevel.Info,
+                string.Empty,
+                "hello",
+                null,
+                null);
+
+            string json = LogJsonBuilder.BuildEvent(evt);
+
+            assert.IsTrue(json.IndexOf("\"ts\":\"2026-04-17T00:00:00.000Z\"") >= 0, "Has ts");
+            assert.IsTrue(json.IndexOf("\"level\":\"INFO\"") >= 0, "Level serialized as INFO");
+            assert.IsTrue(json.IndexOf("\"msg\":\"hello\"") >= 0, "Has msg");
+            assert.IsTrue(json.IndexOf("\"cat\":") < 0, "Empty category is omitted");
+            assert.IsTrue(json.IndexOf("\"props\":") < 0, "No props block when null");
+        }
+
+        [Test]
+        public static void TestLogJsonBuilderLevelToString(Assert assert)
+        {
+            var trace = LogJsonBuilder.BuildEvent(
+                new LogEvent("ts", LogLevel.Trace, string.Empty, "m", null, null));
+            var debug = LogJsonBuilder.BuildEvent(
+                new LogEvent("ts", LogLevel.Debug, string.Empty, "m", null, null));
+            var warn = LogJsonBuilder.BuildEvent(
+                new LogEvent("ts", LogLevel.Warn, string.Empty, "m", null, null));
+            var error = LogJsonBuilder.BuildEvent(
+                new LogEvent("ts", LogLevel.Error, string.Empty, "m", null, null));
+
+            assert.IsTrue(trace.IndexOf("\"level\":\"TRACE\"") >= 0, "Trace → TRACE");
+            assert.IsTrue(debug.IndexOf("\"level\":\"DEBUG\"") >= 0, "Debug → DEBUG");
+            assert.IsTrue(warn.IndexOf("\"level\":\"WARN\"") >= 0, "Warn → WARN");
+            assert.IsTrue(error.IndexOf("\"level\":\"ERROR\"") >= 0, "Error → ERROR");
+        }
+
+        [Test]
+        public static void TestLogJsonBuilderPropertiesFlattening(Assert assert)
+        {
+            var evt = new LogEvent(
+                "ts",
+                LogLevel.Info,
+                "c1",
+                "m",
+                new string[] { "k1", "v1", "k2", "v2" },
+                null);
+
+            string json = LogJsonBuilder.BuildEvent(evt);
+
+            // Flat [k,v,k,v] becomes a nested object under "props".
+            assert.IsTrue(json.IndexOf("\"props\":{\"k1\":\"v1\",\"k2\":\"v2\"}") >= 0,
+                "Flat properties array pairs into an object");
+            assert.IsTrue(json.IndexOf("\"cat\":\"c1\"") >= 0, "Category present");
+        }
+
+        [Test]
+        public static void TestLogJsonBuilderOddPropertiesDropsTrailing(Assert assert)
+        {
+            // An odd-length properties array is a caller bug; trailing key is
+            // dropped silently rather than emitting a malformed key:value pair.
+            var evt = new LogEvent(
+                "ts",
+                LogLevel.Info,
+                string.Empty,
+                "m",
+                new string[] { "k1", "v1", "orphan" },
+                null);
+
+            string json = LogJsonBuilder.BuildEvent(evt);
+
+            assert.IsTrue(json.IndexOf("\"k1\":\"v1\"") >= 0, "Even pair kept");
+            assert.IsTrue(json.IndexOf("\"orphan\"") < 0, "Trailing key dropped");
+        }
+
+        [Test]
+        public static void TestLogJsonBuilderEnvelopeIncludesDropped(Assert assert)
+        {
+            var events = new List<LogEvent>();
+            events.Add(new LogEvent("ts", LogLevel.Info, string.Empty, "a", null, null));
+            events.Add(new LogEvent("ts", LogLevel.Info, string.Empty, "b", null, null));
+
+            string json = LogJsonBuilder.BuildEnvelope(events, 7);
+
+            assert.IsTrue(json.IndexOf("\"events\":[") >= 0, "Has events array");
+            assert.IsTrue(json.IndexOf("\"dropped\":7") >= 0, "Dropped count in envelope");
+            assert.IsTrue(json.IndexOf("\"msg\":\"a\"") >= 0, "First event present");
+            assert.IsTrue(json.IndexOf("\"msg\":\"b\"") >= 0, "Second event present");
+        }
+
+        [Test]
+        public static void TestLogJsonBuilderCallContextCorrelation(Assert assert)
+        {
+            var ctx = CallContext.StartRoot();
+            var evt = new LogEvent(
+                "ts",
+                LogLevel.Info,
+                string.Empty,
+                "m",
+                null,
+                ctx);
+
+            string json = LogJsonBuilder.BuildEvent(evt);
+
+            assert.IsTrue(json.IndexOf("\"actionId\":") >= 0, "actionId present");
+            assert.IsTrue(json.IndexOf("\"traceId\":") >= 0, "traceId present");
+            assert.IsTrue(json.IndexOf("\"spanId\":") >= 0, "spanId present");
+            assert.IsTrue(json.IndexOf("\"depth\":0") >= 0, "Root depth is 0");
+            // Root context has no ParentSpanId, so the key must be absent.
+            assert.IsTrue(json.IndexOf("\"parentSpanId\":") < 0,
+                "parentSpanId omitted for root context");
         }
     }
 }

--- a/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
+++ b/Test/Framework/Sunlight.Framework.Test/LoggerTests.cs
@@ -540,6 +540,89 @@ namespace Sunlight.Framework.Test
         }
 
         [Test]
+        public static void TestLogJsonBuilderNullKeySkipped(Assert assert)
+        {
+            // A null slot in the properties array (e.g. from a caller that
+            // forgot to initialize one entry) must NOT emit "null":"value" —
+            // that would produce an unintentional string-literal key. The
+            // pair is silently skipped instead.
+            var evt = new LogEvent(
+                "ts",
+                LogLevel.Info,
+                string.Empty,
+                "m",
+                new string[] { "k1", "v1", null, "orphan-val", "k2", "v2" },
+                null);
+
+            string json = LogJsonBuilder.BuildEvent(evt);
+
+            assert.IsTrue(json.IndexOf("\"k1\":\"v1\"") >= 0, "First pair kept");
+            assert.IsTrue(json.IndexOf("\"k2\":\"v2\"") >= 0, "Third pair kept");
+            assert.IsTrue(json.IndexOf("\"null\"") < 0, "Null key is not serialized as the literal \"null\"");
+            assert.IsTrue(json.IndexOf("orphan-val") < 0, "Value paired with null key is dropped");
+        }
+
+        [Test]
+        public static void TestHttpLogSinkDetachFlushesQueuedEvents(Assert assert)
+        {
+            // Detach should ship any residual queued events via the beacon
+            // path before going quiet — otherwise the last events before a
+            // sink removal or page unload would be lost silently.
+            ResetLogger();
+            var timer = new ControllableTimer();
+            var payloads = new List<string>();
+            var sink = new HttpLogSink(
+                "/ClientLogs.ashx", 100, 5000, 500, timer,
+                (endpoint, payload) => payloads.Add(payload));
+            Logger.AddSink(sink);
+
+            Logger.Info("queued-1");
+            Logger.Info("queued-2");
+            assert.Equal(0, payloads.Count, "No flush yet — below batchSize");
+
+            Logger.RemoveSink(sink);
+
+            assert.Equal(1, payloads.Count, "Detach drained the queue through the transport");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"queued-1\"") >= 0, "Residual event 'queued-1' included");
+            assert.IsTrue(payloads[0].IndexOf("\"msg\":\"queued-2\"") >= 0, "Residual event 'queued-2' included");
+        }
+
+        [Test]
+        public static void TestNamedLoggerPassesPropertiesThrough(Assert assert)
+        {
+            // NamedLogger.Info(msg, props) must hand the properties array
+            // straight to DispatchInternal without wrapping/copying. The
+            // test locks this in so a future refactor cannot silently drop
+            // the properties argument on the category path.
+            ResetLogger();
+            var fake = new FakeSink();
+            Logger.AddSink(fake);
+
+            var props = new string[] { "userId", "42", "op", "save" };
+            var log = Logger.ForCategory("named-props");
+            log.Info("named-with-props", props);
+
+            assert.Equal(1, fake.Events.Count, "One event dispatched through NamedLogger");
+            assert.StrictEqual(props, fake.Events[0].Properties, "Properties array forwarded unchanged");
+            assert.Equal("named-props", fake.Events[0].Category, "Category preserved");
+        }
+
+        [Test]
+        public static void TestForCategoryNullAndEmptyShareCacheSlot(Assert assert)
+        {
+            // ForCategory(null) normalizes to the empty string and then looks
+            // up the same cache bucket as ForCategory(""). Without this
+            // guarantee, a caller that drifts between null and "" would get
+            // two distinct NamedLogger instances silently.
+            ResetLogger();
+            var nullLog = Logger.ForCategory(null);
+            var emptyLog = Logger.ForCategory(string.Empty);
+
+            assert.StrictEqual(emptyLog, nullLog,
+                "Null and empty string resolve to the same cached NamedLogger");
+        }
+
+        [Test]
         public static void TestLogJsonBuilderCallContextCorrelation(Assert assert)
         {
             var ctx = CallContext.StartRoot();

--- a/Test/Framework/TestWebApplication/ClientLogs.ashx
+++ b/Test/Framework/TestWebApplication/ClientLogs.ashx
@@ -1,0 +1,1 @@
+<%@ WebHandler Language="C#" CodeBehind="ClientLogs.ashx.cs" Class="TestWebApplication.ClientLogs" %>

--- a/Test/Framework/TestWebApplication/ClientLogs.ashx.cs
+++ b/Test/Framework/TestWebApplication/ClientLogs.ashx.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Web;
+using System.Web.Script.Serialization;
+
+namespace TestWebApplication
+{
+    /// <summary>
+    /// Reference ingestion handler for the client-side HttpLogSink.
+    ///
+    /// Accepts batched JSON envelopes from the browser (content-type
+    /// application/json for XHR or text/plain for sendBeacon), deserializes
+    /// each event, and forwards it to <see cref="Trace"/> so the test app can
+    /// surface structured client events alongside server diagnostics.
+    ///
+    /// This handler is intentionally minimal — production integrations should
+    /// pipe events to Serilog / NLog / AppInsights / Kafka / etc.
+    /// </summary>
+    public class ClientLogs : IHttpHandler
+    {
+        public void ProcessRequest(HttpContext context)
+        {
+            if (!string.Equals(context.Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase))
+            {
+                context.Response.StatusCode = 405;
+                return;
+            }
+
+            string body;
+            using (var reader = new StreamReader(context.Request.InputStream, Encoding.UTF8))
+            {
+                body = reader.ReadToEnd();
+            }
+
+            if (string.IsNullOrEmpty(body))
+            {
+                context.Response.StatusCode = 400;
+                return;
+            }
+
+            Dictionary<string, object> envelope;
+            try
+            {
+                // sendBeacon sends a Blob which surfaces as application/json,
+                // but some older browsers default to text/plain — either way
+                // the payload is JSON.
+                var serializer = new JavaScriptSerializer();
+                envelope = serializer.Deserialize<Dictionary<string, object>>(body);
+            }
+            catch
+            {
+                context.Response.StatusCode = 400;
+                return;
+            }
+
+            if (envelope == null)
+            {
+                context.Response.StatusCode = 400;
+                return;
+            }
+
+            object droppedObj;
+            int dropped = 0;
+            if (envelope.TryGetValue("dropped", out droppedObj) && droppedObj != null)
+            {
+                int.TryParse(droppedObj.ToString(), out dropped);
+            }
+
+            if (dropped > 0)
+            {
+                Trace.WriteLine("[ClientLogs] dropped=" + dropped);
+            }
+
+            object eventsObj;
+            if (envelope.TryGetValue("events", out eventsObj) && eventsObj is System.Collections.IEnumerable)
+            {
+                foreach (var item in (System.Collections.IEnumerable)eventsObj)
+                {
+                    var evt = item as Dictionary<string, object>;
+                    if (evt == null) { continue; }
+                    Trace.WriteLine(FormatEvent(evt));
+                }
+            }
+
+            context.Response.StatusCode = 204;
+        }
+
+        private static string FormatEvent(Dictionary<string, object> evt)
+        {
+            // Compact human-readable line plus a JSON dump of the original event
+            // so the developer gets both quick readability and full structure.
+            var sb = new StringBuilder();
+            sb.Append("[ClientLogs] ");
+            AppendField(sb, evt, "ts");
+            sb.Append(' ');
+            AppendField(sb, evt, "level");
+            var cat = Read(evt, "cat");
+            if (!string.IsNullOrEmpty(cat))
+            {
+                sb.Append(' ');
+                sb.Append('[');
+                sb.Append(cat);
+                sb.Append(']');
+            }
+            sb.Append(' ');
+            AppendField(sb, evt, "msg");
+
+            var traceId = Read(evt, "traceId");
+            if (!string.IsNullOrEmpty(traceId))
+            {
+                sb.Append(" traceId=");
+                sb.Append(traceId);
+            }
+            return sb.ToString();
+        }
+
+        private static void AppendField(StringBuilder sb, Dictionary<string, object> evt, string key)
+        {
+            object value;
+            if (evt.TryGetValue(key, out value) && value != null)
+            {
+                sb.Append(value.ToString());
+            }
+        }
+
+        private static string Read(Dictionary<string, object> evt, string key)
+        {
+            object value;
+            if (evt.TryGetValue(key, out value) && value != null)
+            {
+                return value.ToString();
+            }
+            return null;
+        }
+
+        public bool IsReusable
+        {
+            get { return true; }
+        }
+    }
+}

--- a/Test/Framework/TestWebApplication/TestWebApplication.csproj
+++ b/Test/Framework/TestWebApplication/TestWebApplication.csproj
@@ -90,6 +90,9 @@
     <Compile Include="SrcMapper.ashx.cs">
       <DependentUpon>SrcMapper.ashx</DependentUpon>
     </Compile>
+    <Compile Include="ClientLogs.ashx.cs">
+      <DependentUpon>ClientLogs.ashx</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
@@ -102,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="SrcMapper.ashx" />
+    <Content Include="ClientLogs.ashx" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/docs/framework-logging.md
+++ b/docs/framework-logging.md
@@ -1,0 +1,327 @@
+# Structured Client Logging
+
+The `Sunlight.Framework.Logger` static class is the entry point for all client-side logging in NScript applications. In WI-11 the original console-only emitter was refactored into a sink-based pipeline that preserves the legacy API while adding:
+
+- Named/category loggers via `Logger.ForCategory("MyApp.MyComponent")`
+- Pluggable `ILogSink` implementations (`ConsoleSink` default, `HttpLogSink` for server ingestion)
+- Structured property bags carried through as stable JSON
+- Automatic CallContext correlation (`traceId`, `spanId`, `actionId`, …)
+- `Trace` and `Debug` levels that are **stripped from Release builds at compile time** by `[Conditional("DEBUG")]`
+
+This document describes how to use the pipeline, the full JSON schema of emitted events, and how to wire the built-in HTTP transport into Serilog / NLog on the server side.
+
+---
+
+## Quick Start
+
+### Uncategorized logs (legacy API, unchanged)
+
+```csharp
+using Sunlight.Framework;
+
+Logger.Info("user clicked Save");
+Logger.Warn("retrying request");
+Logger.Error("upload failed");
+```
+
+### Category loggers
+
+Prefer category loggers for anything in a reusable component. Cache the returned instance at static-init time — `ForCategory` returns the same `NamedLogger` for the same category string so there is no per-call allocation overhead:
+
+```csharp
+public static class ListView
+{
+    private static readonly NamedLogger log = Logger.ForCategory("TodoApp.ListView");
+
+    public static void AddItem(string id)
+    {
+        log.Info("item added", new string[] { "itemId", id });
+    }
+}
+```
+
+### Structured properties
+
+`string[]` is intentional — it is a flat key/value array: `[k1, v1, k2, v2, …]`. This avoids NScript's minification trap: caller-supplied C# objects would be emitted with minified field names in the generated JS, which would produce unreadable keys in the JSON payload.
+
+```csharp
+log.Info("api call complete", new string[]
+{
+    "method", "POST",
+    "path", "/api/items",
+    "status", "200",
+    "durationMs", "42"
+});
+```
+
+### Trace and Debug (stripped in Release)
+
+```csharp
+log.Trace("rendering item list");   // stripped in Release
+log.Debug("applying filter");        // stripped in Release
+log.Info("filter applied");          // always emitted
+```
+
+See [Compile-Time Stripping](#compile-time-stripping) for the full rules.
+
+---
+
+## Sinks
+
+### Default: ConsoleSink
+
+Writes each event as a single JSON line to the appropriate browser console method (`console.error` / `console.warn` / `console.log`). Installed lazily on the first log call if the application has not otherwise configured sinks.
+
+### HttpLogSink — batched HTTP transport
+
+Register an HTTP sink once at application startup. The constructor parameters:
+
+| Parameter | Purpose |
+|-----------|---------|
+| `endpoint` | URL to POST batches to. |
+| `batchSize` | Flush when the queue reaches this many events. |
+| `flushIntervalMs` | Flush on this timer interval regardless of queue size. |
+| `maxQueueSize` | Oldest events are dropped above this threshold. |
+| `timer` | An `IWindowTimer` — use `new WindowTimer()` in app code, or a test double in tests. |
+
+```csharp
+Logger.AddSink(new HttpLogSink(
+    "/ClientLogs.ashx",
+    batchSize: 20,
+    flushIntervalMs: 5000,
+    maxQueueSize: 500,
+    timer: new WindowTimer()));
+```
+
+#### Flush triggers
+
+An HTTP batch flushes on any of:
+
+1. Queue length reaches `batchSize`.
+2. Timer fires every `flushIntervalMs`.
+3. `Logger.Flush()` is called explicitly.
+4. The page is transitioning away (`pagehide` / `beforeunload`). The sink uses `navigator.sendBeacon` with a `Blob` of type `application/json` so pending events survive even forced navigations.
+
+#### Overflow behavior
+
+When the queue exceeds `maxQueueSize` the sink drops the **oldest** events (keeping the most recent ones — typically the most useful when triaging a crash) and stamps the running drop count into the next payload envelope. The drop count is in the payload, not an HTTP header, because `navigator.sendBeacon` cannot set custom headers and custom headers would trigger CORS preflight on the normal XHR path.
+
+#### Lifecycle
+
+`Logger.RemoveSink(sink)` calls `sink.Detach()` — `HttpLogSink.Detach` clears the timer, removes the unload listener, and performs a best-effort final `sendBeacon` flush of any still-queued events.
+
+### Writing a custom sink
+
+```csharp
+public class MyCustomSink : ILogSink
+{
+    public void Handle(LogEvent evt) { /* enqueue / forward / etc. */ }
+    public void Flush()              { /* flush buffered events */ }
+    public void Detach()             { /* clean up resources */ }
+}
+
+Logger.AddSink(new MyCustomSink());
+```
+
+`Logger` wraps every `Handle`/`Flush`/`Detach` call in a try/catch so a faulty sink cannot break its peers or the original caller (important: `Logger.Error(...)` is called from exception handlers and must never throw).
+
+---
+
+## JSON Schema
+
+### Individual event
+
+```json
+{
+  "ts":       "2026-04-17T18:00:00.000Z",
+  "level":    "INFO",
+  "cat":      "TodoApp.ListView",
+  "msg":      "Item added",
+  "props":    { "itemId": "42", "source": "api" },
+  "traceId":       "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
+  "spanId":        "a1b2c3d4e5f6a7b8",
+  "parentSpanId":  "f1e2d3c4b5a6f7e8",
+  "actionId":      5,
+  "depth":         1
+}
+```
+
+- `level` is the string form of `LogLevel`: `"TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR"`.
+- `cat` is omitted when the event came through the static facade (i.e. uncategorized).
+- `props` is built from the flat `string[]`; omitted when the caller passed none.
+- The `traceId` / `spanId` / `parentSpanId` / `actionId` / `depth` group is included together when a `CallContext` was active at emit time; otherwise the whole group is omitted.
+
+### HTTP batch envelope
+
+```json
+{
+  "events":  [ /* array of events */ ],
+  "dropped": 0
+}
+```
+
+`dropped` is a running counter of events that were evicted from the queue because it exceeded `maxQueueSize`. Always present.
+
+---
+
+## Compile-Time Stripping
+
+`Logger.Trace` and `Logger.Debug` (both the static facade and the `NamedLogger` instance methods) are tagged with `[Conditional("DEBUG")]`. When the **caller's** NScript project is compiled without the `DEBUG` symbol (i.e. Release config), Roslyn removes every call to these methods — including argument evaluation — from the bound tree before it reaches the NScript AST serializer. Result: zero runtime overhead in Release.
+
+### Important: per-assembly
+
+`[Conditional]` strips at the caller's compilation, not the framework's. If a referenced NScript library was built with `DEBUG` defined, its own internal Trace/Debug calls remain even when your app is built in Release. This is standard .NET behavior.
+
+### NScript project template setup
+
+NScript's default project templates already set the right constants:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  <DefineConstants>DEBUG;TRACE</DefineConstants>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <DefineConstants>TRACE</DefineConstants>
+</PropertyGroup>
+```
+
+So stripping works out of the box — no additional build configuration is required.
+
+### Why Trace/Debug are not on `ILogger`
+
+C# does not allow `[Conditional]` on interface methods. If `ILogger` exposed `Trace`/`Debug`, a call through the interface reference would silently bypass stripping — a subtle bug. `ILogger` intentionally exposes only `Info`/`Warn`/`Error`. Callers that want compile-time stripping should hold the concrete `NamedLogger` returned by `Logger.ForCategory(...)` rather than casting to `ILogger`.
+
+---
+
+## Lifecycle
+
+`Logger` is a process-wide static. The first log call installs a default `ConsoleSink` lazily. Once the application calls `AddSink` or `ClearSinks`, the lazy default is suppressed — so after `ClearSinks()` the logger is truly silent until sinks are added again.
+
+Typical startup wiring:
+
+```csharp
+public static class AppBootstrap
+{
+    public static void ConfigureLogging()
+    {
+        Logger.ClearSinks();                           // drop the default
+        Logger.AddSink(new ConsoleSink());              // keep console output in dev
+        Logger.AddSink(new HttpLogSink(                 // + ship to server
+            "/ClientLogs.ashx",
+            batchSize: 20,
+            flushIntervalMs: 5000,
+            maxQueueSize: 500,
+            timer: new WindowTimer()));
+        Logger.MinLevel = LogLevel.Info;
+    }
+}
+```
+
+---
+
+## Server-Side Ingestion
+
+The `TestWebApplication/ClientLogs.ashx` handler is a minimal reference — it forwards each event to `System.Diagnostics.Trace.WriteLine`. Production deployments should pipe the payload into a real logging backend. Below are wiring snippets for two common choices.
+
+### Serilog
+
+```csharp
+public class ClientLogsHandler : IHttpHandler
+{
+    private static readonly ILogger log = Log.ForContext("source", "client");
+
+    public void ProcessRequest(HttpContext context)
+    {
+        var body = new StreamReader(context.Request.InputStream).ReadToEnd();
+        var envelope = JsonConvert.DeserializeObject<ClientLogEnvelope>(body);
+
+        foreach (var evt in envelope.Events)
+        {
+            var level = evt.Level switch
+            {
+                "TRACE" => LogEventLevel.Verbose,
+                "DEBUG" => LogEventLevel.Debug,
+                "INFO"  => LogEventLevel.Information,
+                "WARN"  => LogEventLevel.Warning,
+                "ERROR" => LogEventLevel.Error,
+                _        => LogEventLevel.Information,
+            };
+
+            log
+                .ForContext("TraceId",  evt.TraceId)
+                .ForContext("SpanId",   evt.SpanId)
+                .ForContext("Category", evt.Cat)
+                .ForContext("Props",    evt.Props, destructureObjects: true)
+                .Write(level, "{Message}", evt.Msg);
+        }
+
+        context.Response.StatusCode = 204;
+    }
+
+    public bool IsReusable => true;
+}
+```
+
+### NLog
+
+```csharp
+public class ClientLogsHandler : IHttpHandler
+{
+    private static readonly NLog.Logger log = NLog.LogManager.GetLogger("client");
+
+    public void ProcessRequest(HttpContext context)
+    {
+        var body = new StreamReader(context.Request.InputStream).ReadToEnd();
+        var envelope = JsonConvert.DeserializeObject<ClientLogEnvelope>(body);
+
+        foreach (var evt in envelope.Events)
+        {
+            var theEvent = new LogEventInfo(
+                NLog.LogLevel.FromString(MapLevel(evt.Level)),
+                "client",
+                evt.Msg);
+
+            theEvent.Properties["TraceId"]  = evt.TraceId;
+            theEvent.Properties["SpanId"]   = evt.SpanId;
+            theEvent.Properties["Category"] = evt.Cat;
+            if (evt.Props != null)
+            {
+                foreach (var kvp in evt.Props)
+                {
+                    theEvent.Properties[kvp.Key] = kvp.Value;
+                }
+            }
+
+            log.Log(theEvent);
+        }
+
+        context.Response.StatusCode = 204;
+    }
+
+    private static string MapLevel(string lvl) => lvl switch
+    {
+        "TRACE" => "Trace",
+        "DEBUG" => "Debug",
+        "INFO"  => "Info",
+        "WARN"  => "Warn",
+        "ERROR" => "Error",
+        _        => "Info",
+    };
+
+    public bool IsReusable => true;
+}
+```
+
+---
+
+## Out of Scope (v1)
+
+The following are not implemented in WI-11 but the pipeline is designed to allow them without public-API breaks:
+
+- WebSocket transport sink.
+- Per-category level overrides (beyond a single global `MinLevel`).
+- Sampling / rate limiting.
+- Serilog-style message templates (`"item {ItemId} added"`).
+- Offline / localStorage persistence and retry.
+
+Additional sinks can be added at any time by implementing `ILogSink` and calling `Logger.AddSink(...)`.


### PR DESCRIPTION
Closes #11.

Refactors the client-side `Logger` into a sink-based pipeline while keeping the pre-WI-11 API (`Logger.Debug`/`Info`/`Warn`/`Error`) fully backwards compatible — existing callers such as `TaskScheduler`'s exception handlers compile unchanged.

## Summary

- **`ILogSink`** contract with `Handle`/`Flush`/`Detach` lifecycle.
- **`ConsoleSink`** — default lazy-installed sink that writes one-line JSON to the appropriate `console.*` method.
- **`HttpLogSink`** — batched HTTP transport with size/timer flush, bounded queue with oldest-drop overflow, and `navigator.sendBeacon` fallback on `pagehide`/`beforeunload` for reliable unload delivery.
- **`ILogger` / `NamedLogger`** — category-scoped loggers via `Logger.ForCategory("TodoApp.ListView")`. Instance-cached so holding a static ref is zero-allocation per call.
- **`LogEvent`** immutable snapshot auto-enriched with `CallContext` correlation (`traceId`, `spanId`, `parentSpanId`, `actionId`, `depth`).
- **`LogJsonBuilder`** — pure-C# JSON envelope assembly that survives NScript minification; only string-escape defers to the browser's `JSON.stringify`.

## Compile-time stripping

`Logger.Trace`/`Debug` and `NamedLogger.Trace`/`Debug` carry `[Conditional("DEBUG")]`, so Release builds strip call sites (including argument evaluation) via Roslyn. `Trace`/`Debug` are intentionally **not** on `ILogger` because C# disallows `[Conditional]` on interface members — exposing them there would silently bypass stripping.

## Reliability

- Per-sink `try/catch` in `Logger.DispatchInternal`, `Logger.Flush`, `Logger.RemoveSink`, `Logger.ClearSinks` so a faulty sink cannot break its peers or the caller (which may be an exception handler).
- Re-entrancy guards in `Logger.DispatchInternal` (`dispatching` flag) and `HttpLogSink.Flush` (`flushing` flag) prevent duplicate delivery and runaway recursion.
- `HttpLogSink` swallows transport errors in `Flush`/`Detach`/`OnPageUnload` — the timer callback and unload handler cannot meaningfully react to a network failure, and the design is documented as fire-and-forget.

## JSON schema

```json
{
  "ts":       "2026-04-17T18:00:00.000Z",
  "level":    "INFO",
  "cat":      "TodoApp.ListView",
  "msg":      "Item added",
  "props":    { "itemId": "42" },
  "traceId":       "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
  "spanId":        "a1b2c3d4e5f6a7b8",
  "parentSpanId":  "f1e2d3c4b5a6f7e8",
  "actionId":      5,
  "depth":         1
}
```

HTTP envelope: `{ "events": [...], "dropped": N }`.

## Test plan

- [x] 17 QUnit framework tests in `LoggerTests.cs` — level filtering, multi-sink fan-out, category carry, instance caching, null-category normalization, `CallContext` enrichment, property passthrough, sink fault isolation, `RemoveSink`/`Detach`, `ClearSinks` suppresses lazy default, `Flush`, `Trace` dispatches under DEBUG, `NamedLogger.Trace` carries category, `HttpLogSink` batch-on-size / timer-cleared-on-detach / overflow-drops-oldest.
- [x] All 168 framework QUnit tests pass (759/759 assertions).
- [x] Debug + Release builds clean (0 errors).
- [x] Existing callers (`TaskScheduler`) compile unchanged — confirmed no `Logger.Emit` references anywhere.

## Documentation

`docs/framework-logging.md` covers the JSON schema, server-side wiring snippets for Serilog and NLog, compile-time stripping semantics, lifecycle patterns, and out-of-scope items for follow-up (WebSocket transport, per-category level overrides, sampling, message templates, localStorage retry).

## Reference ingestion handler

`Test/Framework/TestWebApplication/ClientLogs.ashx(.cs)` — minimal handler that forwards each batched event to `Trace.WriteLine`. Intended as a starting point; docs show how to plug into Serilog / NLog / AppInsights.