### PR TITLE
WI-34: WebStoreTable explicit pagination/streaming API

### DIFF
--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -5,6 +5,7 @@ namespace Sunlight.Framework.Data.WebStore
     using System.Runtime.CompilerServices;
     using System.Web.Html;
     using System.Web.Html.Data.IndexedDB;
+    using QueryDef = Sunlight.Framework.Data.WebStore.Query;
 
     internal enum CursorOrCountRequestMode
     {
@@ -173,6 +174,14 @@ namespace Sunlight.Framework.Data.WebStore
         /// <summary>
         /// Runs <paramref name="query"/> and returns all matching records
         /// (filtered by <paramref name="inclFilter"/> when supplied).
+        /// <para>
+        /// The unbounded <see cref="WebStore.Query.All"/> singleton is rejected on
+        /// this materialising path — it would buffer the entire table into a
+        /// <see cref="List{T}"/> with no row ceiling. Use
+        /// <see cref="ForEach(Query, Func{TValue, bool}, WebStoreTransaction)"/>
+        /// to stream the full table, or build a query with an explicit
+        /// <c>QueryBuilder.Limit(n)</c> to bound the result set.
+        /// </para>
         /// </summary>
         public Promise<List<TValue>> Query(
             Query query,
@@ -187,6 +196,30 @@ namespace Sunlight.Framework.Data.WebStore
                     resolve,
                     reject,
                     false));
+        }
+
+        /// <summary>
+        /// Streams every record matching <paramref name="query"/> through
+        /// <paramref name="visit"/> without materialising the result set. The
+        /// visitor returns <c>true</c> to continue, <c>false</c> to stop early.
+        /// Resolves with the number of records visited (including the one the
+        /// visitor returned <c>false</c> for, if any).
+        /// </summary>
+        public Promise<int> ForEach(
+            Query query,
+            Func<TValue, bool> visit,
+            WebStoreTransaction transaction = null)
+        {
+            if (visit == null)
+            { throw new Exception("visit can't be null"); }
+
+            return new Promise<int>((resolve, reject) =>
+                this.ForEachInternal(
+                    transaction,
+                    query,
+                    visit,
+                    resolve,
+                    reject));
         }
 
         /// <summary>Same as <see cref="Query"/> but returns primary keys only (key cursor).</summary>
@@ -475,7 +508,7 @@ namespace Sunlight.Framework.Data.WebStore
             { return; }
 
             var skip = query.Skip ?? 0;
-            var limit = query.Limit ?? 1 << 20;
+            int? remaining = query.Limit;
             bool firstLoop = skip > 0;
 
             request.OnSuccess += (req, evt) =>
@@ -499,10 +532,14 @@ namespace Sunlight.Framework.Data.WebStore
                     if (!onIterate(cursor))
                     { return; }
 
-                    if (--limit == 0)
+                    if (remaining.HasValue)
                     {
-                        _ = onIterate(null);
-                        return;
+                        remaining = remaining.Value - 1;
+                        if (remaining.Value == 0)
+                        {
+                            _ = onIterate(null);
+                            return;
+                        }
                     }
                 }
 
@@ -697,6 +734,43 @@ namespace Sunlight.Framework.Data.WebStore
                 reject);
         }
 
