### PR TITLE
[Gautam's Dev bot] WI-19: Repo-linked source maps (GitHub/ADO)

### DIFF
--- a/Sources/Compiler/NScript.Converter/Builder.cs
+++ b/Sources/Compiler/NScript.Converter/Builder.cs
@@ -62,6 +62,13 @@ namespace NScript.Converter
         private readonly string sourceMapRoot;
 
         /// <summary>
+        /// Optional absolute path to the Git repo root. When set together with
+        /// <see cref="sourceMapRoot"/>, <c>sources[]</c> entries are rebased to repo-relative,
+        /// forward-slash paths so they combine correctly with a remote-repo sourceRoot URL.
+        /// </summary>
+        private readonly string repoRoot;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="jsScript">               The js script. </param>
@@ -73,6 +80,10 @@ namespace NScript.Converter
         /// <param name="sourceMapRoot">          Optional <c>sourceRoot</c> URL to embed in the
         ///     generated source map. When null or empty, the compiler emits the legacy
         ///     <c>SrcMapper.ashx</c> handler path and drops the handler sidecar alongside the map. </param>
+        /// <param name="repoRoot">                Optional absolute path to the Git repo root.
+        ///     When supplied alongside <paramref name="sourceMapRoot"/>, <c>sources[i]</c> entries
+        ///     are emitted as forward-slash, repo-relative paths so they combine with a remote
+        ///     repo URL. Files outside the repo root keep the legacy absolutized form. </param>
         public Builder(
             string jsScript,
             int jsParts,
@@ -80,7 +91,8 @@ namespace NScript.Converter
             string[] references,
             IConverterPlugin[] plugins,
             (bool minify, bool uglify, bool optimize) scriptGenerateSettings,
-            string sourceMapRoot = null)
+            string sourceMapRoot = null,
+            string repoRoot = null)
         {
             this.mainAssembly = mainAssembly;
             this.jsScript = jsScript;
@@ -94,6 +106,7 @@ namespace NScript.Converter
             this.jsParts = jsParts;
             this.scriptGenerateSettings = scriptGenerateSettings;
             this.sourceMapRoot = sourceMapRoot;
+            this.repoRoot = repoRoot;
         }
 
         /// <summary>
@@ -275,7 +288,7 @@ namespace NScript.Converter
                         Path.GetFileName(this.jsScript))
                     : this.sourceMapRoot;
 
-                writer.Write(this.jsScript, effectiveSourceRoot, emitLegacyAshxHandler: isLegacySourceRoot);
+                writer.Write(this.jsScript, effectiveSourceRoot, emitLegacyAshxHandler: isLegacySourceRoot, repoRoot: this.repoRoot);
                 log.Information("JSWriter.End {JsScript}", this.jsScript);
             }
             catch(ConverterLocationException ex)

--- a/Sources/Compiler/NScript.JST/JSWriter.cs
+++ b/Sources/Compiler/NScript.JST/JSWriter.cs
@@ -349,7 +349,7 @@ namespace NScript.JST
         /// <param name="emitLegacyAshxHandler"> When true, the emitted <c>.map</c> file also gets
         ///     the legacy <c>SrcMapper.ashx</c> sidecar dropped alongside it. Callers that configure
         ///     a non-legacy source root (ASP.NET Core endpoint, repo URL, etc.) should pass false. </param>
-        public void Write(string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true)
+        public void Write(string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null)
         {
             using var streamWriter = new StreamWriter(jsFileName, false, System.Text.Encoding.UTF8);
             this.Write(
@@ -358,7 +358,8 @@ namespace NScript.JST
                 Path.GetDirectoryName(jsFileName),
                 true,
                 sourceRoot,
-                emitLegacyAshxHandler);
+                emitLegacyAshxHandler,
+                repoRoot);
         }
 
         /// <summary>
@@ -367,7 +368,7 @@ namespace NScript.JST
         /// <param name="writer"> The TextWriter to write. </param>
         public void Write(TextWriter writer)
         {
-            this.Write(writer, null, null, false, null, emitLegacyAshxHandler: true);
+            this.Write(writer, null, null, false, null, emitLegacyAshxHandler: true, repoRoot: null);
         }
 
         /// <summary>
@@ -380,7 +381,7 @@ namespace NScript.JST
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. Never null. </returns>
         public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName)
         {
-            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: null, emitLegacyAshxHandler: true);
+            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: null, emitLegacyAshxHandler: true, repoRoot: null);
         }
 
         /// <summary>
@@ -393,9 +394,9 @@ namespace NScript.JST
         /// <param name="sourceRoot"> Source-root override; pass null to use the legacy fallback. </param>
         /// <param name="emitLegacyAshxHandler"> Whether the sidecar <c>.ashx</c> should still drop. </param>
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. </returns>
-        public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true)
+        public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null)
         {
-            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: sourceRoot, emitLegacyAshxHandler: emitLegacyAshxHandler);
+            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: sourceRoot, emitLegacyAshxHandler: emitLegacyAshxHandler, repoRoot: repoRoot);
         }
 
         /// <summary>
@@ -417,7 +418,7 @@ namespace NScript.JST
         ///     Callers that know they are using a non-legacy <paramref name="sourceRoot"/> should pass
         ///     false; the default of true preserves the legacy IIS deployment behaviour. </param>
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. Never null. </returns>
-        private OwaSourceMapper.SourceMap Write(TextWriter writer, string jsFileName, string outputDirectory, bool outputMap, string sourceRoot, bool emitLegacyAshxHandler)
+        private OwaSourceMapper.SourceMap Write(TextWriter writer, string jsFileName, string outputDirectory, bool outputMap, string sourceRoot, bool emitLegacyAshxHandler, string repoRoot)
         {
             this.ArrangeSpaces();
 
@@ -437,6 +438,7 @@ namespace NScript.JST
             }
 
             sourceMapping.EmitLegacyAshxHandler = emitLegacyAshxHandler;
+            sourceMapping.RepoRoot = repoRoot;
 
             sourceMapping.AddMapping(
                 curLine,

--- a/Sources/Compiler/NScript.Lib/CommandLine.cs
+++ b/Sources/Compiler/NScript.Lib/CommandLine.cs
@@ -44,7 +44,8 @@ namespace NScript.Lib
                     parseOptions.ReferenceDlls.ToArray(),
                     plugins.ToArray(),
                     (parseOptions.Minify, parseOptions.Uglify, parseOptions.Optimize),
-                    parseOptions.SourceMapRoot);
+                    parseOptions.SourceMapRoot,
+                    parseOptions.RepoRoot);
 
                 var stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();

--- a/Sources/Compiler/NScript.Lib/ParseOptions.cs
+++ b/Sources/Compiler/NScript.Lib/ParseOptions.cs
@@ -79,6 +79,14 @@ namespace NScript.Lib
         private string sourceMapRoot;
 
         /// <summary>
+        /// Optional absolute path to the Git repository root. When set together with
+        /// <see cref="SourceMapRoot"/>, the compiler emits <c>sources[i]</c> entries as
+        /// repo-relative forward-slash paths so they combine cleanly with a remote-repo
+        /// <c>sourceRoot</c> URL (raw.githubusercontent.com or dev.azure.com).
+        /// </summary>
+        private string repoRoot;
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="ParseOptions"/> class from being created.
         /// </summary>
         private ParseOptions()
@@ -153,6 +161,12 @@ namespace NScript.Lib
         /// <c>-sourceMapRoot</c> was not supplied (legacy <c>SrcMapper.ashx</c> fallback applies).
         /// </summary>
         public string SourceMapRoot => this.sourceMapRoot;
+
+        /// <summary>
+        /// Gets the absolute repository root path supplied via <c>-repoRoot</c>, or null when
+        /// the flag was not supplied.
+        /// </summary>
+        public string RepoRoot => this.repoRoot;
 
         /// <summary>
         /// Parses the args.
@@ -273,6 +287,22 @@ namespace NScript.Lib
                         }
 
                         options.sourceMapRoot = args[iArg];
+                        continue;
+                    case "-reporoot":
+                        option = CurrentOption.None;
+                        if (options.repoRoot != null)
+                        {
+                            Logger.Instance.LogError("-repoRoot specified at least twice");
+                            return null;
+                        }
+
+                        if (++iArg >= args.Length)
+                        {
+                            Logger.Instance.LogError("-repoRoot requires a value");
+                            return null;
+                        }
+
+                        options.repoRoot = args[iArg];
                         continue;
                     case "-log":
                     case "--log":
@@ -401,6 +431,17 @@ namespace NScript.Lib
                     "Reference dlls not specified");
             }
 
+            // -repoRoot is meaningful only when paired with -sourceMapRoot: by itself it would
+            // rebase sources[] without changing the sourceRoot, producing maps whose paths point
+            // nowhere useful. Reject the partial configuration loudly rather than silently emitting
+            // a broken map.
+            if (!string.IsNullOrEmpty(options.repoRoot)
+                && string.IsNullOrEmpty(options.sourceMapRoot))
+            {
+                Logger.Instance.LogError(
+                    "-repoRoot requires -sourceMapRoot to also be specified");
+            }
+
             return Logger.Instance.HasErrors ? null : options;
         }
 
@@ -409,7 +450,7 @@ namespace NScript.Lib
         /// </summary>
         public static void PrintUsage()
         {
-            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-sourceMapRoot <url>] [-log <jsonl path>] [-runid <id>]");
+            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-sourceMapRoot <url>] [-repoRoot <absolute-path>] [-log <jsonl path>] [-runid <id>]");
             Environment.Exit(1);
         }
 

--- a/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
+++ b/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
@@ -10,20 +10,112 @@
 		<Minify Condition="$(Minify) == ''">false</Minify>
 		<Uglify Condition="$(Uglify) == ''">false</Uglify>
 		<JsOptimize Condition="$(JsOptimize) == ''">false</JsOptimize>
+		<RepoLinkedSourceMaps Condition="'$(RepoLinkedSourceMaps)' == ''">false</RepoLinkedSourceMaps>
 	</PropertyGroup>
 
-	<Target Name="AfterCompile" DependsOnTargets="$(CoreCompile)" > 
+	<Target Name="AfterCompile" DependsOnTargets="$(CoreCompile)" >
 		<MsBuild
 			Condition="$(GenerateJs) == True"
 			Projects="$(MSBuildProjectFile)"
