### PR TITLE
WI-41: wrap WebStore cursor visitor callbacks in try/catch → reject

### DIFF
--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -531,7 +531,8 @@ namespace Sunlight.Framework.Data.WebStore
 
                 if (firstLoop)
                 {
-                    cursor.Advance(skip);
+                    try { cursor.Advance(skip); }
+                    catch (Exception ex) { aborted = true; reject(ex); return; }
                     firstLoop = false;
                     return;
                 }
@@ -567,14 +568,17 @@ namespace Sunlight.Framework.Data.WebStore
                     }
                 }
 
-                cursor.Continue();
+                try { cursor.Continue(); }
+                catch (Exception ex) { aborted = true; reject(ex); }
             };
 
             var onError = HandleError(reject);
             request.OnError += (req, evt) =>
             {
+                evt.PreventDefault();
                 if (aborted)
                 { return; }
+                aborted = true;
                 onError(req, evt);
             };
         }

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -572,14 +572,15 @@ namespace Sunlight.Framework.Data.WebStore
                 catch (Exception ex) { aborted = true; reject(ex); }
             };
 
-            var onError = HandleError(reject);
             request.OnError += (req, evt) =>
             {
                 evt.PreventDefault();
                 if (aborted)
                 { return; }
                 aborted = true;
-                onError(req, evt);
+                reject(new EventBasedException(
+                    req.Error.ExceptionMessage(),
+                    evt));
             };
         }
 

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -514,13 +514,18 @@ namespace Sunlight.Framework.Data.WebStore
             var skip = query.Skip ?? 0;
             int? remaining = query.Limit;
             bool firstLoop = skip > 0;
+            bool aborted = false;
 
             request.OnSuccess += (req, evt) =>
             {
+                if (aborted)
+                { return; }
+
                 var cursor = Type.AS<object, IDBCursor<TKey, TValue>>(req.Result);
                 if (cursor == null)
                 {
-                    _ = onIterate(null);
+                    try { _ = onIterate(null); }
+                    catch (Exception ex) { aborted = true; reject(ex); }
                     return;
                 }
 
@@ -531,15 +536,23 @@ namespace Sunlight.Framework.Data.WebStore
                     return;
                 }
 
-                if (filter == null || filter(cursor.Value))
+                bool accept;
+                try { accept = filter == null || filter(cursor.Value); }
+                catch (Exception ex) { aborted = true; reject(ex); return; }
+
+                if (accept)
                 {
                     if (remaining.HasValue && remaining.Value <= 0)
                     {
-                        _ = onIterate(null);
+                        try { _ = onIterate(null); }
+                        catch (Exception ex) { aborted = true; reject(ex); }
                         return;
                     }
 
-                    if (!onIterate(cursor))
+                    bool cont;
+                    try { cont = onIterate(cursor); }
+                    catch (Exception ex) { aborted = true; reject(ex); return; }
+                    if (!cont)
                     { return; }
 
                     if (remaining.HasValue)
@@ -547,7 +560,8 @@ namespace Sunlight.Framework.Data.WebStore
                         remaining = remaining.Value - 1;
                         if (remaining.Value == 0)
                         {
-                            _ = onIterate(null);
+                            try { _ = onIterate(null); }
+                            catch (Exception ex) { aborted = true; reject(ex); }
                             return;
                         }
                     }
@@ -556,7 +570,13 @@ namespace Sunlight.Framework.Data.WebStore
                 cursor.Continue();
             };
 