+        private void ForEachInternal(
+            WebStoreTransaction transaction,
+            Query query,
+            Func<TValue, bool> visit,
+            Action<int> resolve,
+            Action<object> reject)
+        {
+            transaction = this.TransactionOrDefault(
+                transaction,
+                TransactionKind.Read);
+
+            int count = 0;
+            this.CursorIterator(
+                transaction,
+                query,
+                null,
+                (cursor) =>
+                {
+                    if (cursor == null)
+                    {
+                        resolve(count);
+                        return true;
+                    }
+
+                    count = count + 1;
+                    if (!visit(cursor.Value))
+                    {
+                        resolve(count);
+                        return false;
+                    }
+
+                    return true;
+                },
+                reject,
+                false);
+        }
+
         private void QueryInternal<U>(
             WebStoreTransaction transaction,
             Query query,
@@ -705,6 +779,15 @@ namespace Sunlight.Framework.Data.WebStore
             Action<object> reject,
             bool isKeyQuery)
         {
+            if (Object.ReferenceEquals(query, QueryDef.All) && filter == null)
+            {
+                reject(new Exception(
+                    "Query(Query.All) is disallowed because it can materialise an "
+                    + "unbounded result set into memory. Use ForEach for streaming, "
+                    + "or set an explicit cap via QueryBuilder.Limit(n)."));
+                return;
+            }
+
             transaction = this.TransactionOrDefault(
                 transaction,
                 TransactionKind.Read);

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -789,7 +789,7 @@ namespace Sunlight.Framework.Data.WebStore
             Action<object> reject,
             bool isKeyQuery)
         {
-            if (Object.ReferenceEquals(query, QueryDef.All) && filter == null)
+            if (Object.ReferenceEquals(query, QueryDef.All) && filter == null && !isKeyQuery)
             {
                 reject(new Exception(
                     "Query(Query.All) is disallowed because it can materialise an "

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -210,16 +210,20 @@ namespace Sunlight.Framework.Data.WebStore
             Func<TValue, bool> visit,
             WebStoreTransaction transaction = null)
         {
-            if (visit == null)
-            { throw new Exception("visit can't be null"); }
-
             return new Promise<int>((resolve, reject) =>
+            {
+                if (visit == null)
+                {
+                    reject(new Exception("visit can't be null"));
+                    return;
+                }
                 this.ForEachInternal(
                     transaction,
                     query,
                     visit,
                     resolve,
-                    reject));
+                    reject);
+            });
         }
 
         /// <summary>Same as <see cref="Query"/> but returns primary keys only (key cursor).</summary>
@@ -529,6 +533,12 @@ namespace Sunlight.Framework.Data.WebStore
 
                 if (filter == null || filter(cursor.Value))
                 {
+                    if (remaining.HasValue && remaining.Value <= 0)
+                    {
+                        _ = onIterate(null);
+                        return;
+                    }
+
                     if (!onIterate(cursor))
                     { return; }
 

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -479,6 +479,135 @@ namespace Sunlight.Framework.Data.Test
         }
 
         /// <summary>
+        /// <c>ForEach</c> combined with <c>QueryBuilder.Limit(2)</c> on a
+        /// 5-record store must stop after 2 records — invoking the visitor
+        /// exactly twice. Pins the interaction between the streaming ForEach
+        /// path and the explicit Limit cap, which were introduced together but
+        /// previously only tested independently.
+        /// </summary>
+        [Test]
+        public static void TestForEachRespectsExplicitLimit(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                var seed = new CrudEntity[5];
+                for (int i = 0; i < 5; i = i + 1)
+                {
+                    seed[i] = NewEntity("f" + i, "todo", i);
+                }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    var query = new QueryBuilder(new string[0])
+                        .Limit(2)
+                        .Build();
+                    int visits = 0;
+
+                    table.ForEach(query, delegate(CrudEntity row)
+                    {
+                        visits = visits + 1;
+                        return true;
+                    }).Then<bool>(delegate(int count)
+                    {
+                        assert.Equal(count, 2, "ForEach + Limit(2) reports visit count of 2");
+                        assert.Equal(visits, 2, "visitor invoked exactly twice under Limit(2)");
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>Query(Query.All, filter)</c> with a non-null filter must resolve
+        /// (not reject) and return only filter-matching rows. Pins the positive
+        /// side of the <c>filter == null</c> escape hatch in the Query.All
+        /// guard — without this a refactor that dropped the filter check would
+        /// silently break filtered scans.
+        /// </summary>
+        [Test]
+        public static void TestQueryAllWithFilterResolvesFiltered(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "done", 2)).Then<bool>(delegate(string k2)
+                    {
+                        table.UpSert(NewEntity("c", "todo", 3)).Then<bool>(delegate(string k3)
+                        {
+                            table.Query(Query.All, delegate(CrudEntity row)
+                            {
+                                return row.Category == "todo";
+                            }).Then<bool>(delegate(List<CrudEntity> results)
+                            {
+                                assert.Equal(results.Count, 2, "Query(All, filter) returns only filtered rows");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>QueryKeys(Query.All)</c> must resolve with every primary key —
+        /// the Query.All materialisation guard exists only for the value-read
+        /// path (which can blow up memory with large rows). A key-only scan
+        /// carries no such risk, so it bypasses the guard via the
+        /// <c>isKeyQuery</c> flag.
+        /// </summary>
+        [Test]
+        public static void TestQueryKeysAllResolves(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "done", 2)).Then<bool>(delegate(string k2)
+                    {
+                        table.QueryKeys(Query.All).Then<bool>(delegate(List<string> keys)
+                        {
+                            assert.Equal(keys.Count, 2, "QueryKeys(All) returns every key (no cap)");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
         /// Defect #3 regression — with the missing [JsonType] on IDBIndexParameters,
         /// the <c>Unique</c> field name would not reach the native IDB call so
         /// uniqueness was never enforced. Declaring a UNIQUE single-column

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -219,6 +219,13 @@ namespace Sunlight.Framework.Data.Test
                         delegate(object err)
                         {
                             assert.IsTrue(err != null, "Query(Query.All) rejects with a descriptive error");
+                            var message = ((Exception)err).Message;
+                            assert.IsTrue(
+                                message != null && message.IndexOf("Query.All") >= 0,
+                                "rejection message names Query.All so callers can diagnose");
+                            assert.IsTrue(
+                                message.IndexOf("Limit") >= 0 || message.IndexOf("ForEach") >= 0,
+                                "rejection message points callers at Limit or ForEach as the fix");
                             client.Close();
                             done();
                             return true;
@@ -309,6 +316,81 @@ namespace Sunlight.Framework.Data.Test
                         done();
                         return true;
                     });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// With 5 seeded records and <c>QueryBuilder.Limit(2)</c>, the scan must
+        /// stop after 2 records. This is the true regression test for the removal
+        /// of the silent <c>1 &lt;&lt; 20</c> default — the previous
+        /// <c>TestLimitedQueryRespectsExplicitLimit</c> passed both before and
+        /// after the fix because <c>Limit == recordCount</c> is a coincidence.
+        /// </summary>
+        [Test]
+        public static void TestLimitSmallerThanRecordCountTruncates(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                var seed = new CrudEntity[5];
+                for (int i = 0; i < 5; i = i + 1)
+                {
+                    seed[i] = NewEntity("s" + i, "todo", i);
+                }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    var query = new QueryBuilder(new string[0])
+                        .Limit(2)
+                        .Build();
+
+                    table.Query(query).Then<bool>(delegate(List<CrudEntity> results)
+                    {
+                        assert.Equal(results.Count, 2, "Limit(2) truncates a 5-record scan to 2");
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>ForEach(Query.All, ...)</c> on an empty store must resolve with a
+        /// visit count of <c>0</c> and never invoke the visitor. Pins the
+        /// null-cursor short-circuit in <c>ForEachInternal</c>.
+        /// </summary>
+        [Test]
+        public static void TestForEachEmptyTableVisitsNothing(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                int visits = 0;
+
+                table.ForEach(Query.All, delegate(CrudEntity row)
+                {
+                    visits = visits + 1;
+                    return true;
+                }).Then<bool>(delegate(int count)
+                {
+                    assert.Equal(count, 0, "empty table resolves with count 0");
+                    assert.Equal(visits, 0, "visitor was never invoked on empty table");
+                    client.Close();
+                    done();
                     return true;
                 });
                 return true;

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -1,6 +1,7 @@
 namespace Sunlight.Framework.Data.Test
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using Sunlight.Framework.Data.WebStore;
     using SunlightUnit;
@@ -144,12 +145,13 @@ namespace Sunlight.Framework.Data.Test
         }
 
         /// <summary>
-        /// Query(Query.All) after three sequential UpSerts must return every
-        /// inserted record. Exercises the cursor scan path and validates that
+        /// <c>ForEach(Query.All, ...)</c> after three sequential UpSerts must
+        /// visit every inserted record. This is the streaming replacement for
+        /// the old <c>Query(Query.All)</c> full-table scan and validates that
         /// the secondary index declaration does not corrupt the primary scan.
         /// </summary>
         [Test]
-        public static void TestQueryAllReturnsEveryRecord(Assert assert)
+        public static void TestForEachAllVisitsEveryRecord(Assert assert)
         {
             var done = assert.Async(1);
             var factory = new WebStoreFactory();
@@ -165,15 +167,146 @@ namespace Sunlight.Framework.Data.Test
                     {
                         table.UpSert(NewEntity("c", "todo", 3)).Then<bool>(delegate(string k3)
                         {
-                            table.Query(Query.All).Then<bool>(delegate(System.Collections.Generic.List<CrudEntity> results)
+                            var visited = new List<string>();
+                            table.ForEach(Query.All, delegate(CrudEntity row)
                             {
-                                assert.Equal(results.Count, 3, "Query(All) returns every record");
+                                visited.Add(row.Id);
+                                return true;
+                            }).Then<bool>(delegate(int count)
+                            {
+                                assert.Equal(count, 3, "ForEach(All) visit count matches inserted count");
+                                assert.Equal(visited.Count, 3, "visitor received every record");
                                 client.Close();
                                 done();
                                 return true;
                             });
                             return true;
                         });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>Query(Query.All)</c> on the materialising read path must be
+        /// rejected with a descriptive error so callers have to opt into either
+        /// streaming via <c>ForEach</c> or an explicit <c>QueryBuilder.Limit</c>.
+        /// </summary>
+        [Test]
+        public static void TestQueryAllMaterialisingThrows(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.Query(Query.All).Then<bool, object>(
+                        delegate(List<CrudEntity> results)
+                        {
+                            assert.IsTrue(false, "Query(Query.All) should reject, not resolve");
+                            client.Close();
+                            done();
+                            return true;
+                        },
+                        delegate(object err)
+                        {
+                            assert.IsTrue(err != null, "Query(Query.All) rejects with a descriptive error");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// A <c>ForEach</c> visitor that returns <c>false</c> after the second
+        /// record must stop iteration immediately — the cursor is abandoned and
+        /// the visit count reflects only the records actually seen.
+        /// </summary>
+        [Test]
+        public static void TestForEachStopsEarly(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "done", 2)).Then<bool>(delegate(string k2)
+                    {
+                        table.UpSert(NewEntity("c", "todo", 3)).Then<bool>(delegate(string k3)
+                        {
+                            int seen = 0;
+                            table.ForEach(Query.All, delegate(CrudEntity row)
+                            {
+                                seen = seen + 1;
+                                return seen < 2;
+                            }).Then<bool>(delegate(int count)
+                            {
+                                assert.Equal(count, 2, "visit count equals records seen before stop");
+                                assert.Equal(seen, 2, "visitor invoked exactly twice");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// With an explicit <c>QueryBuilder.Limit(15)</c> and 15 inserted
+        /// records, the scan must return all 15. Proves the limit path still
+        /// drains the cursor correctly after the silent <c>1 &lt;&lt; 20</c>
+        /// default was removed.
+        /// </summary>
+        [Test]
+        public static void TestLimitedQueryRespectsExplicitLimit(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                var seed = new CrudEntity[15];
+                for (int i = 0; i < 15; i = i + 1)
+                {
+                    seed[i] = NewEntity("r" + i, "todo", i);
+                }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    var query = new QueryBuilder(new string[0])
+                        .Limit(15)
+                        .Build();
+
+                    table.Query(query).Then<bool>(delegate(List<CrudEntity> results)
+                    {
+                        assert.Equal(results.Count, 15, "Limit(15) returns all 15 records");
+                        client.Close();
+                        done();
                         return true;
                     });
                     return true;

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -365,6 +365,87 @@ namespace Sunlight.Framework.Data.Test
         }
 
         /// <summary>
+        /// <c>Query</c> with <c>Limit(0)</c> on a non-empty store must return an
+        /// empty list without visiting any record. Pins the pre-visit cap check
+        /// specifically — distinct from <c>Limit(N)</c> decrement which is
+        /// exercised by <c>TestLimitSmallerThanRecordCountTruncates</c>.
+        /// </summary>
+        [Test]
+        public static void TestLimitZeroVisitsNothing(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
+                    {
+                        var query = new QueryBuilder(new string[0])
+                            .Limit(0)
+                            .Build();
+
+                        table.Query(query).Then<bool>(delegate(List<CrudEntity> results)
+                        {
+                            assert.Equal(results.Count, 0, "Limit(0) returns no records");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>ForEach</c> with a null visitor must reject through the Promise —
+        /// not throw synchronously. This pins the symmetric error surface
+        /// established alongside <c>Query(Query.All)</c>: both argument-
+        /// validation failures route through <c>reject</c> so callers using
+        /// <c>.Then(_, onRejected)</c> see a uniform API.
+        /// </summary>
+        [Test]
+        public static void TestForEachNullVisitRejects(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.ForEach(Query.All, null).Then<bool, object>(
+                    delegate(int count)
+                    {
+                        assert.IsTrue(false, "ForEach(_, null) should reject, not resolve");
+                        client.Close();
+                        done();
+                        return true;
+                    },
+                    delegate(object err)
+                    {
+                        assert.IsTrue(err != null, "ForEach(_, null) rejects with an error");
+                        var message = ((Exception)err).Message;
+                        assert.IsTrue(
+                            message != null && message.IndexOf("visit") >= 0,
+                            "rejection message names the bad argument");
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                return true;
+            });
+        }
+
+        /// <summary>
         /// <c>ForEach(Query.All, ...)</c> on an empty store must resolve with a
         /// visit count of <c>0</c> and never invoke the visitor. Pins the
         /// null-cursor short-circuit in <c>ForEachInternal</c>.

--- a/Test/Framework/TestWebApplication/run-qunit.mjs
+++ b/Test/Framework/TestWebApplication/run-qunit.mjs
@@ -18,6 +18,10 @@ const QUNIT_SUITES = [
     name: 'TodoApp.Test',
     scripts: ['/GeneratedScripts/TodoApp.Test.js'],
   },
+  {
+    name: 'Sunlight.Framework.Data.Test',
+    scripts: ['/GeneratedScripts/Sunlight.Framework.Data.Test.js'],
+  },
 ];
 
 const MIME_TYPES = {

--- a/Test/Framework/TodoApp/Services/TodoDataService.cs
+++ b/Test/Framework/TodoApp/Services/TodoDataService.cs
@@ -5,6 +5,17 @@ namespace TodoApp.Services
     using Sunlight.Framework.Data.WebStore;
 
     /// <summary>
+    /// Conservative per-table row caps for the todo app's expected dataset. All
+    /// <see cref="TodoDataService"/> read paths that would otherwise buffer
+    /// every row pass <see cref="MaxRecords"/> through <c>QueryBuilder.Limit</c>
+    /// so the materialised list size is visible at the call site.
+    /// </summary>
+    internal static class TodoLimits
+    {
+        public const int MaxRecords = 10000;
+    }
+
+    /// <summary>
     /// Typed data access service over <see cref="WebStoreClient"/>. Replaces the
     /// previous manual-JSON IndexedDbService with a strongly-typed layer so
     /// callers never touch raw JSON or JS interop.
@@ -45,11 +56,14 @@ namespace TodoApp.Services
         }
 
         /// <summary>
-        /// Loads every todo record. Caller is expected to translate to view models.
+        /// Loads every todo record up to <see cref="TodoLimits.MaxRecords"/>.
+        /// The explicit cap is expressed via <c>QueryBuilder.Limit</c> so the
+        /// result-size bound is visible at the call site rather than hidden
+        /// inside the cursor iterator.
         /// </summary>
         public Promise<List<TodoEntity>> GetAllTodos()
         {
-            return this.TodosTable().Query(Query.All);
+            return this.TodosTable().Query(AllWithLimit());
         }
 
         /// <summary>Deletes a single todo by id. Resolves true on success.</summary>
@@ -67,16 +81,26 @@ namespace TodoApp.Services
             return this.FoldersTable().UpSert(folder);
         }
 
-        /// <summary>Loads every user-created folder record.</summary>
+        /// <summary>
+        /// Loads every user-created folder record up to
+        /// <see cref="TodoLimits.MaxRecords"/>.
+        /// </summary>
         public Promise<List<FolderEntity>> GetAllFolders()
         {
-            return this.FoldersTable().Query(Query.All);
+            return this.FoldersTable().Query(AllWithLimit());
         }
 
         /// <summary>Deletes a single folder by id. Resolves true on success.</summary>
         public Promise<bool> DeleteFolder(string id)
         {
             return this.FoldersTable().Delete(id);
+        }
+
+        private static Query AllWithLimit()
+        {
+            return new QueryBuilder(new string[0])
+                .Limit(TodoLimits.MaxRecords)
+                .Build();
         }
 
         private WebStoreTable<string, TodoEntity> TodosTable()


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Replaces `WebStoreTable`'s silent `1 << 20` row cap with an explicit pagination/streaming API. Callers must now opt into either streaming via `ForEach` or a bounded materialising `Query` with `QueryBuilder.Limit(n)`.

Fixes #34.

## Motivation

The old read paths silently truncated at ~1M rows — a table that grew past the cap would quietly return partial results with no error. There was also no streaming alternative, so callers had to materialise every match into a `List<T>`.

## Key Decisions

- **Rejected unbounded materialisation**: `Query(Query.All)` without a filter now rejects with a descriptive error instead of resolving. The message names `Query.All` and points callers at `ForEach` or `QueryBuilder.Limit(n)`. Callers with a filter predicate are still allowed to use `Query.All` because the predicate bounds the materialised set.
- **Added `ForEach` streaming API**: `Promise<int> ForEach(Query, Func<TValue,bool>, WebStoreTransaction)`. Visitor returns `false` to stop early; resolve value is the number of records visited.
- **Strict `Limit` semantics**: `CursorIterator` honours `query.Limit` exactly — `null` = unbounded, `0` = no visits, `N` = exactly N. The cap check is placed before the visit so `Limit(0)` is a true no-op (previously would have visited one row due to the decrement-then-check order).
- **Symmetric Promise-based error surface**: Both `ForEach(null)` and `Query(Query.All)` report argument errors through the Promise rejection path so callers using `.Then(_, onRejected)` get a uniform API.
- **Call-site visible cap in TodoApp**: `TodoDataService.GetAllTodos`/`GetAllFolders` now pass `QueryBuilder.Limit(TodoLimits.MaxRecords)` where `TodoLimits.MaxRecords = 10000`. The bound is visible at the call site rather than buried inside the cursor iterator.

## Test Plan

- [x] Debug build (`dotnet build NScript_Full.sln -c Debug`) green
- [x] All QUnit suites green: 71 Framework + 93 UI + 26 TodoApp + 19 Data = **209/209 passed**
- [x] New Data.Test cases:
  - `TestForEachAllVisitsEveryRecord` — streaming hits every record
  - `TestQueryAllMaterialisingThrows` — rejects with descriptive message
  - `TestForEachStopsEarly` — visitor `false` stops iteration
  - `TestLimitedQueryRespectsExplicitLimit` — `Limit == recordCount`
  - `TestLimitSmallerThanRecordCountTruncates` — `Limit(2)` on 5 rows
  - `TestLimitZeroVisitsNothing` — direct `Limit(0)` no-op test
  - `TestForEachEmptyTableVisitsNothing` — empty-store short-circuit
  - `TestForEachNullVisitRejects` — argument validation via rejection
- [x] Sunlight.Framework.Data.Test wired into `run-qunit.mjs` so the suite runs by default in CI
- [x] Two self-review iterations via `code-reviewer:pr-review` (NScript compliance + test coverage), all flagged findings addressed