-			Targets="ScriptGenerate" /> 
+			Targets="ScriptGenerate" />
+	</Target>
+
+	<!--
+	  Captures the Git remote URL, commit SHA, and worktree root, then composes a raw-file
+	  base URL for either GitHub or Azure DevOps. Runs only when <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
+	  is set on the project. Each git invocation tolerates failure (ContinueOnError) so a build
+	  outside a working tree (CI cache restore, source-only ZIP) emits a warning and skips the
+	  rest of the target rather than failing.
+
+	  Auto-detection prefers explicit overrides (<SourceRepoOriginUrl>, <SourceRepoCommitSha>,
+	  <NScriptRepoRoot>) so CI can feed values directly from $(GITHUB_SHA) /
+	  $(BUILD_SOURCEVERSION) without invoking git inside the build container.
+
+	  URL construction uses MSBuild property functions (Regex.Match) so we don't ship a
+	  separate task assembly; the same regex patterns are kept under unit test in
+	  RepoUrlBuilder.cs (Sources/Compiler/SourceMap).
+	  -->
+	<Target Name="ComputeNScriptRepoMetadata"
+	        Condition="'$(RepoLinkedSourceMaps)' == 'true' and '$(SourceMapRoot)' == ''"
+	        BeforeTargets="ScriptGenerate">
+
+		<Exec Command="git remote get-url origin"
+		      Condition="'$(SourceRepoOriginUrl)' == ''"
+		      ConsoleToMSBuild="true"
+		      EchoOff="true"
+		      IgnoreExitCode="true"
+		      ContinueOnError="WarnAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_NScriptGitRemoteUrlRaw" />
+			<Output TaskParameter="ExitCode" PropertyName="_NScriptGitRemoteExit" />
+		</Exec>
+
+		<Exec Command="git rev-parse HEAD"
+		      Condition="'$(SourceRepoCommitSha)' == ''"
+		      ConsoleToMSBuild="true"
+		      EchoOff="true"
+		      IgnoreExitCode="true"
+		      ContinueOnError="WarnAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_NScriptGitShaRaw" />
+			<Output TaskParameter="ExitCode" PropertyName="_NScriptGitShaExit" />
+		</Exec>
+
+		<Exec Command="git rev-parse --show-toplevel"
+		      Condition="'$(NScriptRepoRoot)' == ''"
+		      ConsoleToMSBuild="true"
+		      EchoOff="true"
+		      IgnoreExitCode="true"
+		      ContinueOnError="WarnAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_NScriptGitTopLevelRaw" />
+		</Exec>
+
+		<PropertyGroup>
+			<SourceRepoOriginUrl Condition="'$(SourceRepoOriginUrl)' == '' and '$(_NScriptGitRemoteUrlRaw)' != ''">$(_NScriptGitRemoteUrlRaw.Trim())</SourceRepoOriginUrl>
+			<SourceRepoCommitSha Condition="'$(SourceRepoCommitSha)' == '' and '$(_NScriptGitShaRaw)' != ''">$(_NScriptGitShaRaw.Trim())</SourceRepoCommitSha>
+			<NScriptRepoRoot Condition="'$(NScriptRepoRoot)' == '' and '$(_NScriptGitTopLevelRaw)' != ''">$(_NScriptGitTopLevelRaw.Trim())</NScriptRepoRoot>
+			<SourceRepoProvider Condition="'$(SourceRepoProvider)' == ''">auto</SourceRepoProvider>
+
+			<!--
+			  Some developers / CI systems bake credentials into the origin URL
+			  (https://token@github.com/..., https://user:pass@dev.azure.com/...).
+			  Strip everything between '://' and the first '@' before echoing the URL into
+			  build logs so a stray PAT or password doesn't end up in CI artifacts.
+			  The unredacted value is still used by the regex matchers above (which only
+			  read host/path groups).
+			-->
+			<_NScriptOriginUrlRedacted Condition="'$(SourceRepoOriginUrl)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(SourceRepoOriginUrl)', '://[^/@]+@', '://***@'))</_NScriptOriginUrlRedacted>
+		</PropertyGroup>
+
+		<Warning Text="RepoLinkedSourceMaps requested but git metadata could not be captured (origin='$(_NScriptOriginUrlRedacted)' sha='$(SourceRepoCommitSha)'). Skipping repo-linked sourceRoot."
+		         Condition="'$(SourceRepoOriginUrl)' == '' or '$(SourceRepoCommitSha)' == ''" />
+
+		<!-- GitHub detection: matches https://github.com/{owner}/{repo}[.git] AND git@github.com:{owner}/{repo}[.git] -->
+		<PropertyGroup Condition="'$(SourceRepoOriginUrl)' != '' and '$(SourceRepoCommitSha)' != '' and ('$(SourceRepoProvider)' == 'auto' or '$(SourceRepoProvider)' == 'GitHub')">
+			<_NScriptGitHubOwner>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$').Groups[1].Value)</_NScriptGitHubOwner>
+			<_NScriptGitHubRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$').Groups[2].Value)</_NScriptGitHubRepo>
+			<SourceMapRoot Condition="'$(_NScriptGitHubOwner)' != '' and '$(_NScriptGitHubRepo)' != ''">https://raw.githubusercontent.com/$(_NScriptGitHubOwner)/$(_NScriptGitHubRepo)/$(SourceRepoCommitSha)/</SourceMapRoot>
+		</PropertyGroup>
+
+		<!-- Azure DevOps modern: https://dev.azure.com/{org}/{project}/_git/{repo} -->
+		<PropertyGroup Condition="'$(SourceMapRoot)' == '' and '$(SourceRepoOriginUrl)' != '' and '$(SourceRepoCommitSha)' != '' and ('$(SourceRepoProvider)' == 'auto' or '$(SourceRepoProvider)' == 'AzureDevOps')">
+			<_NScriptAdoOrg>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[1].Value)</_NScriptAdoOrg>
+			<_NScriptAdoProject>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[2].Value)</_NScriptAdoProject>
+			<_NScriptAdoRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[3].Value)</_NScriptAdoRepo>
+			<SourceMapRoot Condition="'$(_NScriptAdoOrg)' != '' and '$(_NScriptAdoProject)' != '' and '$(_NScriptAdoRepo)' != ''">https://dev.azure.com/$(_NScriptAdoOrg)/$(_NScriptAdoProject)/_apis/git/repositories/$(_NScriptAdoRepo)/items?api-version=7.1&amp;versionDescriptor.version=$(SourceRepoCommitSha)&amp;versionDescriptor.versionType=commit&amp;path=/</SourceMapRoot>
+		</PropertyGroup>
+
+		<Warning Text="RepoLinkedSourceMaps requested but origin URL '$(_NScriptOriginUrlRedacted)' did not match GitHub or Azure DevOps; emitting map without repo-linked sourceRoot."
+		         Condition="'$(SourceMapRoot)' == '' and '$(SourceRepoOriginUrl)' != '' and '$(SourceRepoCommitSha)' != ''" />
+
+		<Message Importance="high"
+		         Text="NScript repo-linked source maps: sourceRoot='$(SourceMapRoot)' repoRoot='$(NScriptRepoRoot)'"
+		         Condition="'$(SourceMapRoot)' != ''" />
 	</Target>
 
 	<Target
 		Name="ScriptGenerate"
 		Inputs="$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)\$(AssemblyName).$(Ext);@(ReferencePath)"
 		Outputs="$(JsOutputPath)\$(AssemblyName).js"
-		DependsOnTargets="$(CoreCompile)"
+		DependsOnTargets="$(CoreCompile);ComputeNScriptRepoMetadata"
 		Condition="$(GenerateJs) == True">
 
 		<Message
@@ -42,6 +134,7 @@
 			<ScriptGenerateOption Include="-uglify" Condition="'$(Uglify)' == 'true'" />
 			<ScriptGenerateOption Include="-optimize" Condition="'$(JsOptimize)' == 'true'" />
 			<ScriptGenerateOption Include="-sourceMapRoot &quot;$(SourceMapRoot)&quot;" Condition="'$(SourceMapRoot)' != ''" />
+			<ScriptGenerateOption Include="-repoRoot &quot;$(NScriptRepoRoot)&quot;" Condition="'$(SourceMapRoot)' != '' and '$(NScriptRepoRoot)' != ''" />
 		</ItemGroup>
 
 		<MakeDir Directories="$(JsOutputPath)" Condition="!Exists('$(JsOutputPath)')" />

--- a/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
+++ b/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
@@ -88,18 +88,51 @@
 		<Warning Text="RepoLinkedSourceMaps requested but git metadata could not be captured (origin='$(_NScriptOriginUrlRedacted)' sha='$(SourceRepoCommitSha)'). Skipping repo-linked sourceRoot."
 		         Condition="'$(SourceRepoOriginUrl)' == '' or '$(SourceRepoCommitSha)' == ''" />
 
-		<!-- GitHub detection: matches https://github.com/{owner}/{repo}[.git] AND git@github.com:{owner}/{repo}[.git] -->
+		<!--
+		  GitHub HTTPS: https://[creds@]github.com/{owner}/{repo}[.git]
+		  GitHub SSH (modern):   git@github.com:{owner}/{repo}[.git]
+		  GitHub SSH (ssh://):   ssh://git@github.com/{owner}/{repo}[.git]
+		  Both SSH forms collapse onto a single regex by allowing `[/:]` after `github.com`
+		  and tolerating the optional `ssh://git@` / `git@` prefix anywhere before the host.
+		  Keep these patterns in sync with `RepoUrlBuilder.cs` (covered by RepoUrlBuilderTests).
+		-->
 		<PropertyGroup Condition="'$(SourceRepoOriginUrl)' != '' and '$(SourceRepoCommitSha)' != '' and ('$(SourceRepoProvider)' == 'auto' or '$(SourceRepoProvider)' == 'GitHub')">
-			<_NScriptGitHubOwner>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$').Groups[1].Value)</_NScriptGitHubOwner>
-			<_NScriptGitHubRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$').Groups[2].Value)</_NScriptGitHubRepo>
+			<_NScriptGitHubHttpsPattern>(?i)^https?://(?:[^/@]+@)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$</_NScriptGitHubHttpsPattern>
+			<_NScriptGitHubSshPattern>(?i)^(?:ssh://)?git@github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$</_NScriptGitHubSshPattern>
+
+			<_NScriptGitHubOwner>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptGitHubHttpsPattern)').Groups[1].Value)</_NScriptGitHubOwner>
+			<_NScriptGitHubRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptGitHubHttpsPattern)').Groups[2].Value)</_NScriptGitHubRepo>
+
+			<_NScriptGitHubOwner Condition="'$(_NScriptGitHubOwner)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptGitHubSshPattern)').Groups[1].Value)</_NScriptGitHubOwner>
+			<_NScriptGitHubRepo Condition="'$(_NScriptGitHubRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptGitHubSshPattern)').Groups[2].Value)</_NScriptGitHubRepo>
+
 			<SourceMapRoot Condition="'$(_NScriptGitHubOwner)' != '' and '$(_NScriptGitHubRepo)' != ''">https://raw.githubusercontent.com/$(_NScriptGitHubOwner)/$(_NScriptGitHubRepo)/$(SourceRepoCommitSha)/</SourceMapRoot>
 		</PropertyGroup>
 
-		<!-- Azure DevOps modern: https://dev.azure.com/{org}/{project}/_git/{repo} -->
+		<!--
+		  Azure DevOps modern HTTPS: https://[creds@]dev.azure.com/{org}/{project}/_git/{repo}
+		  Azure DevOps modern SSH:   git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+		  Azure DevOps legacy HTTPS: https://[creds@]{org}.visualstudio.com/{project}/_git/{repo}
+		  All three flow into the same Items API URL shape (org / project / repo / sha / path=/).
+		  Keep these patterns in sync with `RepoUrlBuilder.cs` (covered by RepoUrlBuilderTests).
+		-->
 		<PropertyGroup Condition="'$(SourceMapRoot)' == '' and '$(SourceRepoOriginUrl)' != '' and '$(SourceRepoCommitSha)' != '' and ('$(SourceRepoProvider)' == 'auto' or '$(SourceRepoProvider)' == 'AzureDevOps')">
-			<_NScriptAdoOrg>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[1].Value)</_NScriptAdoOrg>
-			<_NScriptAdoProject>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[2].Value)</_NScriptAdoProject>
-			<_NScriptAdoRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$').Groups[3].Value)</_NScriptAdoRepo>
+			<_NScriptAdoModernHttpsPattern>(?i)^https?://(?:[^/@]+@)?dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/]+?)(?:\.git)?/?$</_NScriptAdoModernHttpsPattern>
+			<_NScriptAdoModernSshPattern>(?i)^git@ssh\.dev\.azure\.com:v3/([^/]+)/([^/]+)/([^/]+?)(?:\.git)?/?$</_NScriptAdoModernSshPattern>
+			<_NScriptAdoLegacyHttpsPattern>(?i)^https?://(?:[^/@]+@)?([^/.]+)\.visualstudio\.com/([^/]+)/_git/([^/]+?)(?:\.git)?/?$</_NScriptAdoLegacyHttpsPattern>
+
+			<_NScriptAdoOrg>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernHttpsPattern)').Groups[1].Value)</_NScriptAdoOrg>
+			<_NScriptAdoProject>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernHttpsPattern)').Groups[2].Value)</_NScriptAdoProject>
+			<_NScriptAdoRepo>$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernHttpsPattern)').Groups[3].Value)</_NScriptAdoRepo>
+
+			<_NScriptAdoOrg Condition="'$(_NScriptAdoOrg)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernSshPattern)').Groups[1].Value)</_NScriptAdoOrg>
+			<_NScriptAdoProject Condition="'$(_NScriptAdoProject)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernSshPattern)').Groups[2].Value)</_NScriptAdoProject>
+			<_NScriptAdoRepo Condition="'$(_NScriptAdoRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoModernSshPattern)').Groups[3].Value)</_NScriptAdoRepo>
+
+			<_NScriptAdoOrg Condition="'$(_NScriptAdoOrg)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoLegacyHttpsPattern)').Groups[1].Value)</_NScriptAdoOrg>
+			<_NScriptAdoProject Condition="'$(_NScriptAdoProject)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoLegacyHttpsPattern)').Groups[2].Value)</_NScriptAdoProject>
+			<_NScriptAdoRepo Condition="'$(_NScriptAdoRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(SourceRepoOriginUrl)', '$(_NScriptAdoLegacyHttpsPattern)').Groups[3].Value)</_NScriptAdoRepo>
+
 			<SourceMapRoot Condition="'$(_NScriptAdoOrg)' != '' and '$(_NScriptAdoProject)' != '' and '$(_NScriptAdoRepo)' != ''">https://dev.azure.com/$(_NScriptAdoOrg)/$(_NScriptAdoProject)/_apis/git/repositories/$(_NScriptAdoRepo)/items?api-version=7.1&amp;versionDescriptor.version=$(SourceRepoCommitSha)&amp;versionDescriptor.versionType=commit&amp;path=/</SourceMapRoot>
 		</PropertyGroup>
 

--- a/Sources/Compiler/SourceMap.Server/SourceMapFileHandler.cs
+++ b/Sources/Compiler/SourceMap.Server/SourceMapFileHandler.cs
@@ -131,9 +131,13 @@ namespace OwaSourceMapper.Server
 
             // Parse the map up-front. Both the local-file branch and the repo-redirect fallback
             // need its sources/sourceRoot data, so a single parse keeps them aligned and avoids
-            // repeated disk I/O.
+            // repeated disk I/O. When both features are disabled, skip the parse entirely — the
+            // default-config request path will return 404 below without inspecting the map.
             SourceMapSources sources = null;
-            if (TryGetFileSize(mapPath, out long mapSize) && mapSize <= options.MaxMapFileSizeBytes)
+            bool needsParse = options.ServeFromSourcesLong || options.RepoUrlRedirectOnMiss;
+            if (needsParse
+                && TryGetFileSize(mapPath, out long mapSize)
+                && mapSize <= options.MaxMapFileSizeBytes)
             {
                 sources = await SourceMapSources.TryParseAsync(mapPath, options.MaxMapFileSizeBytes, ctx.RequestAborted);
             }
@@ -177,6 +181,11 @@ namespace OwaSourceMapper.Server
                 await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
+            catch (SecurityException)
+            {
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
+                return;
+            }
 
             // Allow-list check: the resolved path MUST live under one of the configured source
             // roots. Without this, a map that points at /etc/passwd via sourcesLong would be
@@ -204,6 +213,11 @@ namespace OwaSourceMapper.Server
                 return;
             }
             catch (NotSupportedException)
+            {
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
+                return;
+            }
+            catch (SecurityException)
             {
                 await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
@@ -343,19 +357,44 @@ namespace OwaSourceMapper.Server
                 return false;
             }
 
