### PR TITLE
[Gautam's Dev bot] WI-37: E2E tests for SourceMap.Server handler

### DIFF
--- a/NScript_Full.sln
+++ b/NScript_Full.sln
@@ -134,6 +134,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceMap.Server", "Sources
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceMap.Server.Test", "Test\Compiler\SourceMap.Server.Test\SourceMap.Server.Test.csproj", "{5093B87D-9EBC-4042-9AA0-52FDA482B36E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SourceMap.Server.TestHost", "Test\Compiler\SourceMap.Server.TestHost\SourceMap.Server.TestHost.csproj", "{A15D632A-7088-4863-858F-22C40A9A3E9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -672,6 +674,18 @@ Global
 		{5093B87D-9EBC-4042-9AA0-52FDA482B36E}.Release|x86.Build.0 = Release|Any CPU
 		{5093B87D-9EBC-4042-9AA0-52FDA482B36E}.Release|x64.ActiveCfg = Release|Any CPU
 		{5093B87D-9EBC-4042-9AA0-52FDA482B36E}.Release|x64.Build.0 = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|x86.Build.0 = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Debug|x64.Build.0 = Debug|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|x86.ActiveCfg = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|x86.Build.0 = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|x64.ActiveCfg = Release|Any CPU
+		{A15D632A-7088-4863-858F-22C40A9A3E9E}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -728,6 +742,7 @@ Global
 		{778C79FE-36CA-4094-BDD7-9C83E2B6E22F} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
 		{41E37499-F395-42F7-8A45-DE4E6FDEC8AD} = {159B8E2A-E38A-411C-A798-F5EB41047019}
 		{5093B87D-9EBC-4042-9AA0-52FDA482B36E} = {C3E4332C-8AEF-4CE7-B1CF-030E7A42342C}
+		{A15D632A-7088-4863-858F-22C40A9A3E9E} = {C3E4332C-8AEF-4CE7-B1CF-030E7A42342C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {583A0EE8-123E-4527-835C-EF2149A86292}

--- a/Test/Compiler/SourceMap.Server.Test/EndToEndServerTests.cs
+++ b/Test/Compiler/SourceMap.Server.Test/EndToEndServerTests.cs
@@ -162,10 +162,10 @@ namespace OwaSourceMapper.Server.Test
 
             var resp = await this.client.GetAsync(url);
 
-            Assert.AreNotEqual(
-                HttpStatusCode.OK,
-                resp.StatusCode,
-                "Dotted traversal must never resolve to a 200 response");
+            int status = (int)resp.StatusCode;
+            Assert.IsTrue(
+                status >= 400 && status < 500,
+                "Dotted traversal must fail closed with a 4xx, got " + status);
             string body = await resp.Content.ReadAsStringAsync();
             Assert.IsFalse(
                 body.Contains("namespace FixtureApp"),

--- a/Test/Compiler/SourceMap.Server.Test/EndToEndServerTests.cs
+++ b/Test/Compiler/SourceMap.Server.Test/EndToEndServerTests.cs
@@ -1,0 +1,293 @@
+// -----------------------------------------------------------------------
+// <copyright file="EndToEndServerTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace OwaSourceMapper.Server.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// End-to-end tests for <see cref="SourceMapFileHandler.MapSourceMapFiles"/>
+    /// driven through <see cref="WebApplicationFactory{TEntryPoint}"/>. Unlike
+    /// <see cref="SourceMapFileHandlerTests"/> (which drives
+    /// <see cref="SourceMapFileHandler.HandleAsync"/> against a
+    /// <c>DefaultHttpContext</c>), this suite exercises the real ASP.NET Core
+    /// pipeline — routing, URL decoding, response streaming — so regressions in
+    /// endpoint wiring are caught alongside handler logic.
+    /// </summary>
+    /// <remarks>
+    /// Fixtures (<c>Program.cs</c>, <c>View.xwml</c>, <c>Skin.cshtml</c>) are
+    /// copied into each test's workdir so <c>sourcesLong</c> entries point at
+    /// real bytes the handler can stream back. Maps are produced by the real
+    /// <see cref="OwaSourceMapper.SourceMap"/> class via
+    /// <see cref="FixtureMapEmitter"/>, so each scenario exercises the JSON
+    /// shape the compiler actually emits.
+    /// </remarks>
+    [TestClass]
+    public class EndToEndServerTests
+    {
+        private string workDir;
+        private string mapsDir;
+        private string sourcesDir;
+        private string programCsPath;
+        private string viewXwmlPath;
+        private string skinCshtmlPath;
+        private SourceMapServerFactory factory;
+        private HttpClient client;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this.workDir = Path.Combine(Path.GetTempPath(), "SourceMapServerE2E_" + Guid.NewGuid().ToString("N"));
+            this.mapsDir = Path.Combine(this.workDir, "maps");
+            this.sourcesDir = Path.Combine(this.workDir, "src");
+            Directory.CreateDirectory(this.mapsDir);
+            Directory.CreateDirectory(this.sourcesDir);
+
+            string fixtureRoot = Path.Combine(AppContext.BaseDirectory, "Fixtures");
+            this.programCsPath = CopyFixture(fixtureRoot, "Program.cs");
+            this.viewXwmlPath = CopyFixture(fixtureRoot, "View.xwml");
+            this.skinCshtmlPath = CopyFixture(fixtureRoot, "Skin.cshtml");
+
+            FixtureMapEmitter.Emit(
+                FixtureMapEmitter.DefaultMapName,
+                this.mapsDir,
+                new[] { this.programCsPath, this.viewXwmlPath, this.skinCshtmlPath },
+                sourceRoot: TestStartup.PathPrefix + "/" + FixtureMapEmitter.DefaultMapName,
+                emitLegacyAshxHandler: false);
+
+            TestStartup.CurrentOptions = new SourceMapFileHandlerOptions
+            {
+                MapsDirectory = this.mapsDir,
+                AllowedSourceRoots = new List<string> { this.sourcesDir },
+            };
+
+            this.factory = new SourceMapServerFactory();
+            this.client = this.factory.CreateClient();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.client?.Dispose();
+            this.factory?.Dispose();
+            TestStartup.CurrentOptions = null;
+
+            if (Directory.Exists(this.workDir))
+            {
+                try
+                {
+                    Directory.Delete(this.workDir, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // Best-effort; a transient antivirus hold on Windows should
+                    // not fail the test itself.
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task GET_ShortName_ReturnsMappedSource_Cs()
+        {
+            await AssertFixtureRoundTripAsync(this.programCsPath);
+        }
+
+        [TestMethod]
+        public async Task GET_ShortName_ReturnsMappedSource_Xwml()
+        {
+            await AssertFixtureRoundTripAsync(this.viewXwmlPath);
+        }
+
+        [TestMethod]
+        public async Task GET_ShortName_ReturnsMappedSource_Cshtml()
+        {
+            await AssertFixtureRoundTripAsync(this.skinCshtmlPath);
+        }
+
+        [TestMethod]
+        public async Task GET_UnknownShort_Returns404()
+        {
+            var resp = await this.client.GetAsync(
+                TestStartup.PathPrefix + "/" + FixtureMapEmitter.DefaultMapName + "/C$/does-not-exist/Phantom.cs");
+
+            Assert.AreEqual(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [TestMethod]
+        [DataRow("a:b")]
+        [DataRow("a b")]
+        [DataRow(".hidden")]
+        public async Task GET_MapNameWithDisallowedChars_Returns400(string mapName)
+        {
+            // These map-name patterns survive URL normalization and reach the
+            // endpoint as-is, so the handler's whitelist must reject them with
+            // 400. Dotted-traversal (".." segment) is handled one layer up by
+            // ASP.NET Core path normalization and never reaches the endpoint,
+            // so it is covered by GET_PathTraversalNormalization_DoesNotServeContent.
+            string url = TestStartup.PathPrefix + "/"
+                + Uri.EscapeDataString(mapName) + "/"
+                + FixtureMapEmitter.ToShortName(this.programCsPath);
+
+            var resp = await this.client.GetAsync(url);
+
+            Assert.AreEqual(
+                HttpStatusCode.BadRequest,
+                resp.StatusCode,
+                "Tampered mapName must be refused with 400 before any filesystem lookup");
+        }
+
+        [TestMethod]
+        public async Task GET_PathTraversalNormalization_DoesNotServeContent()
+        {
+            // ASP.NET Core normalizes ".." out of the path before routing, so
+            // the request either misses the endpoint entirely (yielding the
+            // normalized URL which is not a configured route) or hits it with
+            // a collapsed mapName that does not exist. Either outcome is
+            // acceptable — the contract being verified here is simply "no
+            // fixture content can be coerced out via traversal".
+            string url = TestStartup.PathPrefix + "/../"
+                + FixtureMapEmitter.DefaultMapName + "/"
+                + FixtureMapEmitter.ToShortName(this.programCsPath);
+
+            var resp = await this.client.GetAsync(url);
+
+            Assert.AreNotEqual(
+                HttpStatusCode.OK,
+                resp.StatusCode,
+                "Dotted traversal must never resolve to a 200 response");
+            string body = await resp.Content.ReadAsStringAsync();
+            Assert.IsFalse(
+                body.Contains("namespace FixtureApp"),
+                "Traversal response must not leak fixture content");
+        }
+
+        [TestMethod]
+        public async Task GET_UnknownMap_Returns404()
+        {
+            var resp = await this.client.GetAsync(
+                TestStartup.PathPrefix + "/missing/"
+                + FixtureMapEmitter.ToShortName(this.programCsPath));
+
+            Assert.AreEqual(
+                HttpStatusCode.NotFound,
+                resp.StatusCode,
+                "Missing map file must 404 rather than serving any content");
+        }
+
+        [TestMethod]
+        public async Task GET_SiblingPrefixRoot_Returns404_NoBodyLeak()
+        {
+            // Classic containment pitfall: allow-list is <work>/src, attacker
+            // aims at <work>/src-evil/Secret.cs. Repeats the HandleAsync-level
+            // regression coverage at the full HTTP-transport level so future
+            // wiring changes (middleware, filters) cannot reintroduce the leak.
+            string evilDir = Path.Combine(this.workDir, "src-evil");
+            Directory.CreateDirectory(evilDir);
+            string secretPath = Path.Combine(evilDir, "Secret.cs");
+            File.WriteAllText(secretPath, "sibling-evil-payload");
+
+            FixtureMapEmitter.Emit(
+                "sibling",
+                this.mapsDir,
+                new[] { secretPath },
+                sourceRoot: TestStartup.PathPrefix + "/sibling",
+                emitLegacyAshxHandler: false);
+
+            var resp = await this.client.GetAsync(
+                TestStartup.PathPrefix + "/sibling/" + FixtureMapEmitter.ToShortName(secretPath));
+
+            Assert.AreEqual(HttpStatusCode.NotFound, resp.StatusCode);
+            string body = await resp.Content.ReadAsStringAsync();
+            Assert.IsFalse(
+                body.Contains("sibling-evil-payload"),
+                "Containment must fail closed — body must not leak file content");
+        }
+
+        [TestMethod]
+        public void SourceRoot_IsWiredIntoMap_AndNoLegacyAshxSidecar()
+        {
+            // Opens the file the emitter wrote in Init and asserts the two
+            // configuration knobs PR #36 added flowed through end-to-end.
+            string mapPath = Path.Combine(this.mapsDir, FixtureMapEmitter.DefaultMapName + ".map");
+            using var doc = JsonDocument.Parse(File.ReadAllText(mapPath));
+            string sourceRoot = doc.RootElement.GetProperty("sourceRoot").GetString();
+
+            Assert.AreEqual(
+                TestStartup.PathPrefix + "/" + FixtureMapEmitter.DefaultMapName,
+                sourceRoot,
+                "Emitted map's sourceRoot must point at the new handler route, not the legacy .ashx");
+
+            string ashxSidecar = Path.Combine(this.mapsDir, FixtureMapEmitter.DefaultMapName + ".ashx");
+            Assert.IsFalse(
+                File.Exists(ashxSidecar),
+                "EmitLegacyAshxHandler=false must suppress the .ashx sidecar next to the map");
+        }
+
+        [TestMethod]
+        public async Task GET_SourceRootPlusShortName_ResolvesLikeDevTools()
+        {
+            // DevTools composes GET {sourceRoot}/{shortName}. Asserts the two
+            // together form a valid URL that routes into the handler and
+            // streams back the original bytes — the canonical AC #1 flow.
+            string mapPath = Path.Combine(this.mapsDir, FixtureMapEmitter.DefaultMapName + ".map");
+            using var doc = JsonDocument.Parse(File.ReadAllText(mapPath));
+            string sourceRoot = doc.RootElement.GetProperty("sourceRoot").GetString();
+            string shortName = doc.RootElement.GetProperty("sources")[0].GetString();
+
+            string composed = sourceRoot.TrimEnd('/') + "/" + shortName;
+
+            var resp = await this.client.GetAsync(composed);
+
+            Assert.AreEqual(HttpStatusCode.OK, resp.StatusCode);
+            Assert.AreEqual("text/plain; charset=utf-8", resp.Content.Headers.ContentType?.ToString());
+            byte[] expected = File.ReadAllBytes(this.programCsPath);
+            byte[] actual = await resp.Content.ReadAsByteArrayAsync();
+            CollectionAssert.AreEqual(
+                expected,
+                actual,
+                "Body returned by the real HTTP pipeline must be byte-exact with the fixture on disk");
+        }
+
+        private async Task AssertFixtureRoundTripAsync(string fixturePath)
+        {
+            string shortName = FixtureMapEmitter.ToShortName(fixturePath);
+            string url = TestStartup.PathPrefix + "/" + FixtureMapEmitter.DefaultMapName + "/" + shortName;
+
+            var resp = await this.client.GetAsync(url);
+
+            Assert.AreEqual(HttpStatusCode.OK, resp.StatusCode, "Expected 200 for " + url);
+            Assert.AreEqual("text/plain; charset=utf-8", resp.Content.Headers.ContentType?.ToString());
+            byte[] expected = File.ReadAllBytes(fixturePath);
+            byte[] actual = await resp.Content.ReadAsByteArrayAsync();
+            CollectionAssert.AreEqual(
+                expected,
+                actual,
+                "Response body must be byte-identical to the fixture on disk");
+        }
+
+        private string CopyFixture(string fixtureRoot, string relative)
+        {
+            string source = Path.Combine(fixtureRoot, relative);
+            string dest = Path.Combine(this.sourcesDir, relative);
+            string destDir = Path.GetDirectoryName(dest);
+            if (!string.IsNullOrEmpty(destDir))
+            {
+                Directory.CreateDirectory(destDir);
+            }
+
+            File.Copy(source, dest, overwrite: true);
+            return dest;
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.Test/FixtureMapEmitter.cs
+++ b/Test/Compiler/SourceMap.Server.Test/FixtureMapEmitter.cs
@@ -1,0 +1,200 @@
+// -----------------------------------------------------------------------
+// <copyright file="FixtureMapEmitter.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace OwaSourceMapper.Server.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    /// <summary>
+    /// Builds a compiler-emitted <c>.map</c> + companion <c>.js</c> pair for the
+    /// SourceMap.Server end-to-end test suite. The map is produced by the real
+    /// <see cref="OwaSourceMapper.SourceMap"/> class (the same type the NScript
+    /// compiler uses) so the tests exercise the V3 JSON shape the handler will
+    /// encounter in production.
+    /// </summary>
+    /// <remarks>
+    /// Kept deliberately free of any MSTest dependency so it can be reused from
+    /// the <c>SourceMap.Server.TestHost</c> console entry point that backs the
+    /// Playwright browser test. The helper only needs:
+    /// <list type="bullet">
+    ///   <item>A set of fixture source files on disk.</item>
+    ///   <item>A target output directory for the <c>.map</c> + <c>.js</c>.</item>
+    ///   <item>An optional <c>sourceRoot</c> to embed in the map (defaults to a
+    ///     relative URL so the fixture is portable between <c>WebApplicationFactory</c>
+    ///     and a real Kestrel host).</item>
+    /// </list>
+    /// Designed to stay forward-compatible with WI-19 (repo-linked source maps):
+    /// callers can pass any <c>sourceRoot</c> — including a GitHub or Azure DevOps
+    /// raw-file URL — and the emitter will thread it through without change.
+    /// </remarks>
+    public static class FixtureMapEmitter
+    {
+        /// <summary>
+        /// Default map name used by the E2E suite. Matches the URL segment in
+        /// <c>/sourcemap/{mapName}/{shortName}</c>.
+        /// </summary>
+        public const string DefaultMapName = "app";
+
+        /// <summary>
+        /// Emits a <c>{mapName}.map</c> plus a small companion <c>{mapName}.js</c>
+        /// into <paramref name="outputDir"/>. The <c>.js</c> contains a single
+        /// function body and a <c>//# sourceMappingURL=</c> comment pointing at
+        /// the emitted map so a browser loading the JS will fetch the map.
+        /// </summary>
+        /// <param name="mapName">
+        /// URL-safe map name (used for both file stems and the <c>sources[]</c>
+        /// short-name layout). Must satisfy the handler's <c>mapName</c> regex.
+        /// </param>
+        /// <param name="outputDir">
+        /// Directory into which <c>{mapName}.map</c> and <c>{mapName}.js</c> are
+        /// written. Created if it does not exist.
+        /// </param>
+        /// <param name="fixtureFiles">
+        /// Absolute paths to the fixture source files that should be recorded in
+        /// the map's <c>sources</c> / <c>sourcesLong</c> arrays. Each file gets
+        /// one (0, i*8) → (0, 0) mapping anchor — enough for DevTools to resolve a
+        /// <c>Debugger.setBreakpointByUrl</c> against the source URL.
+        /// </param>
+        /// <param name="sourceRoot">
+        /// Optional value for the map's <c>sourceRoot</c>. When null or empty, the
+        /// handler contract dictates the legacy <c>{file}.ashx</c> fallback; when
+        /// set to a URL (e.g. <c>"/sourcemap/app"</c> or
+        /// <c>"https://raw.githubusercontent.com/owner/repo/sha/"</c>), the emitted
+        /// map's <c>sourceRoot</c> is wired to that value.
+        /// </param>
+        /// <param name="emitLegacyAshxHandler">
+        /// Whether to keep the legacy <c>SrcMapper.ashx</c> sidecar alongside the
+        /// <c>.map</c>. Defaults to <c>false</c> for the E2E suite since the new
+        /// handler replaces the legacy WebForms one.
+        /// </param>
+        /// <returns>
+        /// The emitted artifacts — full paths to the <c>.map</c> and <c>.js</c>,
+        /// plus the short-name → long-path dictionary the map records.
+        /// </returns>
+        public static EmittedMap Emit(
+            string mapName,
+            string outputDir,
+            IReadOnlyList<string> fixtureFiles,
+            string sourceRoot = null,
+            bool emitLegacyAshxHandler = false)
+        {
+            if (string.IsNullOrEmpty(mapName))
+            {
+                throw new ArgumentException("mapName must be non-empty", nameof(mapName));
+            }
+
+            if (string.IsNullOrEmpty(outputDir))
+            {
+                throw new ArgumentException("outputDir must be non-empty", nameof(outputDir));
+            }
+
+            if (fixtureFiles == null || fixtureFiles.Count == 0)
+            {
+                throw new ArgumentException("At least one fixture file is required", nameof(fixtureFiles));
+            }
+
+            Directory.CreateDirectory(outputDir);
+
+            var map = new OwaSourceMapper.SourceMap
+            {
+                File = mapName + ".js",
+                EmitLegacyAshxHandler = emitLegacyAshxHandler,
+            };
+
+            if (!string.IsNullOrEmpty(sourceRoot))
+            {
+                map.SourceRoot = sourceRoot;
+            }
+
+            // Each fixture gets one deterministic anchor mapping at (1, 1) in the
+            // generated JS pointing to (1, 1) in the source. The URL-safe short
+            // name is computed the same way SourceMap.ToString() does (":" → "$",
+            // "\" → "/") so tests can predict what appears in the sources array.
+            var shortLongPairs = new Dictionary<string, string>(StringComparer.Ordinal);
+            for (int i = 0; i < fixtureFiles.Count; i++)
+            {
+                string absolute = Path.GetFullPath(fixtureFiles[i]);
+                map.AddMapping(
+                    sLine: 0,
+                    sCol: i * 8,
+                    tLine: 0,
+                    tCol: 0,
+                    file: absolute);
+
+                string shortName = ToShortName(absolute);
+                shortLongPairs[shortName] = absolute;
+            }
+
+            map.Write(outputDir);
+
+            string mapPath = Path.Combine(outputDir, mapName + ".map");
+            string jsPath = Path.Combine(outputDir, mapName + ".js");
+
+            // Compute the sourceMappingURL. The handler resolves maps by map name
+            // alone; the companion .js only needs a URL that returns the right
+            // .map bytes when fetched by the browser. When sourceRoot is a path,
+            // we anchor the mapping URL relative to the .js so a host serving the
+            // .js from "/app.js" resolves the map from "/app.map" at the root.
+            string mappingUrl = mapName + ".map";
+            File.WriteAllText(
+                jsPath,
+                BuildFixtureJs(mapName, fixtureFiles.Count, mappingUrl));
+
+            return new EmittedMap(mapPath, jsPath, shortLongPairs);
+        }
+
+        /// <summary>
+        /// Mirrors <see cref="OwaSourceMapper.SourceMap.ToString"/>'s short-name
+        /// computation so tests can produce the exact URL segment the handler
+        /// will match against the map's <c>sources</c> array.
+        /// </summary>
+        public static string ToShortName(string absolutePath)
+        {
+            return Path.GetFullPath(absolutePath).Replace(":", "$").Replace("\\", "/");
+        }
+
+        private static string BuildFixtureJs(string mapName, int fixtureCount, string mappingUrl)
+        {
+            // The body is intentionally tiny. It exists only so Chromium has
+            // something to parse and a sourceMappingURL to follow.
+            var sb = new System.Text.StringBuilder();
+            sb.Append("// SourceMap.Server E2E fixture — generated by FixtureMapEmitter\n");
+            sb.Append("(function fixtureEntry(){\n");
+            sb.Append("  var count = ").Append(fixtureCount).Append(";\n");
+            sb.Append("  return count;\n");
+            sb.Append("})();\n");
+            sb.Append("//# sourceMappingURL=").Append(mappingUrl).Append('\n');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Result of a fixture emission.
+        /// </summary>
+        public sealed class EmittedMap
+        {
+            internal EmittedMap(string mapPath, string jsPath, IReadOnlyDictionary<string, string> shortToLong)
+            {
+                this.MapPath = mapPath;
+                this.JsPath = jsPath;
+                this.ShortToLong = shortToLong;
+            }
+
+            /// <summary> Absolute path to the emitted <c>.map</c> file. </summary>
+            public string MapPath { get; }
+
+            /// <summary> Absolute path to the emitted companion <c>.js</c> file. </summary>
+            public string JsPath { get; }
+
+            /// <summary>
+            /// URL-safe short name → absolute long path, mirroring the map's
+            /// <c>sources</c> / <c>sourcesLong</c> arrays.
+            /// </summary>
+            public IReadOnlyDictionary<string, string> ShortToLong { get; }
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.Test/Fixtures/Program.cs
+++ b/Test/Compiler/SourceMap.Server.Test/Fixtures/Program.cs
@@ -1,0 +1,12 @@
+// Fixture source for SourceMap.Server E2E tests. Byte-exact contents are
+// compared by test assertions; do not reformat.
+namespace FixtureApp
+{
+    public class Program
+    {
+        public static int Add(int left, int right)
+        {
+            return left + right;
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.Test/Fixtures/Skin.cshtml
+++ b/Test/Compiler/SourceMap.Server.Test/Fixtures/Skin.cshtml
@@ -1,0 +1,5 @@
+@* Fixture Razor skin template for SourceMap.Server E2E tests. Byte-exact
+   contents are compared by test assertions; do not reformat. *@
+<div class="greeting">
+    @Model.Title
+</div>

--- a/Test/Compiler/SourceMap.Server.Test/Fixtures/View.xwml
+++ b/Test/Compiler/SourceMap.Server.Test/Fixtures/View.xwml
@@ -1,0 +1,5 @@
+<!-- Fixture XWML template for SourceMap.Server E2E tests. Byte-exact contents
+     are compared by test assertions; do not reformat. -->
+<Root>
+  <Label Text="{Title}" />
+</Root>

--- a/Test/Compiler/SourceMap.Server.Test/SourceMap.Server.Test.csproj
+++ b/Test/Compiler/SourceMap.Server.Test/SourceMap.Server.Test.csproj
@@ -5,17 +5,29 @@
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
+    <!-- WebApplicationFactory<TEntryPoint> finds Main via HostFactoryResolver
+         reflection on the entry-point type's assembly, so the entry-point
+         discovery symbol is suppressed to keep OutputType=Library viable
+         alongside TestStartup.Main. -->
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CompilerSources)\SourceMap.Server\SourceMap.Server.csproj" />
+    <ProjectReference Include="$(CompilerSources)\SourceMap\SourceMap.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Fixtures\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/Test/Compiler/SourceMap.Server.Test/TestStartup.cs
+++ b/Test/Compiler/SourceMap.Server.Test/TestStartup.cs
@@ -1,0 +1,100 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestStartup.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace OwaSourceMapper.Server.Test
+{
+    using System;
+    using System.Threading;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Mvc.Testing;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// Program/Startup hybrid used as <c>TEntryPoint</c> for
+    /// <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/>
+    /// in the SourceMap.Server end-to-end test suite. The type must be
+    /// <c>public</c> so the factory can locate it via reflection.
+    /// </summary>
+    /// <remarks>
+    /// Each test swaps its own <see cref="SourceMapFileHandlerOptions"/> onto
+    /// <see cref="CurrentOptions"/> in <c>TestInitialize</c>, then constructs a
+    /// fresh <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/>.
+    /// <c>Main</c> pulls the latched options at request time, so each factory
+    /// instance sees the options its test configured.
+    /// </remarks>
+    public class TestStartup
+    {
+        private static SourceMapFileHandlerOptions currentOptions;
+
+        /// <summary>
+        /// Options used by the endpoint on the next pipeline build. Swapped
+        /// atomically so race conditions between parallel test runs cannot
+        /// leak configuration across factories.
+        /// </summary>
+        public static SourceMapFileHandlerOptions CurrentOptions
+        {
+            get => Volatile.Read(ref currentOptions);
+            set => Volatile.Write(ref currentOptions, value);
+        }
+
+        /// <summary>
+        /// Route prefix used when registering the handler. Must match what the
+        /// tests issue HTTP requests against.
+        /// </summary>
+        public const string PathPrefix = "/sourcemap";
+
+        /// <summary>
+        /// Entry point invoked by <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/>.
+        /// Kept minimal: routing + the one endpoint under test, nothing else.
+        /// </summary>
+        /// <param name="args"> Process args (unused). </param>
+        public static void Main(string[] args)
+        {
+            // WebApplicationFactory probes the entry assembly for its content
+            // root; set it explicitly so `WebApplication.CreateBuilder` does
+            // not try to locate wwwroot relative to a non-existent directory
+            // built from the assembly's simple name.
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                Args = args,
+                ContentRootPath = AppContext.BaseDirectory,
+            });
+            var app = builder.Build();
+            var options = CurrentOptions ?? new SourceMapFileHandlerOptions();
+            app.MapSourceMapFiles(PathPrefix, options);
+            app.Run();
+        }
+    }
+
+    /// <summary>
+    /// Thin wrapper around <see cref="WebApplicationFactory{TEntryPoint}"/>
+    /// that pins the content root to <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default content-root discovery logic of the factory prefers the
+    /// solution-relative path derived from the entry-point type's simple
+    /// assembly name, which does not exist in our layout. Hosting the app in
+    /// the test bin directory keeps fixtures resolvable via
+    /// <c>AppContext.BaseDirectory</c> and matches the path used by the
+    /// production <c>SourceMapFileHandler</c> when deployed.
+    /// </remarks>
+    public sealed class SourceMapServerFactory : WebApplicationFactory<TestStartup>
+    {
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            // Returning null forces the factory to build the host via the
+            // Main-invocation path (HostFactoryResolver), where our
+            // WebApplicationOptions.ContentRootPath takes effect.
+            return null;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseContentRoot(AppContext.BaseDirectory);
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.TestHost/Program.cs
+++ b/Test/Compiler/SourceMap.Server.TestHost/Program.cs
@@ -1,0 +1,221 @@
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace OwaSourceMapper.Server.TestHost
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Hosting.Server;
+    using Microsoft.AspNetCore.Hosting.Server.Features;
+    using Microsoft.Extensions.DependencyInjection;
+    using OwaSourceMapper.Server;
+
+    /// <summary>
+    /// End-to-end test host for the Playwright browser suite. Two subcommands:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <term><c>emit &lt;workDir&gt;</c></term>
+    ///     <description>Produces a compiler-shaped <c>{mapName}.map</c> + companion
+    ///       <c>{mapName}.js</c> under <c>{workDir}/maps</c>, and mirrors the
+    ///       bundled <c>Fixtures</c> directory into <c>{workDir}/src</c> so the
+    ///       map's <c>sourcesLong</c> entries resolve to real bytes.</description>
+    ///   </item>
+    ///   <item>
+    ///     <term><c>serve &lt;workDir&gt;</c></term>
+    ///     <description>Starts Kestrel on an ephemeral port, wires
+    ///       <c>/sourcemap</c> to <see cref="SourceMapFileHandler"/>, serves the
+    ///       <c>{workDir}/maps</c> directory as static content (for the
+    ///       <c>.js</c> + <c>.map</c> pair), and prints <c>LISTENING
+    ///       http://127.0.0.1:{port}</c> on stdout so the node harness can parse
+    ///       the URL and drive Playwright against it.</description>
+    ///   </item>
+    /// </list>
+    /// The two subcommands are deliberately decoupled so the node test can
+    /// emit fixtures up front (cheap, deterministic) and only pay the Kestrel
+    /// startup cost once per scenario group.
+    /// </summary>
+    public static class Program
+    {
+        private const string DefaultMapName = "app";
+        private const string PathPrefix = "/sourcemap";
+
+        public static int Main(string[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                Console.Error.WriteLine("Usage: SourceMap.Server.TestHost (emit|serve) <workDir>");
+                return 2;
+            }
+
+            string cmd = args[0];
+            try
+            {
+                return cmd switch
+                {
+                    "emit" => RunEmit(args),
+                    "serve" => RunServe(args),
+                    _ => InvalidUsage(cmd),
+                };
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("TestHost error: " + ex.Message);
+                Console.Error.WriteLine(ex.StackTrace);
+                return 1;
+            }
+        }
+
+        private static int InvalidUsage(string cmd)
+        {
+            Console.Error.WriteLine("Unknown subcommand: " + cmd);
+            Console.Error.WriteLine("Expected: emit | serve");
+            return 2;
+        }
+
+        private static int RunEmit(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.Error.WriteLine("emit requires <workDir>");
+                return 2;
+            }
+
+            string workDir = Path.GetFullPath(args[1]);
+            string mapsDir = Path.Combine(workDir, "maps");
+            string srcDir = Path.Combine(workDir, "src");
+            Directory.CreateDirectory(mapsDir);
+            Directory.CreateDirectory(srcDir);
+
+            string fixtureRoot = Path.Combine(AppContext.BaseDirectory, "Fixtures");
+            var fixtures = new List<string>();
+            foreach (var rel in new[] { "Program.cs", "View.xwml", "Skin.cshtml" })
+            {
+                string src = Path.Combine(fixtureRoot, rel);
+                if (!File.Exists(src))
+                {
+                    Console.Error.WriteLine("Missing fixture: " + src);
+                    return 3;
+                }
+
+                string dst = Path.Combine(srcDir, rel);
+                File.Copy(src, dst, overwrite: true);
+                fixtures.Add(dst);
+            }
+
+            EmitMap(DefaultMapName, mapsDir, fixtures, sourceRoot: PathPrefix + "/" + DefaultMapName);
+            Console.WriteLine("EMITTED " + Path.Combine(mapsDir, DefaultMapName + ".map"));
+            return 0;
+        }
+
+        private static int RunServe(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.Error.WriteLine("serve requires <workDir>");
+                return 2;
+            }
+
+            string workDir = Path.GetFullPath(args[1]);
+            string mapsDir = Path.Combine(workDir, "maps");
+            string srcDir = Path.Combine(workDir, "src");
+
+            if (!Directory.Exists(mapsDir))
+            {
+                Console.Error.WriteLine("maps dir missing; run `emit` first: " + mapsDir);
+                return 3;
+            }
+
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                ContentRootPath = workDir,
+                Args = args,
+            });
+            // Use an ephemeral port so concurrent test runs cannot collide.
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+            var app = builder.Build();
+
+            // Serve the companion .js + .map straight off disk as static files
+            // so Chromium can load them with `fetch` semantics identical to a
+            // production deploy. Fallback mimes are set for .js/.map.
+            app.UseDefaultFiles();
+            app.UseStaticFiles(new Microsoft.AspNetCore.Builder.StaticFileOptions
+            {
+                FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(mapsDir),
+                RequestPath = "/maps",
+                ServeUnknownFileTypes = true,
+                DefaultContentType = "application/octet-stream",
+            });
+
+            var handlerOptions = new SourceMapFileHandlerOptions
+            {
+                MapsDirectory = mapsDir,
+                AllowedSourceRoots = new List<string> { srcDir },
+            };
+            app.MapSourceMapFiles(PathPrefix, handlerOptions);
+
+            // Minimal HTML host page — loads /maps/{mapName}.js which, thanks to
+            // the //# sourceMappingURL comment, triggers a /maps/{mapName}.map
+            // fetch, and then a /sourcemap/{mapName}/{shortName} fetch when the
+            // browser pulls a source.
+            app.MapGet("/fixture.html", () => Microsoft.AspNetCore.Http.Results.Content(
+                "<!doctype html><html><head><title>fixture</title></head>"
+                + "<body><script src=\"/maps/" + DefaultMapName + ".js\"></script></body></html>",
+                "text/html; charset=utf-8"));
+
+            app.StartAsync().GetAwaiter().GetResult();
+
+            var server = app.Services.GetRequiredService<IServer>();
+            var addresses = server.Features.Get<IServerAddressesFeature>();
+            foreach (var addr in addresses.Addresses)
+            {
+                Console.WriteLine("LISTENING " + addr);
+            }
+
+            // Block until parent signals exit via stdin close (node harness
+            // invariant) — clean shutdown on Ctrl+C / SIGTERM is handled by
+            // ASP.NET Core's lifetime.
+            Console.In.ReadToEnd();
+            app.StopAsync().GetAwaiter().GetResult();
+            return 0;
+        }
+
+        private static void EmitMap(
+            string mapName,
+            string outputDir,
+            IList<string> fixtureFiles,
+            string sourceRoot)
+        {
+            var map = new OwaSourceMapper.SourceMap
+            {
+                File = mapName + ".js",
+                EmitLegacyAshxHandler = false,
+                SourceRoot = sourceRoot,
+            };
+
+            for (int i = 0; i < fixtureFiles.Count; i++)
+            {
+                map.AddMapping(
+                    sLine: 0,
+                    sCol: i * 8,
+                    tLine: 0,
+                    tCol: 0,
+                    file: Path.GetFullPath(fixtureFiles[i]));
+            }
+
+            map.Write(outputDir);
+
+            string jsPath = Path.Combine(outputDir, mapName + ".js");
+            File.WriteAllText(jsPath,
+                "// SourceMap.Server.TestHost fixture\n"
+                + "(function fixtureEntry(){ return 1; })();\n"
+                + "//# sourceMappingURL=" + mapName + ".map\n");
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.TestHost/Program.cs
+++ b/Test/Compiler/SourceMap.Server.TestHost/Program.cs
@@ -15,6 +15,7 @@ namespace OwaSourceMapper.Server.TestHost
     using Microsoft.AspNetCore.Hosting.Server.Features;
     using Microsoft.Extensions.DependencyInjection;
     using OwaSourceMapper.Server;
+    using OwaSourceMapper.Server.Test;
 
     /// <summary>
     /// End-to-end test host for the Playwright browser suite. Two subcommands:
@@ -42,7 +43,7 @@ namespace OwaSourceMapper.Server.TestHost
     /// </summary>
     public static class Program
     {
-        private const string DefaultMapName = "app";
+        private const string DefaultMapName = FixtureMapEmitter.DefaultMapName;
         private const string PathPrefix = "/sourcemap";
 
         public static int Main(string[] args)
@@ -108,8 +109,15 @@ namespace OwaSourceMapper.Server.TestHost
                 fixtures.Add(dst);
             }
 
-            EmitMap(DefaultMapName, mapsDir, fixtures, sourceRoot: PathPrefix + "/" + DefaultMapName);
-            Console.WriteLine("EMITTED " + Path.Combine(mapsDir, DefaultMapName + ".map"));
+            // Share the single emitter with the MSTest WAF suite so browser
+            // and WAF tests exercise byte-identical fixtures.
+            var emitted = FixtureMapEmitter.Emit(
+                DefaultMapName,
+                mapsDir,
+                fixtures,
+                sourceRoot: PathPrefix + "/" + DefaultMapName,
+                emitLegacyAshxHandler: false);
+            Console.WriteLine("EMITTED " + emitted.MapPath);
             return 0;
         }
 
@@ -186,36 +194,5 @@ namespace OwaSourceMapper.Server.TestHost
             return 0;
         }
 
-        private static void EmitMap(
-            string mapName,
-            string outputDir,
-            IList<string> fixtureFiles,
-            string sourceRoot)
-        {
-            var map = new OwaSourceMapper.SourceMap
-            {
-                File = mapName + ".js",
-                EmitLegacyAshxHandler = false,
-                SourceRoot = sourceRoot,
-            };
-
-            for (int i = 0; i < fixtureFiles.Count; i++)
-            {
-                map.AddMapping(
-                    sLine: 0,
-                    sCol: i * 8,
-                    tLine: 0,
-                    tCol: 0,
-                    file: Path.GetFullPath(fixtureFiles[i]));
-            }
-
-            map.Write(outputDir);
-
-            string jsPath = Path.Combine(outputDir, mapName + ".js");
-            File.WriteAllText(jsPath,
-                "// SourceMap.Server.TestHost fixture\n"
-                + "(function fixtureEntry(){ return 1; })();\n"
-                + "//# sourceMappingURL=" + mapName + ".map\n");
-        }
     }
 }

--- a/Test/Compiler/SourceMap.Server.TestHost/SourceMap.Server.TestHost.csproj
+++ b/Test/Compiler/SourceMap.Server.TestHost/SourceMap.Server.TestHost.csproj
@@ -28,5 +28,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <!-- Share the single FixtureMapEmitter source with the MSTest project so
+         the browser test and the WAF tests emit byte-identical map+js pairs.
+         The emitter is intentionally free of MSTest dependencies. -->
+    <Compile Include="..\SourceMap.Server.Test\FixtureMapEmitter.cs" Link="FixtureMapEmitter.cs" />
   </ItemGroup>
 </Project>

--- a/Test/Compiler/SourceMap.Server.TestHost/SourceMap.Server.TestHost.csproj
+++ b/Test/Compiler/SourceMap.Server.TestHost/SourceMap.Server.TestHost.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(CompilerNetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <!-- Kestrel-hosted end-to-end fixture runner for the Playwright browser
+         test at Test/Framework/TestWebApplication/source-map-browser.test.mjs.
+         Two subcommands: 'emit <workDir>' emits a fixture map and companion
+         .js for the browser; 'serve <workDir>' boots Kestrel on an ephemeral
+         port and prints the resulting URL on stdout. -->
+    <RootNamespace>OwaSourceMapper.Server.TestHost</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CompilerSources)\SourceMap.Server\SourceMap.Server.csproj" />
+    <ProjectReference Include="$(CompilerSources)\SourceMap\SourceMap.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Fixtures live alongside the E2E test project; link them into the
+         TestHost output so a standalone `dotnet run` emit command has the
+         same bytes the C# WAF tests exercise. -->
+    <Content Include="..\SourceMap.Server.Test\Fixtures\**\*.*">
+      <Link>Fixtures\%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/Test/Framework/TestWebApplication/run-qunit.mjs
+++ b/Test/Framework/TestWebApplication/run-qunit.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'node:url';
+import { createSourceMapRouteHandler } from './source-map-route.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const QUNIT_SUITES = [

--- a/Test/Framework/TestWebApplication/run-qunit.mjs
+++ b/Test/Framework/TestWebApplication/run-qunit.mjs
@@ -32,66 +32,9 @@ const MIME_TYPES = {
 // /sourcemap/{mapName}/{shortSource} devtools route below.
 const GENERATED_SCRIPTS_DIR = path.join(__dirname, 'GeneratedScripts');
 
-// Serve original source files referenced by an NScript .map. Dev ergonomic
-// counterpart of the ASP.NET Core SourceMapFileHandler shipped in
-// Sources/Compiler/SourceMap.Server — lets browser DevTools load C#/XWML/Razor
-// sources alongside the generated JS when the map's sourceRoot points at
-// /sourcemap/{mapName}/. Returns 404 on any mismatch so nothing outside the
-// map's pre-recorded paths can be served.
-function serveSourceMapFile(req, res) {
-  const match = req.url.match(/^\/sourcemap\/([^/]+)\/(.+)$/);
-  if (!match) {
-    res.writeHead(404);
-    res.end('Not Found');
-    return true;
-  }
-
-  const mapName = decodeURIComponent(match[1]);
-  const shortName = decodeURIComponent(match[2]);
-
-  if (mapName.includes('..') || mapName.includes('/') || mapName.includes('\\')) {
-    res.writeHead(400);
-    res.end('Bad Request');
-    return true;
-  }
-
-  const mapPath = path.join(GENERATED_SCRIPTS_DIR, mapName + '.map');
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
-  } catch {
-    res.writeHead(404);
-    res.end('Map not found');
-    return true;
-  }
-
-  const sources = Array.isArray(parsed.sources) ? parsed.sources : null;
-  const sourcesLong = Array.isArray(parsed.sourcesLong) ? parsed.sourcesLong : null;
-  if (!sources) {
-    res.writeHead(404);
-    res.end('Map has no sources');
-    return true;
-  }
-
-  const idx = sources.indexOf(shortName);
-  if (idx < 0) {
-    res.writeHead(404);
-    res.end('Source not listed in map');
-    return true;
-  }
-
-  const longPath = (sourcesLong && idx < sourcesLong.length) ? sourcesLong[idx] : shortName;
-  fs.readFile(longPath, (err, data) => {
-    if (err) {
-      res.writeHead(404);
-      res.end('Source file missing on disk');
-      return;
-    }
-    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-    res.end(data);
-  });
-  return true;
-}
+// Delegate /sourcemap/* handling to the extracted helper so both this harness
+// and its own smoke test exercise the same routing code.
+const serveSourceMapFile = createSourceMapRouteHandler(GENERATED_SCRIPTS_DIR);
 
 function renderQUnitPage(suite) {
   const scriptTags = suite.scripts

--- a/Test/Framework/TestWebApplication/source-map-browser.test.mjs
+++ b/Test/Framework/TestWebApplication/source-map-browser.test.mjs
@@ -1,0 +1,205 @@
+// Playwright + CDP browser test that proves Chromium resolves the sources
+// referenced by an NScript .map through the C# SourceMapFileHandler. Driven
+// against the SourceMap.Server.TestHost Exe (Test/Compiler/SourceMap.Server.
+// TestHost) rather than the node dev helper so the real ASP.NET Core handler
+// is the one producing 200 bytes for the DevTools fetch — the Playwright
+// layer only exists to make the proof end-to-end.
+//
+// Contract under test:
+//   1. When Chromium loads /fixture.html the browser follows
+//      //# sourceMappingURL and fetches /maps/app.map.
+//   2. When DevTools (via CDP) asks for the first source listed in that map,
+//      the handler streams back the fixture bytes (byte-identical body).
+//   3. No `..`/malformed mapName ever produces a 200 — exercised with an
+//      injected fetch from the page context.
+//
+// The test is skipped (not failed) when the TestHost binary is not present,
+// so the suite stays green on developer machines that have only built the
+// framework solution.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Resolve the TestHost DLL relative to the repo root so developers who run
+// `dotnet build` from either Debug or Release configurations can exercise the
+// test without editing this file.
+function resolveTestHostDll() {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const candidates = [
+    path.join(repoRoot, 'Test', 'Compiler', 'bin', 'net8.0', 'SourceMap.Server.TestHost.dll'),
+    path.join(repoRoot, 'Test', 'Compiler', 'bin', 'Debug', 'net8.0', 'SourceMap.Server.TestHost.dll'),
+    path.join(repoRoot, 'Test', 'Compiler', 'bin', 'Release', 'net8.0', 'SourceMap.Server.TestHost.dll'),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function makeTempWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'srcmap-browser-'));
+}
+
+function runDotnet(dllPath, args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('dotnet', [dllPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', chunk => { stdout += chunk.toString(); });
+    proc.stderr.on('data', chunk => { stderr += chunk.toString(); });
+    proc.on('exit', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`dotnet ${args.join(' ')} exited ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      }
+    });
+    proc.on('error', reject);
+  });
+}
+
+// Start the TestHost in 'serve' mode, wait until it prints
+// 'LISTENING http://127.0.0.1:{port}', and return { proc, baseUrl }. The
+// caller is responsible for terminating the child via `proc.stdin.end()` so
+// the host exits cleanly (its Console.In.ReadToEnd gate).
+function startServer(dllPath, workDir) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('dotnet', [dllPath, 'serve', workDir], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let resolved = false;
+    let buffered = '';
+
+    proc.stdout.on('data', chunk => {
+      buffered += chunk.toString();
+      const match = buffered.match(/LISTENING (http:\/\/127\.0\.0\.1:\d+)/);
+      if (match && !resolved) {
+        resolved = true;
+        resolve({ proc, baseUrl: match[1] });
+      }
+    });
+
+    proc.stderr.on('data', chunk => {
+      // Mirror host errors so CI logs are self-explanatory if startup fails.
+      process.stderr.write('[testhost] ' + chunk.toString());
+    });
+
+    proc.on('exit', code => {
+      if (!resolved) {
+        reject(new Error(`TestHost exited before listening (code=${code})`));
+      }
+    });
+
+    proc.on('error', reject);
+
+    setTimeout(() => {
+      if (!resolved) {
+        proc.kill();
+        reject(new Error('TestHost did not print LISTENING within timeout'));
+      }
+    }, 30000);
+  });
+}
+
+async function stopServer(proc) {
+  proc.stdin.end();
+  await new Promise(resolve => {
+    proc.on('exit', resolve);
+    setTimeout(() => {
+      proc.kill();
+      resolve();
+    }, 5000);
+  });
+}
+
+test('Chromium resolves NScript .map sources through the C# handler', async t => {
+  const dllPath = resolveTestHostDll();
+  if (!dllPath) {
+    t.skip('SourceMap.Server.TestHost.dll not built; run `dotnet build` first');
+    return;
+  }
+
+  let playwrightMod;
+  try {
+    playwrightMod = await import('playwright');
+  } catch {
+    t.skip('playwright not installed; run `npm install` in TestWebApplication');
+    return;
+  }
+
+  const workDir = makeTempWorkspace();
+  let serverHandle = null;
+  let browser = null;
+  try {
+    await runDotnet(dllPath, ['emit', workDir]);
+
+    serverHandle = await startServer(dllPath, workDir);
+    const { baseUrl } = serverHandle;
+
+    // Read the emitted map so the test asserts against the exact short name
+    // the C# emitter wrote — decouples us from encoding rules we'd otherwise
+    // have to duplicate.
+    const mapJson = JSON.parse(fs.readFileSync(path.join(workDir, 'maps', 'app.map'), 'utf8'));
+    const shortName = mapJson.sources[0];
+    const sourceRoot = mapJson.sourceRoot;
+    const expectedBody = fs.readFileSync(path.join(workDir, 'src', 'Program.cs'), 'utf8');
+
+    browser = await playwrightMod.chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const sourceRequests = [];
+    page.on('request', req => {
+      if (req.url().includes('/sourcemap/')) {
+        sourceRequests.push(req.url());
+      }
+    });
+
+    // Trigger the full load path: HTML → /maps/app.js → (sourceMappingURL)
+    // /maps/app.map. DevTools would now resolve sources on demand; we drive
+    // that last step explicitly via fetch() from the page context to avoid
+    // needing an attached debugger UI.
+    await page.goto(`${baseUrl}/fixture.html`, { waitUntil: 'networkidle' });
+
+    const composed = sourceRoot.replace(/\/$/, '') + '/' + shortName;
+    const resolved = await page.evaluate(async url => {
+      const resp = await fetch(url);
+      return { status: resp.status, body: await resp.text() };
+    }, composed);
+
+    assert.equal(resolved.status, 200, 'handler must stream the source');
+    assert.equal(
+      resolved.body,
+      expectedBody,
+      'browser-side body must be byte-identical to on-disk fixture');
+
+    // Negative case: a tampered mapName must get a 4xx — the handler's
+    // whitelist is part of the browser-facing contract too.
+    const badMap = await page.evaluate(async url => {
+      const resp = await fetch(url);
+      return resp.status;
+    }, `${baseUrl}/sourcemap/bad..name/foo`);
+    assert.ok(badMap >= 400 && badMap < 500, `tampered mapName must 4xx, got ${badMap}`);
+
+    assert.ok(
+      sourceRequests.length >= 1,
+      'at least one /sourcemap/ request must have reached the handler');
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    if (serverHandle) {
+      await stopServer(serverHandle.proc);
+    }
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/Test/Framework/TestWebApplication/source-map-browser.test.mjs
+++ b/Test/Framework/TestWebApplication/source-map-browser.test.mjs
@@ -79,12 +79,28 @@ function startServer(dllPath, workDir) {
     let resolved = false;
     let buffered = '';
 
+    const startupTimer = setTimeout(() => {
+      if (!resolved) {
+        proc.kill();
+        reject(new Error('TestHost did not print LISTENING within timeout'));
+      }
+    }, 30000);
+
+    const settle = (settler, value) => {
+      if (resolved) {
+        return;
+      }
+
+      resolved = true;
+      clearTimeout(startupTimer);
+      settler(value);
+    };
+
     proc.stdout.on('data', chunk => {
       buffered += chunk.toString();
       const match = buffered.match(/LISTENING (http:\/\/127\.0\.0\.1:\d+)/);
-      if (match && !resolved) {
-        resolved = true;
-        resolve({ proc, baseUrl: match[1] });
+      if (match) {
+        settle(resolve, { proc, baseUrl: match[1] });
       }
     });
 
@@ -94,19 +110,10 @@ function startServer(dllPath, workDir) {
     });
 
     proc.on('exit', code => {
-      if (!resolved) {
-        reject(new Error(`TestHost exited before listening (code=${code})`));
-      }
+      settle(reject, new Error(`TestHost exited before listening (code=${code})`));
     });
 
-    proc.on('error', reject);
-
-    setTimeout(() => {
-      if (!resolved) {
-        proc.kill();
-        reject(new Error('TestHost did not print LISTENING within timeout'));
-      }
-    }, 30000);
+    proc.on('error', err => settle(reject, err));
   });
 }
 

--- a/Test/Framework/TestWebApplication/source-map-route.mjs
+++ b/Test/Framework/TestWebApplication/source-map-route.mjs
@@ -1,0 +1,85 @@
+// Dev-ergonomic counterpart of the ASP.NET Core SourceMapFileHandler shipped
+// in Sources/Compiler/SourceMap.Server. Serves original source files referenced
+// by an NScript .map when the map's sourceRoot points at
+// /sourcemap/{mapName}/. Returns 404 on any mismatch so nothing outside the
+// map's pre-recorded paths can be served.
+//
+// Factored out of run-qunit.mjs so the behavior is testable in isolation (see
+// source-map-route.test.mjs) and reusable from any node http server.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Map names must not contain separators or relative segments; matches the
+// whitelist enforced by the C# handler's regex at SourceMapFileHandler.cs.
+const DISALLOWED_MAP_NAME_FRAGMENTS = ['..', '/', '\\'];
+
+/**
+ * Create a request handler bound to a specific generated-scripts directory.
+ * Returns a function (req, res) => boolean — true when the request was
+ * handled, false when the caller should continue routing.
+ *
+ * @param {string} generatedScriptsDir Absolute path to the directory holding
+ *   the emitted .map files. Sources referenced from those maps may live
+ *   anywhere on disk (sourcesLong entries are absolute paths).
+ */
+export function createSourceMapRouteHandler(generatedScriptsDir) {
+  if (!generatedScriptsDir || typeof generatedScriptsDir !== 'string') {
+    throw new TypeError('generatedScriptsDir must be a non-empty string');
+  }
+
+  return function handleSourceMapRoute(req, res) {
+    const match = req.url.match(/^\/sourcemap\/([^/]+)\/(.+)$/);
+    if (!match) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return true;
+    }
+
+    const mapName = decodeURIComponent(match[1]);
+    const shortName = decodeURIComponent(match[2]);
+
+    if (DISALLOWED_MAP_NAME_FRAGMENTS.some(fragment => mapName.includes(fragment))) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return true;
+    }
+
+    const mapPath = path.join(generatedScriptsDir, mapName + '.map');
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+    } catch {
+      res.writeHead(404);
+      res.end('Map not found');
+      return true;
+    }
+
+    const sources = Array.isArray(parsed.sources) ? parsed.sources : null;
+    const sourcesLong = Array.isArray(parsed.sourcesLong) ? parsed.sourcesLong : null;
+    if (!sources) {
+      res.writeHead(404);
+      res.end('Map has no sources');
+      return true;
+    }
+
+    const idx = sources.indexOf(shortName);
+    if (idx < 0) {
+      res.writeHead(404);
+      res.end('Source not listed in map');
+      return true;
+    }
+
+    const longPath = (sourcesLong && idx < sourcesLong.length) ? sourcesLong[idx] : shortName;
+    fs.readFile(longPath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Source file missing on disk');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end(data);
+    });
+    return true;
+  };
+}

--- a/Test/Framework/TestWebApplication/source-map-route.mjs
+++ b/Test/Framework/TestWebApplication/source-map-route.mjs
@@ -10,9 +10,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-// Map names must not contain separators or relative segments; matches the
-// whitelist enforced by the C# handler's regex at SourceMapFileHandler.cs.
-const DISALLOWED_MAP_NAME_FRAGMENTS = ['..', '/', '\\'];
+// Mirror the C# SourceMapFileHandler whitelist (SourceMapFileHandler.cs):
+//   ^[A-Za-z0-9_-][A-Za-z0-9._-]*$
+// First char rejects leading dots (so ".hidden" fails closed), remaining
+// characters reject separators, colons, spaces, and any other URL-hostile
+// input that would otherwise reach the filesystem join below.
+const MAP_NAME_ALLOWED = /^[A-Za-z0-9_-][A-Za-z0-9._-]*$/;
 
 /**
  * Create a request handler bound to a specific generated-scripts directory.
@@ -39,7 +42,7 @@ export function createSourceMapRouteHandler(generatedScriptsDir) {
     const mapName = decodeURIComponent(match[1]);
     const shortName = decodeURIComponent(match[2]);
 
-    if (DISALLOWED_MAP_NAME_FRAGMENTS.some(fragment => mapName.includes(fragment))) {
+    if (!MAP_NAME_ALLOWED.test(mapName)) {
       res.writeHead(400);
       res.end('Bad Request');
       return true;

--- a/Test/Framework/TestWebApplication/source-map-route.test.mjs
+++ b/Test/Framework/TestWebApplication/source-map-route.test.mjs
@@ -175,6 +175,30 @@ test('GET with empty sub-path under /sourcemap/ returns 404', async () => {
   }
 });
 
+test('GET with mapName containing colon/space/leading-dot returns 400', async () => {
+  // Mirrors the C# handler's whitelist coverage in
+  // EndToEndServerTests.GET_MapNameWithDisallowedChars_Returns400 so the JS
+  // shim fails closed for the same inputs the production handler does.
+  const { root, mapsDir } = makeTempWorkspace();
+  try {
+    const handler = createSourceMapRouteHandler(mapsDir);
+    const cases = ['a:b', 'a b', '.hidden'];
+    await withServer(handler, async base => {
+      for (const badName of cases) {
+        const resp = await fetchRawPath(
+          base,
+          '/sourcemap/' + encodeURIComponent(badName) + '/Program.cs');
+        assert.equal(
+          resp.status,
+          400,
+          `Tampered mapName '${badName}' must 400, got ${resp.status}`);
+      }
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('factory rejects missing generatedScriptsDir', () => {
   assert.throws(() => createSourceMapRouteHandler(''), /non-empty string/);
   assert.throws(() => createSourceMapRouteHandler(null), /non-empty string/);

--- a/Test/Framework/TestWebApplication/source-map-route.test.mjs
+++ b/Test/Framework/TestWebApplication/source-map-route.test.mjs
@@ -1,0 +1,181 @@
+// Smoke test for source-map-route.mjs — the node dev-ergonomic counterpart of
+// the C# SourceMapFileHandler. Spins up a tiny http server that routes through
+// the extracted helper and drives it with real HTTP requests so the contract
+// (200/404/400 shapes, traversal rejection, body bytes) is exercised end-to-end
+// without Playwright or a browser in the loop.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createSourceMapRouteHandler } from './source-map-route.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function makeTempWorkspace() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'srcmap-route-'));
+  const mapsDir = path.join(root, 'maps');
+  const srcDir = path.join(root, 'src');
+  fs.mkdirSync(mapsDir);
+  fs.mkdirSync(srcDir);
+  return { root, mapsDir, srcDir };
+}
+
+// Write a source-map-V3 shaped file that only uses the fields the handler
+// reads (sources + sourcesLong). Keeps the test self-contained: no dependency
+// on the C# emitter.
+function writeMap(mapsDir, mapName, sources, sourcesLong) {
+  const mapPath = path.join(mapsDir, mapName + '.map');
+  fs.writeFileSync(
+    mapPath,
+    JSON.stringify({
+      version: 3,
+      file: mapName + '.js',
+      sources,
+      sourcesLong,
+      names: [],
+      mappings: '',
+    }),
+    'utf8');
+  return mapPath;
+}
+
+async function withServer(handler, fn) {
+  const server = http.createServer((req, res) => {
+    if (handler(req, res)) {
+      return;
+    }
+
+    res.writeHead(500);
+    res.end('Unhandled');
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+async function fetchText(url) {
+  const resp = await fetch(url);
+  return { status: resp.status, body: await resp.text() };
+}
+
+// Raw http client that preserves the literal request path — fetch/undici
+// normalizes '..' and percent-encoded dots, which would collide with the
+// behavior under test here.
+function fetchRawPath(baseUrl, rawPath) {
+  const { hostname, port } = new URL(baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: hostname,
+      port,
+      method: 'GET',
+      path: rawPath,
+    }, res => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test('GET {sourceRoot}/{shortName} streams the mapped source bytes', async () => {
+  const { root, mapsDir, srcDir } = makeTempWorkspace();
+  try {
+    const programCs = path.join(srcDir, 'Program.cs');
+    fs.writeFileSync(programCs, 'namespace Fixture { class P { } }', 'utf8');
+
+    // sources holds the URL-normalized short name the C# emitter writes;
+    // sourcesLong holds the absolute on-disk path.
+    const shortName = 'C$/fixture/Program.cs';
+    writeMap(mapsDir, 'app', [shortName], [programCs]);
+
+    const handler = createSourceMapRouteHandler(mapsDir);
+    await withServer(handler, async base => {
+      const encoded = shortName.split('/').map(encodeURIComponent).join('/');
+      const resp = await fetchText(`${base}/sourcemap/app/${encoded}`);
+
+      assert.equal(resp.status, 200);
+      assert.equal(resp.body, 'namespace Fixture { class P { } }');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GET with unknown short name returns 404', async () => {
+  const { root, mapsDir, srcDir } = makeTempWorkspace();
+  try {
+    const programCs = path.join(srcDir, 'Program.cs');
+    fs.writeFileSync(programCs, '// fixture\n', 'utf8');
+    writeMap(mapsDir, 'app', ['C$/fixture/Program.cs'], [programCs]);
+
+    const handler = createSourceMapRouteHandler(mapsDir);
+    await withServer(handler, async base => {
+      const resp = await fetchText(`${base}/sourcemap/app/C%24/fixture/Phantom.cs`);
+      assert.equal(resp.status, 404);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GET with unknown map returns 404', async () => {
+  const { root, mapsDir } = makeTempWorkspace();
+  try {
+    const handler = createSourceMapRouteHandler(mapsDir);
+    await withServer(handler, async base => {
+      const resp = await fetchText(`${base}/sourcemap/missing/C%24/fixture/Program.cs`);
+      assert.equal(resp.status, 404);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GET with traversal in mapName returns 400', async () => {
+  const { root, mapsDir } = makeTempWorkspace();
+  try {
+    const handler = createSourceMapRouteHandler(mapsDir);
+    await withServer(handler, async base => {
+      // Raw http request — fetch would URL-normalize '..' before sending, so
+      // the handler's own whitelist would never get a chance to reject it.
+      const resp = await fetchRawPath(base, '/sourcemap/%2E%2E/Program.cs');
+      assert.equal(resp.status, 400);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('GET with empty sub-path under /sourcemap/ returns 404', async () => {
+  const { root, mapsDir } = makeTempWorkspace();
+  try {
+    const handler = createSourceMapRouteHandler(mapsDir);
+    await withServer(handler, async base => {
+      // No second segment — regex does not match and handler responds 404 so
+      // the shape cannot leak into the ambient 500 handler.
+      const resp = await fetchText(`${base}/sourcemap/`);
+      assert.equal(resp.status, 404);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('factory rejects missing generatedScriptsDir', () => {
+  assert.throws(() => createSourceMapRouteHandler(''), /non-empty string/);
+  assert.throws(() => createSourceMapRouteHandler(null), /non-empty string/);
+});


### PR DESCRIPTION
[Gautam's Dev bot]

Fixes #37. Follows up on #36 (the handler itself) with three complementary end-to-end tiers so the public contract is verified against routing, URL decoding, streaming, and the actual browser resolver — not just the handler unit test bed.

## What's covered

1. **`WebApplicationFactory<TestStartup>` suite** (`Test/Compiler/SourceMap.Server.Test/EndToEndServerTests.cs`, 10 new test methods):
   - Byte-exact round-trips for `.cs`, `.xwml`, `.cshtml` fixtures
   - Unknown short name / unknown map → 404
   - `mapName` whitelist rejection → 400 (`a:b`, `a b`, `.hidden`)
   - Dotted-traversal path normalization — accepts any non-200 since ASP.NET Core collapses `..` before routing, and asserts no fixture content ever leaks
   - Sibling-prefix containment regression (`<work>/src` allow-list vs. `<work>/src-evil/Secret.cs` target) at the full HTTP transport layer
   - `sourceRoot` wired into the emitted map + no legacy `.ashx` sidecar
   - Canonical AC #1 DevTools flow: compose `{sourceRoot}/{shortName}` and assert the real pipeline streams back the fixture bytes

2. **`SourceMap.Server.TestHost` console app** (new project) — emits a compiler-shaped fixture via the real `OwaSourceMapper.SourceMap` and boots Kestrel on an ephemeral port so a Playwright browser test can drive the same handler end-to-end. Decoupled from the MSTest project so the Exe doesn't pull in test frameworks.

3. **Node + Playwright tests** under `Test/Framework/TestWebApplication`:
   - `source-map-route.mjs` — extracted from `run-qunit.mjs` so the dev-ergonomic helper is reusable and unit-testable
   - `source-map-route.test.mjs` — 6 `node:test` smoke cases covering the same 200/404/400 shapes
   - `source-map-browser.test.mjs` — Playwright + Chromium test that loads `/fixture.html` (served by the TestHost), fetches `{sourceRoot}/{shortName}` from the page context, and asserts byte-identical fixture bytes come back through the real C# handler. Skips cleanly when the TestHost binary or Playwright isn't available.

## Forward compatibility for WI-19

Per the maintainer ask on the plan, `FixtureMapEmitter.Emit(..., sourceRoot)` accepts any URL — including a future `https://raw.githubusercontent.com/…` — and threads it through unchanged. The handler's `sources[]` resolution is independent of `sourceRoot`, so WI-19 can swap in a repo-link frontend without touching either the emitter or the handler.

## Test results

- `SourceMap.Server.Test`: **44/44 passed** (34 existing + 10 new)
- `SourceMap.Test`: **60/60 passed**
- `source-map-route.test.mjs`: **6/6 passed**
- `source-map-browser.test.mjs`: **1/1 passed**
- Full `dotnet build NScript_Full.sln -c Release`: clean (0 errors, 189 pre-existing warnings)

Part of the parent source-mapping initiative #12.