-            request.OnError += HandleError(reject);
+            var onError = HandleError(reject);
+            request.OnError += (req, evt) =>
+            {
+                if (aborted)
+                { return; }
+                onError(req, evt);
+            };
         }
 
         private IDBRequest GetCursor(

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -679,8 +679,10 @@ namespace Sunlight.Framework.Data.Test
                 {
                     table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
                     {
+                        int visitCount = 0;
                         table.ForEach(Query.All, delegate(CrudEntity row)
                         {
+                            visitCount++;
                             throw new Exception("boom-visit");
                         }).Then<bool, object>(
                             delegate(int count)
@@ -692,6 +694,7 @@ namespace Sunlight.Framework.Data.Test
                             },
                             delegate(object err)
                             {
+                                assert.Equal(visitCount, 1, "visitor called exactly once before abort");
                                 assert.IsTrue(err != null, "rejection has an error");
                                 var message = ((Exception)err).Message;
                                 assert.IsTrue(

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -657,6 +657,246 @@ namespace Sunlight.Framework.Data.Test
             });
         }
 
+        /// <summary>
+        /// A <c>ForEach</c> visitor that throws must reject the returned
+        /// Promise with the original exception — not hang the caller. Before
+        /// WI-41, the throw escaped the IDB <c>OnSuccess</c> handler and the
+        /// promise was never settled. The centralised try/catch in
+        /// <c>CursorIterator</c> routes the thrown exception to <c>reject</c>.
+        /// </summary>
+        [Test]
+        public static void TestForEachVisitThrowsRejects(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
+                    {
+                        table.ForEach(Query.All, delegate(CrudEntity row)
+                        {
+                            throw new Exception("boom-visit");
+                        }).Then<bool, object>(
+                            delegate(int count)
+                            {
+                                assert.IsTrue(false, "throwing visitor should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                assert.IsTrue(err != null, "rejection has an error");
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("boom-visit") >= 0,
+                                    "original thrown exception propagates to reject");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// A <c>Query</c> filter that throws must reject the returned Promise
+        /// with the original exception. Exercises the <c>filter(cursor.Value)</c>
+        /// call edge in <c>CursorIterator</c>, distinct from the <c>onIterate</c>
+        /// edge covered by <c>TestForEachVisitThrowsRejects</c>.
+        /// </summary>
+        [Test]
+        public static void TestQueryFilterThrowsRejects(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
+                    {
+                        table.Query(Query.All, delegate(CrudEntity row)
+                        {
+                            throw new Exception("boom-filter");
+                        }).Then<bool, object>(
+                            delegate(List<CrudEntity> results)
+                            {
+                                assert.IsTrue(false, "throwing filter should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                assert.IsTrue(err != null, "rejection has an error");
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("boom-filter") >= 0,
+                                    "original thrown exception propagates to reject");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// A <c>Delete(query, filter)</c> whose filter throws must reject and
+        /// must not remove any record — the cursor aborts before the batched
+        /// key list reaches the delete call. Confirms the aborted flag
+        /// prevents subsequent cursor events from scheduling a partial delete.
+        /// </summary>
+        [Test]
+        public static void TestDeleteFilterThrowsRejects(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
+                    {
+                        var query = new QueryBuilder(new string[0])
+                            .Limit(10)
+                            .Build();
+
+                        table.Delete(query, delegate(CrudEntity row)
+                        {
+                            throw new Exception("boom-delete-filter");
+                        }).Then<bool, object>(
+                            delegate(int count)
+                            {
+                                assert.IsTrue(false, "throwing delete filter should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                assert.IsTrue(err != null, "rejection has an error");
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("boom-delete-filter") >= 0,
+                                    "original thrown exception propagates to reject");
+
+                                // Both records must survive — the cursor aborted before any batched delete ran.
+                                table.TryGet("a").Then<bool>(delegate(CrudEntity rowA)
+                                {
+                                    assert.IsTrue(rowA != null, "record 'a' survives an aborted delete scan");
+
+                                    table.TryGet("b").Then<bool>(delegate(CrudEntity rowB)
+                                    {
+                                        assert.IsTrue(rowB != null, "record 'b' survives an aborted delete scan");
+                                        client.Close();
+                                        done();
+                                        return true;
+                                    });
+                                    return true;
+                                });
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// An <c>Update(query, updateFunc)</c> whose <c>updateFunc</c> throws
+        /// must reject and must not mutate any record. Exercises the
+        /// <c>updateFunc(cursor.Value)</c> call edge inside the
+        /// <c>QueryUpdateOrDeleteInternal</c> <c>onIterate</c> lambda, reaching
+        /// the <c>CursorIterator</c> guard transitively.
+        /// </summary>
+        [Test]
+        public static void TestUpdateFuncThrowsRejects(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+
+                table.UpSert(NewEntity("a", "todo", 1)).Then<bool>(delegate(string k1)
+                {
+                    table.UpSert(NewEntity("b", "todo", 2)).Then<bool>(delegate(string k2)
+                    {
+                        var query = new QueryBuilder(new string[0])
+                            .Limit(10)
+                            .Build();
+
+                        table.Update(query, delegate(CrudEntity row)
+                        {
+                            throw new Exception("boom-update");
+                        }).Then<bool, object>(
+                            delegate(int count)
+                            {
+                                assert.IsTrue(false, "throwing updateFunc should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                assert.IsTrue(err != null, "rejection has an error");
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("boom-update") >= 0,
+                                    "original thrown exception propagates to reject");
+
+                                // Records unchanged — the cursor aborted before the batched update ran.
+                                table.Get("a").Then<bool>(delegate(CrudEntity rowA)
+                                {
+                                    assert.Equal(rowA.Score, 1, "record 'a' score unchanged after aborted update");
+
+                                    table.Get("b").Then<bool>(delegate(CrudEntity rowB)
+                                    {
+                                        assert.Equal(rowB.Score, 2, "record 'b' score unchanged after aborted update");
+                                        client.Close();
+                                        done();
+                                        return true;
+                                    });
+                                    return true;
+                                });
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
         private static CrudEntity NewEntity(string id, string category, int score)
         {
             var e = new CrudEntity();


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Closes #41.

`WebStoreTable.CursorIterator` invokes three user-provided callback seams (`filter`, `visit`, `updateFunc`) inside an IDB `OnSuccess` handler. If any callback threw, the exception escaped the event handler and the wrapping `Promise` never settled — callers hung forever.

This PR centralises a try/catch barrier inside `CursorIterator` that covers every user-callback seam. On throw, the barrier rejects the returned `Promise` with the **original** exception and marks the iterator `aborted` so subsequent `OnSuccess`/`OnError` events are discarded.

## Why one barrier instead of three per-caller try/catches

All three seams funnel through `CursorIterator.OnSuccess`:
- `filter(cursor.Value)` — direct call inside `CursorIterator`.
- `visit(cursor.Value)` — inside `ForEachInternal`'s `onIterate` lambda, reached via `onIterate(cursor)`.
- `updateFunc(cursor.Value)` — inside `QueryUpdateOrDeleteInternal`'s `onIterate` lambda, reached via `onIterate(cursor)`.

Wrapping each `onIterate(cursor)` call edge transitively catches `visit()` and `updateFunc()` because they execute synchronously inside the delegate. One barrier; any new `*Internal` consumer is covered automatically.

## On-throw behaviour

- Call `reject(ex)` with the thrown exception (preserved, not wrapped).
- Do **not** continue the cursor → IDB auto-closes once `OnSuccess` returns without `Continue()`.
- Do **not** `transaction.Abort()` — matches the existing cursor `OnError` path, which also does not abort. For `Delete`/`Update`, writes are batched via `BatchUpdateOrDeleteWithKeys` only after the cursor terminates, so a mid-cursor abort never reaches the write path.
- An `aborted` flag guards the catch path and the `OnError` handler so a catch-then-error race settles the promise exactly once (mirrors `AddBatchInternal.requestAborted`).

## Tests

Four new regression tests in `WebStoreCrudTests.cs`, one per user-callback seam:

| Test | Exercises |
|------|-----------|
| `TestForEachVisitThrowsRejects` | `ForEach` visitor throw → reject with original exception |
| `TestQueryFilterThrowsRejects` | `Query(query, filter)` filter throw → reject |
| `TestDeleteFilterThrowsRejects` | `Delete(query, filter)` filter throw → reject; both records survive |
| `TestUpdateFuncThrowsRejects` | `Update(query, updateFunc)` updateFunc throw → reject; both record scores unchanged |

Each test asserts the rejection propagates the **original** exception message (`boom-visit`, `boom-filter`, `boom-delete-filter`, `boom-update`) so the fix hasn't silently wrapped caller errors.

## Test plan
- [x] `dotnet build NScript_Full.sln -c Debug` green (0 errors, 188 pre-existing warnings).
- [x] Browser QUnit suite via Playwright: 26/26 Data tests pass (22 existing + 4 new).
- [x] Pre-existing regression tests unchanged (`TestForEachAllVisitsEveryRecord`, `TestForEachStopsEarly`, `TestForEachRespectsExplicitLimit`, `TestQueryAllWithFilterResolvesFiltered`, `TestQueryKeysAllResolves`, `TestLimit*`).

## Risk

Low. Pure additive safety net. Happy-path fallthrough is byte-identical to today's code — the `try` blocks only trigger on exception. The `aborted` flag gates a pre-existing `reject`-only error path that already tolerated double-settle.