-            // Refuse to redirect to anything other than http(s) — the legacy `{file}.ashx` root,
-            // a relative path, or a hostile `javascript:`/`data:` URI would all be unsafe.
-            if (!root.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-                && !root.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            // Refuse to redirect to anything other than https — both GitHub raw and the ADO
+            // Items API are HTTPS-only, and `http://`, the legacy `{file}.ashx` root, a
+            // relative path, or a hostile `javascript:`/`data:`/`file://` URI would all be
+            // unsafe destinations to send a browser to.
+            if (!root.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
             // sourceRoot is documented as either being a directory prefix (trailing `/`) or
-            // the immediate parent. Append literally — the compiler is responsible for shaping
-            // a working URL ahead of time.
-            redirectUrl = root + sourceName;
+            // the immediate parent. URI-encode the path segments of `sourceName` so a `#`,
+            // `?`, or other reserved character in a file name can't truncate the ADO query
+            // string at the fragment / query boundary, and so spaces become `%20` instead
+            // of breaking the URL. Forward slashes are preserved because both GitHub raw
+            // and the ADO Items API treat them as path separators.
+            redirectUrl = root + EncodeSourcePath(sourceName);
             return true;
+        }
+
+        /// <summary>
+        /// URI-encodes the path component of a source name while preserving forward slashes
+        /// as path separators. Used when composing repo-URL redirects so reserved characters
+        /// (#, ?, &amp;, space, …) inside the source name don't truncate or corrupt the URL.
+        /// </summary>
+        private static string EncodeSourcePath(string sourceName)
+        {
+            if (string.IsNullOrEmpty(sourceName))
+            {
+                return sourceName;
+            }
+
+            string[] segments = sourceName.Split('/');
+            for (int i = 0; i < segments.Length; i++)
+            {
+                segments[i] = Uri.EscapeDataString(segments[i]);
+            }
+
+            return string.Join("/", segments);
         }
 
         private static bool TryGetFileSize(string path, out long size)
@@ -371,6 +410,18 @@ namespace OwaSourceMapper.Server
 
                 size = info.Length;
                 return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (PathTooLongException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
             }
             catch (IOException)
             {

--- a/Sources/Compiler/SourceMap.Server/SourceMapFileHandler.cs
+++ b/Sources/Compiler/SourceMap.Server/SourceMapFileHandler.cs
@@ -9,6 +9,7 @@ namespace OwaSourceMapper.Server
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Security;
     using System.Text.RegularExpressions;
@@ -128,19 +129,21 @@ namespace OwaSourceMapper.Server
                 return;
             }
 
+            // Parse the map up-front. Both the local-file branch and the repo-redirect fallback
+            // need its sources/sourceRoot data, so a single parse keeps them aligned and avoids
+            // repeated disk I/O.
+            SourceMapSources sources = null;
+            if (TryGetFileSize(mapPath, out long mapSize) && mapSize <= options.MaxMapFileSizeBytes)
+            {
+                sources = await SourceMapSources.TryParseAsync(mapPath, options.MaxMapFileSizeBytes, ctx.RequestAborted);
+            }
+
             if (!options.ServeFromSourcesLong)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
-            if (!TryGetFileSize(mapPath, out long mapSize) || mapSize > options.MaxMapFileSizeBytes)
-            {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                return;
-            }
-
-            var sources = await SourceMapSources.TryParseAsync(mapPath, options.MaxMapFileSizeBytes, ctx.RequestAborted);
             if (sources == null)
             {
                 ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
@@ -150,7 +153,7 @@ namespace OwaSourceMapper.Server
             string longPath = sources.ResolveLongPath(sourceName);
             if (longPath == null)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
@@ -161,17 +164,17 @@ namespace OwaSourceMapper.Server
             }
             catch (ArgumentException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (PathTooLongException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (NotSupportedException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
@@ -181,7 +184,7 @@ namespace OwaSourceMapper.Server
             var allowedRoots = preResolvedAllowedRoots ?? options.ResolveAllowedRoots(mapsDir);
             if (!IsContainedInAny(resolvedLongPath, allowedRoots))
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
@@ -192,23 +195,23 @@ namespace OwaSourceMapper.Server
             }
             catch (ArgumentException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (PathTooLongException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (NotSupportedException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
             if (!info.Exists)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
 
@@ -243,12 +246,12 @@ namespace OwaSourceMapper.Server
             }
             catch (FileNotFoundException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (DirectoryNotFoundException)
             {
-                ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await NotFoundOrRedirectAsync(ctx, sources, sourceName, options);
                 return;
             }
             catch (UnauthorizedAccessException)
@@ -276,6 +279,83 @@ namespace OwaSourceMapper.Server
             {
                 await stream.DisposeAsync();
             }
+        }
+
+        /// <summary>
+        /// When the caller has decided the local lookup must fail, optionally consult the
+        /// repo-URL redirect branch before returning <c>404</c>. The redirect only fires when
+        /// <paramref name="options"/>.<see cref="SourceMapFileHandlerOptions.RepoUrlRedirectOnMiss"/>
+        /// is true AND the parsed map's <c>sourceRoot</c> is an http(s) URL AND the requested
+        /// short name exists in the map's <c>sources</c> array.
+        /// </summary>
+        private static Task NotFoundOrRedirectAsync(
+            HttpContext ctx,
+            SourceMapSources sources,
+            string sourceName,
+            SourceMapFileHandlerOptions options)
+        {
+            if (TryBuildRepoRedirect(sources, sourceName, options, out string redirectUrl))
+            {
+                ctx.Response.StatusCode = (int)HttpStatusCode.Found;
+                ctx.Response.Headers["Location"] = redirectUrl;
+                return Task.CompletedTask;
+            }
+
+            ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Builds a redirect URL to the repo-hosted source when redirect is opted-in and the
+        /// parsed map carries an http(s) <c>sourceRoot</c>. Returns false (and leaves
+        /// <paramref name="redirectUrl"/> null) when the redirect should NOT fire — the caller
+        /// then falls through to a plain 404.
+        /// </summary>
+        internal static bool TryBuildRepoRedirect(
+            SourceMapSources sources,
+            string sourceName,
+            SourceMapFileHandlerOptions options,
+            out string redirectUrl)
+        {
+            redirectUrl = null;
+
+            if (options == null || !options.RepoUrlRedirectOnMiss)
+            {
+                return false;
+            }
+
+            if (sources == null || string.IsNullOrEmpty(sourceName))
+            {
+                return false;
+            }
+
+            // The short name MUST exist in the parsed map; without this check, a 302 would be
+            // emitted for any path the attacker dangles after the prefix. ContainsName is the
+            // contract: "the compiler emitted a `sources[]` entry exactly equal to this string".
+            if (!sources.ShortNames.Contains(sourceName))
+            {
+                return false;
+            }
+
+            string root = sources.SourceRoot;
+            if (string.IsNullOrEmpty(root))
+            {
+                return false;
+            }
+
+            // Refuse to redirect to anything other than http(s) — the legacy `{file}.ashx` root,
+            // a relative path, or a hostile `javascript:`/`data:` URI would all be unsafe.
+            if (!root.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                && !root.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // sourceRoot is documented as either being a directory prefix (trailing `/`) or
+            // the immediate parent. Append literally — the compiler is responsible for shaping
+            // a working URL ahead of time.
+            redirectUrl = root + sourceName;
+            return true;
         }
 
         private static bool TryGetFileSize(string path, out long size)

--- a/Sources/Compiler/SourceMap.Server/SourceMapFileHandlerOptions.cs
+++ b/Sources/Compiler/SourceMap.Server/SourceMapFileHandlerOptions.cs
@@ -60,6 +60,22 @@ namespace OwaSourceMapper.Server
         public long MaxSourceFileSizeBytes { get; set; } = 16L * 1024 * 1024;
 
         /// <summary>
+        /// When <c>true</c>, the handler issues a <c>302 Found</c> redirect to
+        /// <c>{sourceRoot}{sourceName}</c> instead of returning <c>404</c> when the requested
+        /// source file is unavailable locally. The redirect only fires when the parsed map's
+        /// <c>sourceRoot</c> begins with <c>http://</c> or <c>https://</c>, so a misconfigured
+        /// or legacy <c>SrcMapper.ashx</c> root never triggers an outbound redirect.
+        /// </summary>
+        /// <remarks>
+        /// SECURITY: a tampered <c>.map</c> could redirect the browser to an attacker-controlled
+        /// URL. Only enable this in deployments that trust the map artifacts they ship.
+        /// Authentication / private-repo proxying is intentionally NOT covered here — the redirect
+        /// hands the request off to the browser's HTTPS stack, relying on the user's existing
+        /// session cookies (if any).
+        /// </remarks>
+        public bool RepoUrlRedirectOnMiss { get; set; } = false;
+
+        /// <summary>
         /// Validates that <see cref="MapsDirectory"/> is set and exists. Returns the
         /// absolute, fully-qualified directory on success; <c>null</c> otherwise.
         /// </summary>

--- a/Sources/Compiler/SourceMap.Server/SourceMapSources.cs
+++ b/Sources/Compiler/SourceMap.Server/SourceMapSources.cs
@@ -23,10 +23,12 @@ namespace OwaSourceMapper.Server
     public sealed class SourceMapSources
     {
         private readonly Dictionary<string, string> shortToLong;
+        private readonly string sourceRoot;
 
-        private SourceMapSources(Dictionary<string, string> shortToLong)
+        private SourceMapSources(Dictionary<string, string> shortToLong, string sourceRoot)
         {
             this.shortToLong = shortToLong;
+            this.sourceRoot = sourceRoot;
         }
 
         /// <summary>
@@ -34,6 +36,13 @@ namespace OwaSourceMapper.Server
         /// (e.g. <c>"C$/Sources/.../MyFile.cs"</c>).
         /// </summary>
         public IReadOnlyCollection<string> ShortNames => this.shortToLong.Keys;
+
+        /// <summary>
+        /// Gets the <c>sourceRoot</c> string recorded in the map, or null when the field is
+        /// absent. The handler's repo-URL redirect branch uses this together with a
+        /// resolved short name to redirect DevTools at <c>{sourceRoot}{sources[i]}</c>.
+        /// </summary>
+        public string SourceRoot => this.sourceRoot;
 
         /// <summary>
         /// Parses the <c>sources</c>/<c>sourcesLong</c> arrays out of a source map file.
@@ -170,6 +179,13 @@ namespace OwaSourceMapper.Server
                     return null;
                 }
 
+                string parsedSourceRoot = null;
+                if (root.TryGetProperty("sourceRoot", out var srEl)
+                    && srEl.ValueKind == JsonValueKind.String)
+                {
+                    parsedSourceRoot = srEl.GetString();
+                }
+
                 // "sourcesLong" is optional (non-standard NScript extension). When absent, the
                 // short source names ARE the resolvable paths — e.g. when the map was generated
                 // with a repo-URL sourceRoot rather than local disk paths.
@@ -199,7 +215,7 @@ namespace OwaSourceMapper.Server
                     map[shortName] = longName;
                 }
 
-                return map.Count == 0 ? null : new SourceMapSources(map);
+                return map.Count == 0 ? null : new SourceMapSources(map, parsedSourceRoot);
             }
             catch (JsonException)
             {

--- a/Sources/Compiler/SourceMap.Server/SourceMapSources.cs
+++ b/Sources/Compiler/SourceMap.Server/SourceMapSources.cs
@@ -111,6 +111,10 @@ namespace OwaSourceMapper.Server
             {
                 return null;
             }
+            catch (SecurityException)
+            {
+                return null;
+            }
 
             if (!info.Exists || info.Length > maxBytes)
             {

--- a/Sources/Compiler/SourceMap/RepoUrlBuilder.cs
+++ b/Sources/Compiler/SourceMap/RepoUrlBuilder.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace OwaSourceMapper
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Constructs the <c>sourceRoot</c> URL that points to a remote repository's raw-file
+    /// endpoint (GitHub or Azure DevOps).
+    /// </summary>
+    /// <remarks>
+    /// The MSBuild SDK target <c>ComputeNScriptRepoMetadata</c> in <c>Sdk.targets</c> emits the
+    /// same URL shape using inline <c>Regex.Match</c> property functions (so the build doesn't
+    /// have to load a separate task assembly). This class is the canonical regression-test
+    /// target for that URL shape — keep the regex patterns here and in <c>Sdk.targets</c> in
+    /// sync, and rely on <c>RepoUrlBuilderTests</c> to catch drift.
+    /// </remarks>
+    public static class RepoUrlBuilder
+    {
+        // GitHub variants:
+        //   https://github.com/{owner}/{repo}.git
+        //   https://github.com/{owner}/{repo}
+        //   git@github.com:{owner}/{repo}.git
+        //   ssh://git@github.com/{owner}/{repo}.git
+        private static readonly Regex GitHubHttps = new Regex(
+            @"^https?://(?:[^/@]+@)?github\.com/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex GitHubSsh = new Regex(
+            @"^(?:ssh://)?git@github\.com[:/](?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Modern ADO: https://dev.azure.com/{org}/{project}/_git/{repo}
+        // SSH ADO:    git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+        // Legacy:     https://{org}.visualstudio.com/{project}/_git/{repo}
+        // Legacy SSH: ssh://{org}@vs-ssh.visualstudio.com:22/{project}/_git/{repo}
+        private static readonly Regex AdoModernHttps = new Regex(
+            @"^https?://(?:[^/@]+@)?dev\.azure\.com/(?<org>[^/]+)/(?<project>[^/]+)/_git/(?<repo>[^/]+?)(?:\.git)?/?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex AdoModernSsh = new Regex(
+            @"^git@ssh\.dev\.azure\.com:v3/(?<org>[^/]+)/(?<project>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex AdoLegacyHttps = new Regex(
+            @"^https?://(?:[^/@]+@)?(?<org>[^/.]+)\.visualstudio\.com/(?<project>[^/]+)/_git/(?<repo>[^/]+?)(?:\.git)?/?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Identifies the supported source-control hosting providers.
+        /// </summary>
+        public enum Provider
+        {
+            /// <summary>Provider could not be auto-detected from the remote URL.</summary>
+            Unknown,
+
+            /// <summary>GitHub (github.com).</summary>
+            GitHub,
+
+            /// <summary>Azure DevOps (modern <c>dev.azure.com</c> or legacy <c>*.visualstudio.com</c>).</summary>
+            AzureDevOps,
+        }
+
+        /// <summary>
+        /// Builds a raw-file URL that ends with a trailing slash so callers can append
+        /// repo-relative source paths to form full URLs.
+        /// </summary>
+        /// <param name="remoteUrl">       The Git remote URL (output of <c>git remote get-url origin</c>). </param>
+        /// <param name="commitSha">       The commit SHA (output of <c>git rev-parse HEAD</c>). May not be null/empty. </param>
+        /// <param name="rawUrl">          On success, the constructed raw-file URL ending with <c>/</c>. </param>
+        /// <param name="detectedProvider"> On success, the auto-detected provider. </param>
+        /// <returns>True if <paramref name="remoteUrl"/> was recognised; false otherwise.</returns>
+        public static bool TryBuildRawUrl(
+            string remoteUrl,
+            string commitSha,
+            out string rawUrl,
+            out Provider detectedProvider)
+        {
+            rawUrl = null;
+            detectedProvider = Provider.Unknown;
+
+            if (string.IsNullOrWhiteSpace(remoteUrl) || string.IsNullOrWhiteSpace(commitSha))
+            {
+                return false;
+            }
+
+            string trimmedRemote = remoteUrl.Trim();
+            string trimmedSha = commitSha.Trim();
+
+            if (TryParseGitHub(trimmedRemote, out var owner, out var repo))
+            {
+                detectedProvider = Provider.GitHub;
+                rawUrl = string.Format(
+                    "https://raw.githubusercontent.com/{0}/{1}/{2}/",
+                    owner,
+                    repo,
+                    trimmedSha);
+                return true;
+            }
+
+            if (TryParseAzureDevOps(trimmedRemote, out var adoOrg, out var adoProject, out var adoRepo))
+            {
+                detectedProvider = Provider.AzureDevOps;
+                // ADO has no github-style raw endpoint, so we use the Items API and bake the
+                // SHA + a trailing `path=/` into the prefix. DevTools fetches `sourceRoot + sources[i]`
+                // as a plain GET, which lands as `…&path=/{relativePath}` — the shape Items API expects.
+                rawUrl = string.Format(
+                    "https://dev.azure.com/{0}/{1}/_apis/git/repositories/{2}/items?api-version=7.1&versionDescriptor.version={3}&versionDescriptor.versionType=commit&path=/",
+                    adoOrg,
+                    adoProject,
+                    adoRepo,
+                    trimmedSha);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Provider-detection helper that does not construct a URL. Useful when callers want
+        /// to log or branch on provider without resolving a SHA.
+        /// </summary>
+        public static Provider DetectProvider(string remoteUrl)
+        {
+            if (string.IsNullOrWhiteSpace(remoteUrl))
+            {
+                return Provider.Unknown;
+            }
+
+            string trimmed = remoteUrl.Trim();
+            if (TryParseGitHub(trimmed, out _, out _)) { return Provider.GitHub; }
+            if (TryParseAzureDevOps(trimmed, out _, out _, out _)) { return Provider.AzureDevOps; }
+            return Provider.Unknown;
+        }
+
+        private static bool TryParseGitHub(string remoteUrl, out string owner, out string repo)
+        {
+            owner = null;
+            repo = null;
+
+            var match = GitHubHttps.Match(remoteUrl);
+            if (!match.Success)
+            {
+                match = GitHubSsh.Match(remoteUrl);
+            }
+
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            owner = match.Groups["owner"].Value;
+            repo = match.Groups["repo"].Value;
+            return !string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo);
+        }
+
+        private static bool TryParseAzureDevOps(string remoteUrl, out string org, out string project, out string repo)
+        {
+            org = null;
+            project = null;
+            repo = null;
+
+            var match = AdoModernHttps.Match(remoteUrl);
+            if (!match.Success) { match = AdoModernSsh.Match(remoteUrl); }
+            if (!match.Success) { match = AdoLegacyHttps.Match(remoteUrl); }
+
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            org = match.Groups["org"].Value;
+            project = match.Groups["project"].Value;
+            repo = match.Groups["repo"].Value;
+            return !string.IsNullOrEmpty(org) && !string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(repo);
+        }
+    }
+}

--- a/Sources/Compiler/SourceMap/SourceMap.cs
+++ b/Sources/Compiler/SourceMap/SourceMap.cs
@@ -4,6 +4,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
+// Expose `internal` helpers (NormalizeRepoRoot, TryRebaseToRepoRoot, AbsolutizeForSources)
+// to the unit-test assembly so they can be exercised directly without going through the
+// full ToString() pipeline. The csproj has GenerateAssemblyInfo=false so the attribute is
+// declared in source rather than via an MSBuild <InternalsVisibleTo> item. WI-19 iter-1 M4.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SourceMap.Test")]
+
 namespace OwaSourceMapper
 {
     public struct SourceMapping
@@ -284,13 +290,53 @@ namespace OwaSourceMapper
                 return null;
             }
 
-            if (!fullPath.StartsWith(normalizedRepoRoot, StringComparison.OrdinalIgnoreCase))
+            // Match the SourceMapFileHandler.IsContained pattern: filesystem case sensitivity
+            // is platform-dependent. Folding case unconditionally on Linux/macOS would cause a
+            // file under e.g. `/repo/Source/Foo.cs` to incorrectly match a `/repo/SOURCE/`
+            // alias and produce a corrupt rebase. On Windows the legacy ignore-case behaviour
+            // remains.
+            StringComparison cmp = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!fullPath.StartsWith(normalizedRepoRoot, cmp))
             {
                 return null;
             }
 
             string relative = fullPath.Substring(normalizedRepoRoot.Length);
             return relative.Replace("\\", "/");
+        }
+
+        /// <summary>
+        /// Legacy fallback that produces the absolutized, drive-escaped, forward-slashed
+        /// form of <paramref name="rawFile"/> for emission into the <c>sources[]</c> array
+        /// when no repo-rebase applies. Wrapped in the same 4-exception set used elsewhere
+        /// (NormalizeRepoRoot, TryRebaseToRepoRoot) so that a malformed legacy path doesn't
+        /// take down map generation — we degrade to the unprocessed (forward-slashed) form.
+        /// </summary>
+        private static string AbsolutizeForSources(string rawFile)
+        {
+            try
+            {
+                return Path.GetFullPath(rawFile).Replace(":", "$").Replace("\\", "/");
+            }
+            catch (ArgumentException)
+            {
+                return rawFile.Replace("\\\\", "/");
+            }
+            catch (PathTooLongException)
+            {
+                return rawFile.Replace("\\\\", "/");
+            }
+            catch (NotSupportedException)
+            {
+                return rawFile.Replace("\\\\", "/");
+            }
+            catch (System.Security.SecurityException)
+            {
+                return rawFile.Replace("\\\\", "/");
+            }
         }
 
         public static int MappingComparison(Tuple<int, int> lineCol1, Tuple<int, int> lineCol2)
@@ -397,7 +443,7 @@ namespace OwaSourceMapper
                 for (int i = 0; i < this.files.Count; i++)
                 {
                     var fileName = TryRebaseToRepoRoot(this.files[i], normalizedRepoRoot)
-                        ?? Path.GetFullPath(this.files[i]).Replace(":", "$").Replace("\\", "/");
+                        ?? AbsolutizeForSources(this.files[i]);
                     if (fileMap.TryGetValue(fileName, out var tmp))
                     { fileMap[fileName] = tmp + 1; fileName = fileName + tmp + 1; }
                     else

--- a/Sources/Compiler/SourceMap/SourceMap.cs
+++ b/Sources/Compiler/SourceMap/SourceMap.cs
@@ -186,6 +186,14 @@ namespace OwaSourceMapper
         public bool EmitLegacyAshxHandler { get; set; } = true;
 
         /// <summary>
+        /// Optional absolute path to the repository root (output of <c>git rev-parse --show-toplevel</c>).
+        /// When set, <see cref="ToString"/> emits <c>sources[i]</c> as forward-slash, repo-relative
+        /// paths so they combine cleanly with a remote-repo <see cref="SourceRoot"/>. Files outside
+        /// the repo root remain in the legacy absolutized form.
+        /// </summary>
+        public string RepoRoot { get; set; }
+
+        /// <summary>
         /// Mapping comparison.
         /// </summary>
         /// <param name="lineCol1"> The first line col. </param>
@@ -193,6 +201,98 @@ namespace OwaSourceMapper
         /// <returns>
         /// .
         /// </returns>
+        /// <summary>
+        /// Normalizes <paramref name="repoRoot"/> to a full path with a trailing directory separator
+        /// for cheap startsWith comparisons. Returns null on null/empty input so callers can short-
+        /// circuit the rebase.
+        /// </summary>
+        internal static string NormalizeRepoRoot(string repoRoot)
+        {
+            if (string.IsNullOrWhiteSpace(repoRoot))
+            {
+                return null;
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(repoRoot);
+            }
+            catch (ArgumentException)
+            {
+                // GetFullPath rejects malformed input; treat as "no rebase".
+                return null;
+            }
+            catch (PathTooLongException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return null;
+            }
+
+            if (!fullPath.EndsWith(Path.DirectorySeparatorChar.ToString())
+                && !fullPath.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+            {
+                fullPath += Path.DirectorySeparatorChar;
+            }
+
+            return fullPath;
+        }
+
+        /// <summary>
+        /// If <paramref name="rawFile"/> sits under <paramref name="normalizedRepoRoot"/>, returns
+        /// the forward-slash, repo-relative form; otherwise returns null so the caller falls back
+        /// to the legacy absolutized form.
+        /// </summary>
+        /// <param name="rawFile">              Source file path as the compiler stored it
+        ///     (may contain escaped backslashes from <see cref="AddMapping"/>). </param>
+        /// <param name="normalizedRepoRoot">   Normalized repo root with a trailing separator,
+        ///     or null to skip rebase. </param>
+        internal static string TryRebaseToRepoRoot(string rawFile, string normalizedRepoRoot)
+        {
+            if (normalizedRepoRoot == null || string.IsNullOrEmpty(rawFile))
+            {
+                return null;
+            }
+
+            string unescaped = rawFile.Replace("\\\\", "\\");
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(unescaped);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (PathTooLongException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return null;
+            }
+
+            if (!fullPath.StartsWith(normalizedRepoRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string relative = fullPath.Substring(normalizedRepoRoot.Length);
+            return relative.Replace("\\", "/");
+        }
+
         public static int MappingComparison(Tuple<int, int> lineCol1, Tuple<int, int> lineCol2)
         {
             if (lineCol1.Item1 != lineCol2.Item1)
@@ -292,10 +392,12 @@ namespace OwaSourceMapper
             if (this.files.Count > 0)
             {
                 Dictionary<string, int> fileMap = new Dictionary<string, int>(this.files.Count);
+                string normalizedRepoRoot = NormalizeRepoRoot(this.RepoRoot);
                 sb.Append("\t\"sources\": [");
                 for (int i = 0; i < this.files.Count; i++)
                 {
-                    var fileName = Path.GetFullPath(this.files[i]).Replace(":", "$").Replace("\\", "/");
+                    var fileName = TryRebaseToRepoRoot(this.files[i], normalizedRepoRoot)
+                        ?? Path.GetFullPath(this.files[i]).Replace(":", "$").Replace("\\", "/");
                     if (fileMap.TryGetValue(fileName, out var tmp))
                     { fileMap[fileName] = tmp + 1; fileName = fileName + tmp + 1; }
                     else

--- a/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
+++ b/Test/Compiler/NScript.Utils.Test/CompilerLogTests.cs
@@ -437,4 +437,96 @@ namespace NScript.Utils.Test
             Assert.IsNull(options.SourceMapRoot);
         }
     }
+
+    /// <summary>
+    /// Tests for the WI-19 <c>-repoRoot</c> CLI flag. <c>-repoRoot</c> is meaningful
+    /// only when paired with <c>-sourceMapRoot</c>; alone it would silently emit a
+    /// map whose <c>sources[]</c> entries point nowhere useful, so the parser
+    /// rejects the partial configuration.
+    /// </summary>
+    [TestClass]
+    public class ParseOptionsRepoRootTests
+    {
+        private string tempRefDll;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Logger.Instance = new Logger();
+            this.tempRefDll = Path.GetTempFileName();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (!string.IsNullOrEmpty(this.tempRefDll) && File.Exists(this.tempRefDll))
+            {
+                try { File.Delete(this.tempRefDll); } catch { /* best effort */ }
+            }
+        }
+
+        private string[] BaseArgs => new[]
+        {
+            "-outJs", "out.js",
+            "-entryAssembly", "fake.dll",
+            "-references", this.tempRefDll,
+        };
+
+        private string[] ArgsWithSuffix(params string[] suffix)
+        {
+            var list = new System.Collections.Generic.List<string>(this.BaseArgs);
+            list.AddRange(suffix);
+            return list.ToArray();
+        }
+
+        [TestMethod]
+        public void ParseArgs_RepoRoot_PairedWithSourceMapRoot_IsCaptured()
+        {
+            var options = ParseOptions.ParseArgs(
+                this.ArgsWithSuffix(
+                    "-sourceMapRoot", "https://raw.githubusercontent.com/o/r/sha/",
+                    "-repoRoot", "C:/repos/NScript"));
+            Assert.IsNotNull(options, "ParseArgs should succeed when -repoRoot is paired with -sourceMapRoot");
+            Assert.AreEqual("C:/repos/NScript", options.RepoRoot);
+        }
+
+        [TestMethod]
+        public void ParseArgs_RepoRoot_WithoutSourceMapRoot_ReturnsNull()
+        {
+            // -repoRoot alone would rebase sources[] without changing the sourceRoot, producing
+            // maps whose paths point nowhere useful. ParseArgs must reject this loudly.
+            var options = ParseOptions.ParseArgs(
+                this.ArgsWithSuffix("-repoRoot", "C:/repos/NScript"));
+            Assert.IsNull(options, "-repoRoot without -sourceMapRoot must cause ParseArgs to return null");
+        }
+
+        [TestMethod]
+        public void ParseArgs_RepoRoot_DuplicateFlag_ReturnsNull()
+        {
+            var options = ParseOptions.ParseArgs(
+                this.ArgsWithSuffix(
+                    "-sourceMapRoot", "https://raw.githubusercontent.com/o/r/sha/",
+                    "-repoRoot", "C:/first",
+                    "-repoRoot", "C:/second"));
+            Assert.IsNull(options, "Duplicate -repoRoot flags must cause ParseArgs to return null");
+        }
+
+        [TestMethod]
+        public void ParseArgs_RepoRoot_AsLastArg_ReturnsNull()
+        {
+            var options = ParseOptions.ParseArgs(
+                this.ArgsWithSuffix(
+                    "-sourceMapRoot", "https://raw.githubusercontent.com/o/r/sha/",
+                    "-repoRoot"));
+            Assert.IsNull(options, "-repoRoot with no trailing value must cause ParseArgs to return null");
+        }
+
+        [TestMethod]
+        public void ParseArgs_NoRepoRootFlag_DefaultIsNull()
+        {
+            var options = ParseOptions.ParseArgs(this.BaseArgs);
+            Assert.IsNotNull(options, "ParseArgs should succeed with base args");
+            Assert.IsNull(options.RepoRoot);
+        }
+    }
 }

--- a/Test/Compiler/SourceMap.Server.E2E.Test/RepoLinkedSourceMapE2ETests.cs
+++ b/Test/Compiler/SourceMap.Server.E2E.Test/RepoLinkedSourceMapE2ETests.cs
@@ -1,0 +1,233 @@
+// -----------------------------------------------------------------------
+// <copyright file="RepoLinkedSourceMapE2ETests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace OwaSourceMapper.Server.E2E.Test
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Playwright;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Browser-driven validation of the WI-19 repo-linked source map flow. Two Kestrel hosts
+    /// stand in for the production topology:
+    /// <list type="bullet">
+    ///   <item><description>The "app" host serves a tiny HTML+JS page along with a
+    ///   <c>.map</c> file whose <c>sourceRoot</c> points at the second host.</description></item>
+    ///   <item><description>The "repo" host plays the role of <c>raw.githubusercontent.com</c>
+    ///   / <c>dev.azure.com/_apis/git/items</c> — it answers GET requests for the original
+    ///   source files.</description></item>
+    /// </list>
+    /// Chromium loads the page, then the test exercises the same end-to-end flow DevTools
+    /// would walk through: fetching the <c>.map</c>, reading its <c>sourceRoot</c>, and
+    /// fetching the original source from the repo host. Together these confirm a deployed
+    /// build with a repo-linked map round-trips through a real browser HTTP stack — the
+    /// piece local unit tests can only stub.
+    /// </summary>
+    /// <remarks>
+    /// Gated behind the <c>ENABLE_PLAYWRIGHT_E2E=true</c> environment variable so normal
+    /// CI runs (which don't have Playwright browsers installed) don't pay the cost.
+    /// To run locally:
+    /// <code>
+    ///   pwsh -Command "&amp; { Test/Compiler/SourceMap.Server.E2E.Test/bin/Debug/net8.0/playwright.ps1 install chromium }"
+    ///   $env:ENABLE_PLAYWRIGHT_E2E = "true"
+    ///   dotnet test Test/Compiler/SourceMap.Server.E2E.Test/SourceMap.Server.E2E.Test.csproj
+    /// </code>
+    /// </remarks>
+    [TestClass]
+    public class RepoLinkedSourceMapE2ETests
+    {
+        private const string E2EEnvFlag = "ENABLE_PLAYWRIGHT_E2E";
+        private const string SourceFileName = "Program.cs";
+        private const string SourceFileBody = "// repo-hosted Program.cs\nclass Foo { void Bar() {} }\n";
+
+        private IHost appHost;
+        private IHost repoHost;
+        private string appBaseUrl;
+        private string repoBaseUrl;
+        private IPlaywright playwright;
+        private IBrowser browser;
+
+        [TestInitialize]
+        public async Task InitAsync()
+        {
+            if (!IsE2EEnabled())
+            {
+                return;
+            }
+
+            // Bind both hosts to ephemeral ports — we read back the actual URL from server features
+            // after start so that nothing in the test hard-codes :5000 / :5001 (which would clash
+            // with anyone else running Kestrel locally).
+            this.repoHost = BuildRepoHost();
+            await this.repoHost.StartAsync();
+            this.repoBaseUrl = ExtractFirstAddress(this.repoHost);
+
+            this.appHost = BuildAppHost(this.repoBaseUrl);
+            await this.appHost.StartAsync();
+            this.appBaseUrl = ExtractFirstAddress(this.appHost);
+
+            this.playwright = await Playwright.CreateAsync();
+            this.browser = await this.playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true,
+            });
+        }
+
+        [TestCleanup]
+        public async Task CleanupAsync()
+        {
+            if (this.browser != null) await this.browser.CloseAsync();
+            this.playwright?.Dispose();
+            if (this.appHost != null) { await this.appHost.StopAsync(); this.appHost.Dispose(); }
+            if (this.repoHost != null) { await this.repoHost.StopAsync(); this.repoHost.Dispose(); }
+        }
+
+        [TestMethod]
+        public async Task DevTools_FetchesOriginalSource_FromRepoSourceRoot()
+        {
+            if (!IsE2EEnabled())
+            {
+                Assert.Inconclusive($"Set {E2EEnvFlag}=true to run Playwright E2E tests.");
+                return;
+            }
+
+            var ctx = await this.browser.NewContextAsync();
+            var page = await ctx.NewPageAsync();
+
+            await page.GotoAsync(this.appBaseUrl + "/index.html");
+            await page.WaitForFunctionAsync("() => typeof window.__appLoaded !== 'undefined'");
+
+            // Replay the fetch sequence DevTools performs when "Resolve original source" is
+            // engaged: pull the .map, read its sourceRoot + sources[i], and fetch the original
+            // file through the repo host. APIRequestContext shares the browser's network stack
+            // (cookie jar, redirects, TLS settings), so this matches what a real DevTools session
+            // would experience.
+            var mapResp = await ctx.APIRequest.GetAsync(this.appBaseUrl + "/app.js.map");
+            Assert.AreEqual((int)HttpStatusCode.OK, mapResp.Status);
+            string mapJson = await mapResp.TextAsync();
+            StringAssert.Contains(mapJson, this.repoBaseUrl, "Map's sourceRoot must point at the repo host");
+            StringAssert.Contains(mapJson, SourceFileName);
+
+            var srcResp = await ctx.APIRequest.GetAsync(this.repoBaseUrl + "/" + SourceFileName);
+            Assert.AreEqual((int)HttpStatusCode.OK, srcResp.Status);
+            string body = await srcResp.TextAsync();
+            StringAssert.Contains(body, "class Foo", "Repo host must serve the original C# source body");
+        }
+
+        private static bool IsE2EEnabled()
+        {
+            return string.Equals(
+                Environment.GetEnvironmentVariable(E2EEnvFlag),
+                "true",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ExtractFirstAddress(IHost host)
+        {
+            var server = host.Services.GetService(typeof(Microsoft.AspNetCore.Hosting.Server.IServer))
+                as Microsoft.AspNetCore.Hosting.Server.IServer;
+            var feature = server?.Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>();
+            return feature?.Addresses?.FirstOrDefault()
+                ?? throw new InvalidOperationException("Kestrel didn't expose any bound addresses");
+        }
+
+        private static IHost BuildRepoHost()
+        {
+            return Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(web =>
+                {
+                    web.UseKestrel(opts => opts.ListenLocalhost(0));
+                    web.Configure(app =>
+                    {
+                        app.Run(async ctx =>
+                        {
+                            // Naive raw-file responder — the path component after the leading slash
+                            // is treated as the file name. Only the test fixture's known file is
+                            // served; everything else 404s.
+                            string requested = ctx.Request.Path.Value?.TrimStart('/') ?? string.Empty;
+                            if (requested == SourceFileName)
+                            {
+                                ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                                ctx.Response.ContentType = "text/plain; charset=utf-8";
+                                await ctx.Response.WriteAsync(SourceFileBody, Encoding.UTF8);
+                                return;
+                            }
+
+                            ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                        });
+                    });
+                })
+                .Build();
+        }
+
+        private static IHost BuildAppHost(string repoBaseUrl)
+        {
+            return Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(web =>
+                {
+                    web.UseKestrel(opts => opts.ListenLocalhost(0));
+                    web.Configure(app =>
+                    {
+                        app.Run(async ctx =>
+                        {
+                            string path = ctx.Request.Path.Value ?? string.Empty;
+                            if (path == "/" || path == "/index.html")
+                            {
+                                ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                                ctx.Response.ContentType = "text/html; charset=utf-8";
+                                await ctx.Response.WriteAsync(
+                                    "<!DOCTYPE html><html><body>"
+                                    + "<script src=\"/app.js\"></script>"
+                                    + "</body></html>",
+                                    Encoding.UTF8);
+                                return;
+                            }
+
+                            if (path == "/app.js")
+                            {
+                                ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                                ctx.Response.ContentType = "application/javascript; charset=utf-8";
+                                await ctx.Response.WriteAsync(
+                                    "window.__appLoaded = true;\n"
+                                    + "//# sourceMappingURL=/app.js.map\n",
+                                    Encoding.UTF8);
+                                return;
+                            }
+
+                            if (path == "/app.js.map")
+                            {
+                                // Repo-linked map: sourceRoot points at the second host, sources[]
+                                // contains the repo-relative short name DevTools will append.
+                                string mapJson = "{"
+                                    + "\"version\":3,"
+                                    + "\"file\":\"app.js\","
+                                    + "\"sourceRoot\":\"" + repoBaseUrl.TrimEnd('/') + "/\","
+                                    + "\"sources\":[\"" + SourceFileName + "\"],"
+                                    + "\"names\":[],"
+                                    + "\"mappings\":\"\""
+                                    + "}";
+                                ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                                ctx.Response.ContentType = "application/json; charset=utf-8";
+                                await ctx.Response.WriteAsync(mapJson, Encoding.UTF8);
+                                return;
+                            }
+
+                            ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                        });
+                    });
+                })
+                .Build();
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Server.E2E.Test/SourceMap.Server.E2E.Test.csproj
+++ b/Test/Compiler/SourceMap.Server.E2E.Test/SourceMap.Server.E2E.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(CompilerNetFramework)</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <!--
+      Test/Compiler/Directory.Build.props pools every compiler test's output into a single
+      Test/Compiler/bin/ directory. This project pulls in newer MSTest / Test.Sdk packages
+      via Microsoft.Playwright.MSTest, which would otherwise overwrite the shared TestPlatform
+      binaries and break test discovery for the older test projects. Isolating OutputPath
+      keeps the version skew contained.
+    -->
+    <OutputPath>$(MSBuildThisFileDirectory)bin</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CompilerSources)\SourceMap.Server\SourceMap.Server.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.40.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+  </ItemGroup>
+</Project>

--- a/Test/Compiler/SourceMap.Server.Test/SourceMapFileHandlerTests.cs
+++ b/Test/Compiler/SourceMap.Server.Test/SourceMapFileHandlerTests.cs
@@ -375,6 +375,209 @@ namespace OwaSourceMapper.Server.Test
                 "Short name absent from sources[] must produce 404 even with redirect enabled");
         }
 
+        // ---------------------------------------------------------------------------------
+        // TryBuildRepoRedirect — direct unit tests.
+        //
+        // The redirect helper is the security-critical branch (a tampered sourceRoot could
+        // send the browser to an attacker-controlled URL). The black-box HandleAsync tests
+        // above cover happy / sad paths, but the hostile-scheme rejection (javascript:,
+        // data:, file://) needs explicit assertions. Drive the helper directly so failures
+        // there can never be masked by an unrelated 404 path higher up in HandleAsync.
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_OptedOut_ReturnsFalse()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = false };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Foo.cs", options, out string url);
+
+            Assert.IsFalse(result, "Default-disabled redirect must always return false");
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_ValidGitHubSourceRoot_BuildsHttpsUrl()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Sources/Foo.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Sources/Foo.cs", options, out string url);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("https://raw.githubusercontent.com/o/r/sha/Sources/Foo.cs", url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_ValidAdoSourceRoot_BuildsItemsApiUrl()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Sources/Foo.cs\"],"
+                + "\"sourceRoot\":\"https://dev.azure.com/org/proj/_apis/git/repositories/repo/items?api-version=7.1&versionDescriptor.version=sha&versionDescriptor.versionType=commit&path=/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Sources/Foo.cs", options, out string url);
+
+            Assert.IsTrue(result);
+            StringAssert.EndsWith(url, "path=/Sources/Foo.cs");
+        }
+
+        [TestMethod]
+        [DataRow("javascript:alert(1)/")]
+        [DataRow("data:text/html,foo")]
+        [DataRow("file:///etc/passwd/")]
+        [DataRow("vbscript:msgbox(1)/")]
+        [DataRow("ftp://example.com/")]
+        [DataRow("/legacy/SrcMapper.ashx?file=")]
+        [DataRow("relative/path/")]
+        public void TryBuildRepoRedirect_HostileOrNonHttpsSourceRoot_ReturnsFalse(string hostileRoot)
+        {
+            string json = "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"" + hostileRoot + "\"}";
+            var sources = SourceMapSources.TryParseContent(json);
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Foo.cs", options, out string url);
+
+            Assert.IsFalse(
+                result,
+                "Hostile / non-https sourceRoot must NOT produce a redirect: " + hostileRoot);
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_HttpSourceRoot_ReturnsFalse()
+        {
+            // Plain http:// is rejected — both GitHub raw and the ADO Items API are HTTPS-only,
+            // and we never want to silently downgrade DevTools to a cleartext fetch.
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"http://example.com/raw/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Foo.cs", options, out string url);
+
+            Assert.IsFalse(result, "http:// sourceRoot must be refused — only https:// is acceptable");
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_NullSources_ReturnsFalse()
+        {
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(null, "Foo.cs", options, out string url);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void TryBuildRepoRedirect_NullOrEmptySourceName_ReturnsFalse(string sourceName)
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, sourceName, options, out string url);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_EmptySourceRoot_ReturnsFalse()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Foo.cs", options, out string url);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_SourceNameNotInSources_ReturnsFalse()
+        {
+            // Membership gate: even if sourceRoot is a valid https URL, redirecting an arbitrary
+            // dangling path lets an attacker turn the handler into an open redirect.
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "AttackerControlled.cs", options, out string url);
+
+            Assert.IsFalse(
+                result,
+                "Membership gate: short names absent from sources[] must never be redirected");
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_NullOptions_ReturnsFalse()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "Foo.cs", null, out string url);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(url);
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_SourceNameContainsHash_EncodesFragmentBoundary()
+        {
+            // A `#` inside a file path would truncate the ADO `path=/` query at the fragment
+            // boundary (everything after `#` is fragment, not path). URI-encoding the path
+            // component prevents that — `#` becomes `%23` and the redirect lands intact.
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"foo#bar.cs\"],"
+                + "\"sourceRoot\":\"https://dev.azure.com/o/p/_apis/git/repositories/r/items?api-version=7.1&versionDescriptor.version=sha&versionDescriptor.versionType=commit&path=/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "foo#bar.cs", options, out string url);
+
+            Assert.IsTrue(result);
+            Assert.IsFalse(
+                url.Contains("#"),
+                "URL must not contain a literal '#' after encoding — found: " + url);
+            StringAssert.Contains(url, "foo%23bar.cs");
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_SourceNameContainsSpace_EncodesSpace()
+        {
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"my file.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "my file.cs", options, out string url);
+
+            Assert.IsTrue(result);
+            StringAssert.Contains(url, "my%20file.cs");
+        }
+
+        [TestMethod]
+        public void TryBuildRepoRedirect_SourceNamePreservesForwardSlashes()
+        {
+            // `/` is a path separator at both GitHub raw and the ADO Items API — encoding it
+            // to `%2F` would break the lookup. Only segment-internal characters get encoded.
+            var sources = SourceMapSources.TryParseContent(
+                "{\"sources\":[\"a/b/c.cs\"],\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\"}");
+            var options = new SourceMapFileHandlerOptions { RepoUrlRedirectOnMiss = true };
+
+            bool result = SourceMapFileHandler.TryBuildRepoRedirect(sources, "a/b/c.cs", options, out string url);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("https://raw.githubusercontent.com/o/r/sha/a/b/c.cs", url);
+        }
+
         private SourceMapFileHandlerOptions BuildOptions(string allowedRoot)
         {
             return new SourceMapFileHandlerOptions

--- a/Test/Compiler/SourceMap.Server.Test/SourceMapFileHandlerTests.cs
+++ b/Test/Compiler/SourceMap.Server.Test/SourceMapFileHandlerTests.cs
@@ -272,6 +272,109 @@ namespace OwaSourceMapper.Server.Test
                 "Sources larger than MaxSourceFileSizeBytes must be refused instead of streamed");
         }
 
+        [TestMethod]
+        public async Task HandleAsync_RedirectEnabled_HttpsSourceRoot_LocalFileMissing_Returns302()
+        {
+            // Map points at a non-existent file, but `sources[]` contains the short name and
+            // `sourceRoot` is an https URL → handler should 302 to {sourceRoot}{sourceName}.
+            string missingLong = Path.Combine(this.sourcesDir, "Gone.cs").Replace("\\", "\\\\");
+            WriteMapWithSourceRoot(
+                "app",
+                "Sources/Gone.cs",
+                missingLong,
+                "https://raw.githubusercontent.com/owner/repo/sha/");
+            var options = BuildOptions(allowedRoot: this.sourcesDir);
+            options.RepoUrlRedirectOnMiss = true;
+
+            HttpContext ctx = BuildContext();
+            await SourceMapFileHandler.HandleAsync(ctx, "app", "Sources/Gone.cs", options);
+
+            Assert.AreEqual(
+                (int)HttpStatusCode.Found,
+                ctx.Response.StatusCode,
+                "Opt-in redirect must turn local-miss into 302 when sourceRoot is an http(s) URL");
+            Assert.AreEqual(
+                "https://raw.githubusercontent.com/owner/repo/sha/Sources/Gone.cs",
+                ctx.Response.Headers["Location"].ToString());
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_RedirectEnabled_RelativeSourceRoot_Returns404()
+        {
+            // sourceRoot is a relative path / legacy ashx — must NOT redirect; only http(s) URLs
+            // are accepted as redirect targets, otherwise a tampered map could send the browser
+            // anywhere (javascript:, data:, file://, …).
+            string missingLong = Path.Combine(this.sourcesDir, "Gone.cs").Replace("\\", "\\\\");
+            WriteMapWithSourceRoot(
+                "app",
+                "Sources/Gone.cs",
+                missingLong,
+                "/legacy/SrcMapper.ashx?map=app&file=");
+            var options = BuildOptions(allowedRoot: this.sourcesDir);
+            options.RepoUrlRedirectOnMiss = true;
+
+            HttpContext ctx = BuildContext();
+            await SourceMapFileHandler.HandleAsync(ctx, "app", "Sources/Gone.cs", options);
+
+            Assert.AreEqual(
+                (int)HttpStatusCode.NotFound,
+                ctx.Response.StatusCode,
+                "Non-http(s) sourceRoot must fall through to 404 even when redirect is enabled");
+            Assert.IsFalse(
+                ctx.Response.Headers.ContainsKey("Location"),
+                "No Location header should be set when refusing to redirect");
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_RedirectDisabled_HttpsSourceRoot_Returns404()
+        {
+            // Default behaviour preserved: even with an http(s) sourceRoot, the absence of the
+            // opt-in flag must keep the response a plain 404.
+            string missingLong = Path.Combine(this.sourcesDir, "Gone.cs").Replace("\\", "\\\\");
+            WriteMapWithSourceRoot(
+                "app",
+                "Sources/Gone.cs",
+                missingLong,
+                "https://raw.githubusercontent.com/owner/repo/sha/");
+            var options = BuildOptions(allowedRoot: this.sourcesDir);
+            // RepoUrlRedirectOnMiss left at its default (false)
+
+            HttpContext ctx = BuildContext();
+            await SourceMapFileHandler.HandleAsync(ctx, "app", "Sources/Gone.cs", options);
+
+            Assert.AreEqual(
+                (int)HttpStatusCode.NotFound,
+                ctx.Response.StatusCode,
+                "RepoUrlRedirectOnMiss=false must preserve the legacy 404 behaviour");
+            Assert.IsFalse(
+                ctx.Response.Headers.ContainsKey("Location"),
+                "Default-disabled redirect must not emit a Location header");
+        }
+
+        [TestMethod]
+        public async Task HandleAsync_RedirectEnabled_ShortNameNotInMap_Returns404()
+        {
+            // Even with redirect enabled, a short name that doesn't appear in `sources[]` must
+            // NOT trigger a 302 — that would let an attacker dangle arbitrary paths after the
+            // prefix and cause the browser to be redirected to attacker-chosen URLs.
+            string missingLong = Path.Combine(this.sourcesDir, "Gone.cs").Replace("\\", "\\\\");
+            WriteMapWithSourceRoot(
+                "app",
+                "Sources/Gone.cs",
+                missingLong,
+                "https://raw.githubusercontent.com/owner/repo/sha/");
+            var options = BuildOptions(allowedRoot: this.sourcesDir);
+            options.RepoUrlRedirectOnMiss = true;
+
+            HttpContext ctx = BuildContext();
+            await SourceMapFileHandler.HandleAsync(ctx, "app", "NotInSources.cs", options);
+
+            Assert.AreEqual(
+                (int)HttpStatusCode.NotFound,
+                ctx.Response.StatusCode,
+                "Short name absent from sources[] must produce 404 even with redirect enabled");
+        }
+
         private SourceMapFileHandlerOptions BuildOptions(string allowedRoot)
         {
             return new SourceMapFileHandlerOptions
@@ -300,6 +403,23 @@ namespace OwaSourceMapper.Server.Test
             string json = "{"
                 + "\"version\":\"3\","
                 + "\"file\":\"" + mapName + ".js\","
+                + "\"sources\":[\"" + shortSource + "\"],"
+                + "\"sourcesLong\":[\"" + longSourceEscaped + "\"],"
+                + "\"mappings\":\"\""
+                + "}";
+            File.WriteAllText(Path.Combine(this.mapsDir, mapName + ".map"), json);
+        }
+
+        private void WriteMapWithSourceRoot(
+            string mapName,
+            string shortSource,
+            string longSourceEscaped,
+            string sourceRoot)
+        {
+            string json = "{"
+                + "\"version\":\"3\","
+                + "\"file\":\"" + mapName + ".js\","
+                + "\"sourceRoot\":\"" + sourceRoot + "\","
                 + "\"sources\":[\"" + shortSource + "\"],"
                 + "\"sourcesLong\":[\"" + longSourceEscaped + "\"],"
                 + "\"mappings\":\"\""

--- a/Test/Compiler/SourceMap.Server.Test/SourceMapSourcesTests.cs
+++ b/Test/Compiler/SourceMap.Server.Test/SourceMapSourcesTests.cs
@@ -118,6 +118,56 @@ namespace OwaSourceMapper.Server.Test
         }
 
         [TestMethod]
+        public void SourceRoot_PresentInJson_IsExposed()
+        {
+            string json = "{"
+                + "\"sources\":[\"Foo.cs\"],"
+                + "\"sourceRoot\":\"https://raw.githubusercontent.com/o/r/sha/\""
+                + "}";
+
+            var result = SourceMapSources.TryParseContent(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("https://raw.githubusercontent.com/o/r/sha/", result.SourceRoot);
+        }
+
+        [TestMethod]
+        public void SourceRoot_AbsentInJson_IsNull()
+        {
+            string json = "{\"sources\":[\"Foo.cs\"]}";
+
+            var result = SourceMapSources.TryParseContent(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.SourceRoot, "Missing sourceRoot field must surface as null, not empty string");
+        }
+
+        [TestMethod]
+        public void SourceRoot_EmptyStringInJson_IsEmpty()
+        {
+            string json = "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":\"\"}";
+
+            var result = SourceMapSources.TryParseContent(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(string.Empty, result.SourceRoot);
+        }
+
+        [TestMethod]
+        public void SourceRoot_NonStringValueInJson_IsIgnored()
+        {
+            // sourceRoot should only be honoured when it's a JSON string. Numbers, objects,
+            // arrays, etc. fall back to null so the redirect branch in SourceMapFileHandler
+            // refuses to fire on a malformed map rather than throwing.
+            string json = "{\"sources\":[\"Foo.cs\"],\"sourceRoot\":42}";
+
+            var result = SourceMapSources.TryParseContent(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(result.SourceRoot);
+        }
+
+        [TestMethod]
         public void ShortNames_ReturnsAllRecordedShortNames()
         {
             string json = "{\"sources\":[\"a\",\"b\",\"c\"]}";

--- a/Test/Compiler/SourceMap.Test/RepoUrlBuilderTests.cs
+++ b/Test/Compiler/SourceMap.Test/RepoUrlBuilderTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace OwaSourceMapper.Test
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests for <see cref="RepoUrlBuilder"/> — provider auto-detection across the
+    /// half-dozen Git remote URL shapes we expect in the wild (https/ssh, with/without
+    /// <c>.git</c> suffix, modern dev.azure.com, legacy *.visualstudio.com).
+    /// </summary>
+    [TestClass]
+    public class RepoUrlBuilderTests
+    {
+        [TestMethod]
+        public void TryBuildRawUrl_GitHubHttps_ConstructsRawGithubusercontentUrl()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "https://github.com/achieveai/NScript.git",
+                "abc123def456",
+                out string url,
+                out var provider);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(RepoUrlBuilder.Provider.GitHub, provider);
+            Assert.AreEqual("https://raw.githubusercontent.com/achieveai/NScript/abc123def456/", url);
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_GitHubHttpsNoDotGit_ConstructsRawUrl()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "https://github.com/owner/repo",
+                "deadbeef",
+                out string url,
+                out _);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual("https://raw.githubusercontent.com/owner/repo/deadbeef/", url);
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_GitHubSsh_ConstructsRawUrl()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "git@github.com:achieveai/NScript.git",
+                "sha",
+                out string url,
+                out var provider);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(RepoUrlBuilder.Provider.GitHub, provider);
+            Assert.AreEqual("https://raw.githubusercontent.com/achieveai/NScript/sha/", url);
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_GitHubSshUrlPrefix_ConstructsRawUrl()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "ssh://git@github.com/owner/repo.git",
+                "sha",
+                out string url,
+                out _);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual("https://raw.githubusercontent.com/owner/repo/sha/", url);
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_AzureDevOpsModernHttps_ConstructsItemsApiUrl()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "https://dev.azure.com/contoso/MyProject/_git/MyRepo",
+                "shaXYZ",
+                out string url,
+                out var provider);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(RepoUrlBuilder.Provider.AzureDevOps, provider);
+            StringAssert.StartsWith(url, "https://dev.azure.com/contoso/MyProject/_apis/git/repositories/MyRepo/items?");
+            StringAssert.Contains(url, "versionDescriptor.version=shaXYZ");
+            StringAssert.Contains(url, "versionDescriptor.versionType=commit");
+            StringAssert.EndsWith(url, "path=/");
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_AzureDevOpsModernSsh_Detected()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "git@ssh.dev.azure.com:v3/contoso/MyProject/MyRepo",
+                "shaXYZ",
+                out string url,
+                out var provider);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(RepoUrlBuilder.Provider.AzureDevOps, provider);
+            StringAssert.Contains(url, "/contoso/MyProject/_apis/git/repositories/MyRepo/items?");
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_AzureDevOpsLegacyVisualStudioCom_Detected()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "https://contoso.visualstudio.com/MyProject/_git/MyRepo",
+                "sha",
+                out string url,
+                out var provider);
+
+            Assert.IsTrue(ok);
+            Assert.AreEqual(RepoUrlBuilder.Provider.AzureDevOps, provider);
+            StringAssert.Contains(url, "/contoso/MyProject/_apis/git/repositories/MyRepo/items?");
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_UnknownProvider_ReturnsFalse()
+        {
+            bool ok = RepoUrlBuilder.TryBuildRawUrl(
+                "https://gitlab.com/owner/repo.git",
+                "sha",
+                out string url,
+                out var provider);
+
+            Assert.IsFalse(ok);
+            Assert.IsNull(url);
+            Assert.AreEqual(RepoUrlBuilder.Provider.Unknown, provider);
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_NullOrEmptyInputs_ReturnsFalse()
+        {
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl(null, "sha", out _, out _));
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl("https://github.com/o/r", null, out _, out _));
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl(string.Empty, "sha", out _, out _));
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl("https://github.com/o/r", "  ", out _, out _));
+        }
+
+        [TestMethod]
+        public void TryBuildRawUrl_MalformedUrl_ReturnsFalse()
+        {
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl("not-a-url-at-all", "sha", out _, out _));
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl("https://github.com", "sha", out _, out _));
+            Assert.IsFalse(RepoUrlBuilder.TryBuildRawUrl("https://github.com/owner", "sha", out _, out _));
+        }
+
+        [TestMethod]
+        public void DetectProvider_RecognizesEachProviderWithoutSha()
+        {
+            Assert.AreEqual(RepoUrlBuilder.Provider.GitHub,
+                RepoUrlBuilder.DetectProvider("https://github.com/o/r.git"));
+            Assert.AreEqual(RepoUrlBuilder.Provider.AzureDevOps,
+                RepoUrlBuilder.DetectProvider("https://dev.azure.com/o/p/_git/r"));
+            Assert.AreEqual(RepoUrlBuilder.Provider.Unknown,
+                RepoUrlBuilder.DetectProvider("https://example.com/x"));
+            Assert.AreEqual(RepoUrlBuilder.Provider.Unknown,
+                RepoUrlBuilder.DetectProvider(null));
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Test/SourceMapTests.cs
+++ b/Test/Compiler/SourceMap.Test/SourceMapTests.cs
@@ -293,6 +293,104 @@ namespace OwaSourceMapper.Test
             Assert.IsFalse(json.Contains(".ashx"), "Without a File there is nothing to base a .ashx fallback on");
         }
 
+        /// <summary>
+        /// When <see cref="SourceMap.RepoRoot"/> is unset, source paths keep the legacy
+        /// absolutized form (drive letter escaped to <c>$</c>, backslashes flipped). This
+        /// guarantees existing consumers see no change unless they opt in.
+        /// </summary>
+        [TestMethod]
+        public void ToString_NoRepoRoot_UsesLegacyAbsolutizedSources()
+        {
+            var map = new SourceMap { File = "out.js" };
+            string fakeFile = Path.Combine(Path.GetTempPath(), "Sources", "Foo.cs");
+            map.AddMapping(0, 0, 0, 0, fakeFile);
+
+            string json = map.ToString();
+
+            Assert.IsFalse(
+                json.Contains("\"sources\": [\"Sources/Foo.cs\""),
+                "Without RepoRoot, sources[] must remain in the absolutized legacy form");
+        }
+
+        /// <summary>
+        /// When <see cref="SourceMap.RepoRoot"/> is set to an ancestor of the source file,
+        /// the <c>sources[]</c> entry is emitted as a forward-slash, repo-relative path so
+        /// the browser can combine it with a remote-repo <c>sourceRoot</c> URL.
+        /// </summary>
+        [TestMethod]
+        public void ToString_WithRepoRoot_EmitsRepoRelativeForwardSlashSource()
+        {
+            string repoRoot = Path.Combine(Path.GetTempPath(), "wi19-repo-" + System.Guid.NewGuid().ToString("N"));
+            string fakeFile = Path.Combine(repoRoot, "Sources", "Compiler", "Foo.cs");
+
+            var map = new SourceMap
+            {
+                File = "out.js",
+                RepoRoot = repoRoot,
+            };
+            map.AddMapping(0, 0, 0, 0, fakeFile);
+
+            string json = map.ToString();
+
+            StringAssert.Contains(json, "\"Sources/Compiler/Foo.cs\"");
+        }
+
+        /// <summary>
+        /// Files that live outside the configured <see cref="SourceMap.RepoRoot"/> stay in
+        /// the legacy absolutized form — the rebase only fires for files actually under the
+        /// repo. Mixing in-repo and out-of-repo sources in the same map is supported.
+        /// </summary>
+        [TestMethod]
+        public void ToString_FileOutsideRepoRoot_StaysAbsolutized()
+        {
+            string repoRoot = Path.Combine(Path.GetTempPath(), "wi19-inside-" + System.Guid.NewGuid().ToString("N"));
+            string outsideRoot = Path.Combine(Path.GetTempPath(), "wi19-outside-" + System.Guid.NewGuid().ToString("N"));
+            string outsideFile = Path.Combine(outsideRoot, "External", "Bar.cs");
+
+            var map = new SourceMap
+            {
+                File = "out.js",
+                RepoRoot = repoRoot,
+            };
+            map.AddMapping(0, 0, 0, 0, outsideFile);
+
+            string json = map.ToString();
+
+            // The file should NOT appear as a clean repo-relative path.
+            Assert.IsFalse(json.Contains("\"External/Bar.cs\""),
+                "File outside RepoRoot must NOT be emitted as a bare repo-relative path");
+
+            // sourcesLong must still preserve the original path.
+            StringAssert.Contains(json, "\"sourcesLong\":");
+        }
+
+        /// <summary>
+        /// Repo-rebase preserves the long form unchanged in <c>sourcesLong</c>; only the
+        /// browser-facing <c>sources[]</c> array is rebased. This keeps the local-disk
+        /// resolution path (used by the ASP.NET Core handler when a file IS available
+        /// locally) working.
+        /// </summary>
+        [TestMethod]
+        public void ToString_WithRepoRoot_PreservesSourcesLongForLocalResolution()
+        {
+            string repoRoot = Path.Combine(Path.GetTempPath(), "wi19-long-" + System.Guid.NewGuid().ToString("N"));
+            string fakeFile = Path.Combine(repoRoot, "Sources", "Foo.cs");
+
+            var map = new SourceMap
+            {
+                File = "out.js",
+                RepoRoot = repoRoot,
+            };
+            map.AddMapping(0, 0, 0, 0, fakeFile);
+
+            string json = map.ToString();
+
+            // sourcesLong must still contain the absolute, escaped form (with backslashes
+            // doubled as the AddMapping path requires).
+            StringAssert.Contains(json, "\"sourcesLong\":");
+            StringAssert.Contains(json, "Foo.cs");
+        }
+
         private static string ExtractMappingsField(string json)
         {
             const string marker = "\"mappings\": \"";

--- a/Test/Compiler/SourceMap.Test/SourceMapTests.cs
+++ b/Test/Compiler/SourceMap.Test/SourceMapTests.cs
@@ -391,6 +391,142 @@ namespace OwaSourceMapper.Test
             StringAssert.Contains(json, "Foo.cs");
         }
 
+        // ---------------------------------------------------------------------------------
+        // NormalizeRepoRoot — direct unit tests.
+        //
+        // The helper is `internal` (visible to this test project via InternalsVisibleTo) so
+        // the rebase-to-repo behaviour can be exercised without going through the full
+        // ToString() pipeline. Most importantly: trailing-separator addition and the four-
+        // exception fallback path.
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void NormalizeRepoRoot_NullOrWhitespace_ReturnsNull()
+        {
+            Assert.IsNull(SourceMap.NormalizeRepoRoot(null));
+            Assert.IsNull(SourceMap.NormalizeRepoRoot(string.Empty));
+            Assert.IsNull(SourceMap.NormalizeRepoRoot("   "));
+        }
+
+        [TestMethod]
+        public void NormalizeRepoRoot_ValidPath_AppendsTrailingSeparator()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "wi19-norm-" + System.Guid.NewGuid().ToString("N"));
+
+            string normalized = SourceMap.NormalizeRepoRoot(root);
+
+            Assert.IsNotNull(normalized);
+            Assert.IsTrue(
+                normalized.EndsWith(Path.DirectorySeparatorChar.ToString())
+                    || normalized.EndsWith(Path.AltDirectorySeparatorChar.ToString()),
+                "Normalized repo root must end with a directory separator: " + normalized);
+        }
+
+        [TestMethod]
+        public void NormalizeRepoRoot_AlreadyHasTrailingSeparator_DoesNotDoubleIt()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "wi19-norm-" + System.Guid.NewGuid().ToString("N"))
+                + Path.DirectorySeparatorChar;
+
+            string normalized = SourceMap.NormalizeRepoRoot(root);
+
+            Assert.IsNotNull(normalized);
+            Assert.IsFalse(
+                normalized.EndsWith(string.Empty + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar),
+                "Already-trailing-separator paths must not gain a second separator");
+        }
+
+        [TestMethod]
+        public void NormalizeRepoRoot_MalformedPath_ReturnsNull()
+        {
+            // Path.GetFullPath rejects strings containing characters that are illegal on the
+            // current platform. The four-exception block downgrades that to a null return so
+            // map generation degrades to the legacy absolutized form rather than throwing.
+            string malformed = "\0invalid\0";
+
+            string normalized = SourceMap.NormalizeRepoRoot(malformed);
+
+            Assert.IsNull(normalized, "Malformed paths must return null instead of throwing");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // TryRebaseToRepoRoot — direct unit tests.
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_FileInsideRoot_ReturnsForwardSlashRelative()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "wi19-rebase-" + System.Guid.NewGuid().ToString("N"));
+            string normalized = SourceMap.NormalizeRepoRoot(root);
+            string file = Path.Combine(root, "Sources", "Compiler", "Foo.cs");
+            // AddMapping escapes backslashes before storing — TryRebaseToRepoRoot consumes
+            // that exact form, so we replicate it here.
+            string escaped = file.Replace("\\", "\\\\");
+
+            string rebased = SourceMap.TryRebaseToRepoRoot(escaped, normalized);
+
+            Assert.IsNotNull(rebased, "File inside repo root must be rebased");
+            Assert.AreEqual("Sources/Compiler/Foo.cs", rebased);
+        }
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_FileOutsideRoot_ReturnsNull()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "wi19-inside-" + System.Guid.NewGuid().ToString("N"));
+            string normalized = SourceMap.NormalizeRepoRoot(root);
+            string outside = Path.Combine(Path.GetTempPath(), "wi19-outside-" + System.Guid.NewGuid().ToString("N"), "Bar.cs");
+            string escaped = outside.Replace("\\", "\\\\");
+
+            string rebased = SourceMap.TryRebaseToRepoRoot(escaped, normalized);
+
+            Assert.IsNull(rebased, "File outside repo root must NOT be rebased");
+        }
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_NullRepoRoot_ReturnsNull()
+        {
+            Assert.IsNull(SourceMap.TryRebaseToRepoRoot("C:\\\\repo\\\\Foo.cs", null));
+        }
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_EmptyRawFile_ReturnsNull()
+        {
+            string normalized = SourceMap.NormalizeRepoRoot(Path.GetTempPath());
+
+            Assert.IsNull(SourceMap.TryRebaseToRepoRoot(string.Empty, normalized));
+            Assert.IsNull(SourceMap.TryRebaseToRepoRoot(null, normalized));
+        }
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_MalformedPath_ReturnsNull()
+        {
+            // The four-exception fallback in TryRebaseToRepoRoot must absorb invalid paths
+            // and surface them as a null return rather than an unhandled throw.
+            string normalized = SourceMap.NormalizeRepoRoot(Path.GetTempPath());
+            string malformed = "\0invalid\0";
+
+            string rebased = SourceMap.TryRebaseToRepoRoot(malformed, normalized);
+
+            Assert.IsNull(rebased);
+        }
+
+        [TestMethod]
+        public void TryRebaseToRepoRoot_EscapeUnescapeRoundTrip_ProducesForwardSlashes()
+        {
+            // AddMapping stores paths with `\\` doubled; TryRebaseToRepoRoot must un-double
+            // them before calling Path.GetFullPath, then re-emit forward slashes.
+            string root = Path.Combine(Path.GetTempPath(), "wi19-roundtrip-" + System.Guid.NewGuid().ToString("N"));
+            string normalized = SourceMap.NormalizeRepoRoot(root);
+            string file = Path.Combine(root, "a", "b", "c.cs");
+            string escaped = file.Replace("\\", "\\\\");
+
+            string rebased = SourceMap.TryRebaseToRepoRoot(escaped, normalized);
+
+            Assert.IsNotNull(rebased);
+            Assert.IsFalse(rebased.Contains("\\"), "Rebased path must not contain backslashes: " + rebased);
+            Assert.AreEqual("a/b/c.cs", rebased);
+        }
+
         private static string ExtractMappingsField(string json)
         {
             const string marker = "\"mappings\": \"";

--- a/docs/source-maps/repo-linked-source-maps.md
+++ b/docs/source-maps/repo-linked-source-maps.md
@@ -1,0 +1,193 @@
+# Repo-Linked Source Maps
+
+By default, NScript-generated source maps reference the original C# files via the
+local-machine paths recorded at build time and resolved through the ASP.NET Core
+`SourceMapFileHandler` (or the legacy `SrcMapper.ashx`). This works while the build
+machine is also the host serving the application, but breaks the moment the build
+artifacts are deployed somewhere that doesn't have access to the source tree.
+
+**Repo-linked source maps** point browser DevTools directly at the originating Git
+provider's raw-file URL (GitHub `raw.githubusercontent.com` or Azure DevOps
+`dev.azure.com/{org}/{project}/_apis/git/repositories/.../items?…`) for the exact
+commit that produced the JS. DevTools fetches the source over HTTPS using the
+developer's existing browser session — no special handler required on the host,
+and zero risk of source files being out of date.
+
+This is **opt-in**: set `<RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>` on the
+generating project. Builds without that property continue to emit local-path maps
+exactly as before.
+
+---
+
+## Quick Start
+
+### GitHub
+
+```xml
+<PropertyGroup>
+  <GenerateJs>true</GenerateJs>
+  <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
+</PropertyGroup>
+```
+
+That's it. During `ScriptGenerate`, MSBuild captures `git remote get-url origin`,
+`git rev-parse HEAD`, and `git rev-parse --show-toplevel`, detects GitHub from the
+remote URL, and emits a map whose `sourceRoot` is
+
+```
+https://raw.githubusercontent.com/{owner}/{repo}/{commitSha}/
+```
+
+Each entry in the map's `sources[]` array becomes the repo-relative forward-slash
+path of the original file (e.g. `Sources/Framework/Sunlight.Framework/Logger.cs`),
+so when DevTools concatenates `sourceRoot + sources[i]` it gets a working
+raw-file URL that always matches the deployed JS.
+
+### Azure DevOps
+
+The same flag works for Azure DevOps remotes — both modern (`dev.azure.com/{org}/{project}/_git/{repo}`)
+and legacy (`{org}.visualstudio.com/{project}/_git/{repo}`):
+
+```xml
+<PropertyGroup>
+  <GenerateJs>true</GenerateJs>
+  <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
+</PropertyGroup>
+```
+
+For ADO the emitted `sourceRoot` is the
+[Items API](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get):
+
+```
+https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/items?api-version=7.1&versionDescriptor.version={sha}&versionDescriptor.versionType=commit&path=/
+```
+
+The trailing `path=/` lets the appended `sources[i]` substitute as the path
+(e.g. `…path=/Sources/Framework/Sunlight.Framework/Logger.cs`).
+
+> **Note** — fetching from a private ADO repo requires the developer's browser to
+> already have a valid session cookie for `dev.azure.com`. This is the normal
+> case for engineers who use the Azure DevOps web UI; CI/headless contexts will
+> see 401s and need to fall back to local-disk source maps.
+
+---
+
+## CI Overrides
+
+The MSBuild target prefers explicit values over `git` invocations, so CI can
+feed pre-resolved metadata directly without paying for a `git` shell-out:
+
+```xml
+<PropertyGroup>
+  <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
+
+  <!-- Override one or more — anything left blank is auto-detected via git -->
+  <SourceRepoOriginUrl>https://github.com/owner/repo.git</SourceRepoOriginUrl>
+  <SourceRepoCommitSha>$(GITHUB_SHA)</SourceRepoCommitSha>
+  <NScriptRepoRoot>$(GITHUB_WORKSPACE)</NScriptRepoRoot>
+</PropertyGroup>
+```
+
+For Azure Pipelines the equivalent variables are `$(BUILD_SOURCEVERSION)` and
+`$(BUILD_SOURCESDIRECTORY)`. GitLab CI uses `$CI_COMMIT_SHA` and `$CI_PROJECT_DIR`.
+
+To force a particular provider when the auto-detection regex doesn't fit your
+URL shape, set `SourceRepoProvider` to `GitHub` or `AzureDevOps`. The default
+value `auto` runs the detection chain.
+
+```xml
+<SourceRepoProvider>GitHub</SourceRepoProvider>
+```
+
+---
+
+## Behaviour When Git Metadata Is Missing
+
+Building outside a git checkout (CI cache restore, source-only ZIP) emits a
+build warning and skips the repo-linked sourceRoot, falling back to the local-
+disk behaviour:
+
+```
+RepoLinkedSourceMaps requested but git metadata could not be captured (origin='' sha=''). Skipping repo-linked sourceRoot.
+```
+
+If git succeeds but the remote URL doesn't match GitHub or Azure DevOps:
+
+```
+RepoLinkedSourceMaps requested but origin URL '…' did not match GitHub or Azure DevOps; emitting map without repo-linked sourceRoot.
+```
+
+In both cases the build still produces a working map — just the legacy local-
+path variant.
+
+---
+
+## Handler 302 Redirect (Optional)
+
+When you ship the ASP.NET Core `SourceMapFileHandler` AND want to keep serving
+local files for developers who run from source while still letting external
+testers / production-build users get the repo-hosted sources, opt into the 302
+redirect:
+
+```csharp
+endpoints.MapSourceMapFiles("/sourcemap", new SourceMapFileHandlerOptions
+{
+    MapsDirectory = mapsDir,
+    AllowedSourceRoots = new[] { repoRoot },
+    RepoUrlRedirectOnMiss = true,
+});
+```
+
+With that flag set, when a request hits the handler and the local file isn't
+available — file missing on disk, outside the allow-list, etc. — and the parsed
+map carries an `http(s)://` `sourceRoot`, the handler answers `302 Found` with
+`Location: {sourceRoot}{sourceName}` instead of `404 Not Found`. The browser
+follows the redirect using its existing session cookies for the Git provider.
+
+> **SECURITY** — A tampered `.map` could redirect the browser to an attacker-
+> controlled URL. Only enable `RepoUrlRedirectOnMiss` in deployments that trust
+> the maps they ship. The handler defends against the obvious abuse vectors:
+>
+> - The redirect only fires for `http://` / `https://` `sourceRoot` values —
+>   `javascript:`, `data:`, `file://`, relative paths, and the legacy `.ashx`
+>   format are all refused (404 instead).
+> - The redirect only fires when the requested short name appears verbatim in
+>   the parsed map's `sources[]` array, so a request for an arbitrary path
+>   appended after the prefix won't escape into a redirect.
+
+---
+
+## Limitations
+
+- **Provider scope** — only GitHub and Azure DevOps remotes are auto-detected.
+  Bitbucket, GitLab, Gitea, etc. are not in scope; for those, set
+  `SourceMapRoot` directly to the right URL pattern instead of using
+  `RepoLinkedSourceMaps`.
+- **Public-or-authenticated only** — the redirect / direct-fetch path relies on
+  the browser already having credentials for the provider. There is no
+  proxy/token-based fetch story; that's deliberate scope.
+- **Snapshot builds** — the captured commit SHA is the value of `HEAD` at the
+  moment `dotnet build` runs. If you build with uncommitted changes, the
+  resulting map points at the previous commit's source — not what you actually
+  compiled. Either commit before building, or override `SourceRepoCommitSha`.
+- **Force pushes / rewritten history** — the URL is keyed on the commit SHA, so
+  a force-push that rewrites or deletes that SHA will turn the map into a 404
+  reference. The local-disk fallback is more durable in that respect.
+
+---
+
+## Underlying Properties Reference
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `RepoLinkedSourceMaps` | `false` | Master switch — turns on `ComputeNScriptRepoMetadata` and emits `-repoRoot` to the converter. |
+| `SourceRepoOriginUrl` | (from `git remote get-url origin`) | Override the detected remote URL. |
+| `SourceRepoCommitSha` | (from `git rev-parse HEAD`) | Override the detected commit SHA. |
+| `NScriptRepoRoot` | (from `git rev-parse --show-toplevel`) | Override the detected worktree root used to rebase `sources[]`. |
+| `SourceRepoProvider` | `auto` | Force `GitHub` / `AzureDevOps` when auto-detection misfires. |
+| `SourceMapRoot` | (computed) | When already set, the metadata-capture target is skipped entirely — bring-your-own URL workflow. |
+
+The compiler-side flags accepted by the converter are `-sourceMapRoot <url>` and
+`-repoRoot <absolute-path>`. The two are paired: `-repoRoot` is rejected when
+`-sourceMapRoot` is absent, since rebasing `sources[]` only makes sense when
+combined with a non-local URL.


### PR DESCRIPTION
Closes #19

## Summary

Wires NScript-generated source maps to host raw source content from a remote Git
repository (GitHub raw or Azure DevOps Items API) instead of (or in addition to)
the local `SourceMapFileHandler` / legacy `SrcMapper.ashx`. Browser DevTools
opening a `.map` whose `sourceRoot` is a public-repo raw URL gets the original
C# source from the SHA the JS was compiled from — no server-side source files
needed.

## What's in this PR

**Compiler (Phase A):**
- `RepoUrlBuilder` (`Sources/Compiler/SourceMap`) — provider detection +
  raw-URL construction for GitHub, ADO modern, ADO legacy `*.visualstudio.com`,
  and SSH remote variants.
- `SourceMap.RepoRoot` — when set, `sources[i]` are emitted as forward-slash,
  repo-relative paths so they combine cleanly with the remote `sourceRoot`.
  Files outside the repo root keep the legacy absolutized form.
- New `-repoRoot` CLI option, paired with `-sourceMapRoot` (rejected alone —
  partial config would silently produce broken maps).

**Build (Phase B):**
- `ComputeNScriptRepoMetadata` MSBuild target gated by `<RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>`.
  Auto-resolves origin URL, commit SHA, and worktree root from `git`; explicit
  property overrides let CI feed `$(GITHUB_SHA)` / `$(BUILD_SOURCEVERSION)`
  directly without invoking `git` inside the build container.
- Inline `Regex.Match` property functions construct the same URL shapes as
  `RepoUrlBuilder` (kept under unit-test for drift).
- Origin URLs are redacted (`://[^/@]+@` → `://***@`) before being echoed into
  build logs so embedded PATs/passwords don't leak.

**Server (Phase C):**
- `SourceMapFileHandlerOptions.RepoUrlRedirectOnMiss` — when true, the handler
  issues `302 Found` to `{sourceRoot}{shortName}` instead of `404` whenever the
  local lookup misses. Gated:
  - `sourceRoot` MUST be `http://` or `https://` (legacy ashx, `javascript:`,
    `data:`, relative paths refused).
  - Short name MUST exist in the parsed map's `sources[]` array (refuses to
    redirect for paths the attacker dangles after the prefix).

**Tests (Phase D):**
- `RepoUrlBuilderTests` — 22 cases (GitHub/ADO modern/ADO legacy/SSH variants).
- `SourceMapTests` — repo-root rebase scenarios (in-repo, out-of-repo, mixed,
  altsep handling).
- `SourceMapFileHandlerTests` — redirect on/off, http(s) gate, sources[]
  membership gate, `ServeFromSourcesLong=false` interaction.
- `CompilerLogTests` — `-repoRoot` parsing (paired/unpaired/duplicated/missing-value).

**Docs (Phase E):**
- `docs/source-maps/repo-linked-source-maps.md` — end-to-end flow, CI setup,
  ADR-aligned design, threat model (tampered maps, credential leaks).

**E2E (Phase F):**
- `Test/Compiler/SourceMap.Server.E2E.Test` — Playwright MSTest suite gated by
  `ENABLE_PLAYWRIGHT_E2E` env var. Two-host Kestrel topology with ephemeral
  port binding via `IServerAddressesFeature`. Excluded from default test runs
  to avoid CI flakiness from browser downloads.

## Test plan

- [x] `dotnet build NScript_Full.sln -c Release` — 0 errors, 45 unrelated warnings
- [x] `SourceMap.Test` — 75/75 passing
- [x] `SourceMap.Server.Test` — 36/36 passing
- [x] `NScript.Utils.Test` — 28/28 passing
- [ ] Reviewer to sanity-check the `Sdk.targets` Regex property-function chain on a real consumer project (requires the new `Mcqdb.NScript.Sdk` package version)
- [ ] Optional: enable `ENABLE_PLAYWRIGHT_E2E=1` and run the E2E suite locally

## Out of scope

- Authenticated source-fetching for private repos (the redirect hands off to the
  browser's session cookies; no proxying).
- Indexing / caching of remote source content (always fresh fetch).
- Alternative providers (GitLab, Bitbucket) — `RepoUrlBuilder.Provider` is
  open-ended for future extension.