### PR TITLE
[Gautam's Dev bot] WI-42: author NScript documentation set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _ReSharper*/
 [Tt]est[Rr]esult*.xml
 [Bb]in/
 [Dd]ebug*/
+!docs/debugging/
 [Oo]bj/
 /NScriptToolSet/lib/Microsoft.CSharp.dll
 /NScriptToolSet/lib/Microsoft.CSharp.pdb

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ The following C# features are not supported:
 
 For the latest feature support status, see [csharp8-todos.md](csharp8-todos.md).
 
+## Documentation
+
+Full documentation lives under [`docs/`](docs/README.md). Highlights:
+
+- [Getting started](docs/getting-started/README.md) — first NScript app
+- [Framework reference](docs/framework/sunlight-core.md) — observables, binders, IoC, scheduler
+- [Templates: Razor](docs/templates/razor.md) and [XWML](docs/templates/xwml.md)
+- [Interop attributes](docs/interop/attributes.md) — `[Script]`, `[ImportedType]`, `[JsonType]`, naming
+- [Compiler pipeline](docs/compiler/pipeline.md) and [plugins](docs/compiler/plugins.md)
+- [MSBuild SDK](docs/build/msbuild-sdk.md), [Testing](docs/testing/README.md), [Source maps](docs/debugging/source-maps.md)
+- [Architecture Decision Records](docs/adr/) — 25 accepted ADRs
+
 ## Packages
 
 The NScript project generates 10 NuGet packages:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# NScript Documentation
+
+NScript is a **C# to JavaScript transpiler** plus a runtime framework for client-side web applications. Source C# is compiled by a custom Roslyn-based front end into a DLL with an embedded bound AST, then a second stage (`cs2jsc`) emits the JavaScript. This documentation covers both sides of that contract: how to *write* an NScript application and how the toolchain *processes* it.
+
+## Audience routing
+
+If you are **writing an NScript application**, start with:
+
+1. [Getting started](getting-started/README.md) — prerequisites, first app, day-1 pitfalls
+2. [Framework: Core BCL surface](framework/core.md) — what works in `mscorlib` / `System.Core`
+3. [Framework: Web & DOM](framework/web.md) — `System.Web` and `System.Web.Html`
+4. [Framework: Sunlight Core](framework/sunlight-core.md) — `ObservableObject`, binders, `IoC`, `Logger`, `TaskScheduler`, `CallContext`
+5. [Framework: Sunlight UI](framework/sunlight-ui.md) — `UIElement`, `ListView`, `SkinFactory`, binding-strategy attributes
+6. [Templates: Razor `.skin.cshtml`](templates/razor.md) — modern template frontend
+7. [Templates: XWML (legacy)](templates/xwml.md) — original XML-based templates
+8. [Interop: attributes reference](interop/attributes.md) — every script-attribute you might apply
+9. [Interop: JsonType & ImportedType patterns](interop/json-and-imported-types.md) — typed JS interop
+10. [Interop: dynamic types](interop/dynamic.md) — `System.Dynamic` support level
+11. [Language: limitations & unsupported C# features](language/limitations.md) — what NScript will *not* compile
+12. [Debugging: source maps](debugging/source-maps.md) — debugging generated JS in the browser
+
+If you are **contributing to the NScript toolchain itself**, start with:
+
+1. [Compiler pipeline overview](compiler/pipeline.md) — two-stage architecture, JST, DCE, devirtualization, dedup
+2. [Compiler plugins](compiler/plugins.md) — writing an `IConverterPlugin`
+3. [Build & MSBuild SDK](build/msbuild-sdk.md) — `Mcqdb.NScript.Sdk`, `Directory.Build.props`, package generation
+4. [Testing](testing/README.md) — compiler unit tests vs framework behavioral tests; SunlightUnit
+
+## Status — DoD coverage for #42
+
+| § | Page | Topic |
+|---|------|-------|
+| 1 | [framework/core.md](framework/core.md) | Framework Core (BCL surface) |
+| 2 | [framework/web.md](framework/web.md) | Framework Web & DOM |
+| 3 | [framework/sunlight-core.md](framework/sunlight-core.md) | Sunlight.Framework (core) |
+| 4 | [framework/sunlight-ui.md](framework/sunlight-ui.md) | Sunlight.Framework.UI (controls) |
+| 5 | [templates/razor.md](templates/razor.md) | Razor skin templates + CSS |
+| 6 | [interop/attributes.md](interop/attributes.md) | Interop attributes reference |
+| 7 | [interop/json-and-imported-types.md](interop/json-and-imported-types.md) | JsonType / ImportedType patterns |
+| 8 | [interop/dynamic.md](interop/dynamic.md) | Dynamic types (`System.Dynamic`) |
+| 9 | [templates/xwml.md](templates/xwml.md) | XWML templates (legacy) |
+| 10 | [compiler/pipeline.md](compiler/pipeline.md) | Compiler pipeline overview |
+| 11 | [compiler/plugins.md](compiler/plugins.md) | Plugin architecture |
+| 12 | [build/msbuild-sdk.md](build/msbuild-sdk.md) | Build & MSBuild SDK |
+| 13 | [getting-started/README.md](getting-started/README.md) | Getting started / Hello World |
+| 14 | [language/limitations.md](language/limitations.md) | Limitations & unsupported features |
+| 15 | [testing/README.md](testing/README.md) | Testing |
+| 16 | [debugging/source-maps.md](debugging/source-maps.md) | Debugging & source maps |
+
+## Other documentation in this repo
+
+- [Architecture Decision Records](adr/) — 25 accepted ADRs covering Roslyn fork, pipeline shape, runtime type model, template system, optimization passes
+- [Structured client logging](framework-logging.md) — `Logger`, `ILogSink`, JSON schema, server-side ingestion (Serilog / NLog)
+- [Plans](plans/) — feature plans and execution notes
+
+## Authoring conventions
+
+When extending these docs:
+
+- Use [`_template.md`](_template.md) as the page skeleton.
+- Cross-link to ADRs in `adr/`; do not re-derive recorded decisions.
+- Every code example must compile under NScript's supported C# subset (no `dynamic`, no `yield return`, no reflection, no P/Invoke). See [`language/limitations.md`](language/limitations.md).
+- One H1 per page; H2/H3 below. Filenames are kebab-case.
+- Diagrams: Mermaid first, images only when Mermaid can't express the shape.
+- For logging / property-bag samples, always use `string[]` flat arrays — NScript renames C# field names during minification.

--- a/docs/_template.md
+++ b/docs/_template.md
@@ -1,0 +1,48 @@
+# Page Title
+
+> **Audience:** *App authors* or *Contributors* — pick one.
+
+## TL;DR
+
+3–5 lines. What the reader will be able to do or understand after reading this page.
+
+## Quick start
+
+A small, complete, runnable code snippet. No `// ...` ellipses unless they hide irrelevant boilerplate.
+
+```csharp
+// Concrete example here.
+```
+
+## Reference
+
+The API surface, attribute table, or pipeline diagram for the topic. Tables preferred over prose lists for member-by-member references.
+
+## Examples
+
+2–4 canonical patterns the reader will reach for.
+
+## Known gotchas & limitations
+
+The sharp edges. A docs page that omits these is a docs page that lies.
+
+## Diagnostics
+
+Compiler / runtime messages the reader will see, with the cause of each.
+
+## Cross-links
+
+- Related docs page: `path/to/page.md`
+- ADR: `../adr/NNNN-decision.md`
+
+---
+
+## Authoring conventions
+
+- One H1 (`#`) per page; H2/H3 only below that. No deeper nesting.
+- Cross-link to ADRs in `docs/adr/`; never re-derive a decision recorded there.
+- Every code example must compile under NScript's supported subset (no `dynamic`, no `yield return`, no reflection, no P/Invoke).
+- Diagrams: prefer Mermaid (renders on GitHub). Images only when Mermaid can't express the shape.
+- Attribute reference tables use a uniform shape: **Name | Target | Effect | Example | ADR**.
+- Logging / property-bag examples use `string[]` flat key/value arrays — NScript minifies field names, so anonymous-object property names break in the emitted JS (see `framework-logging.md`).
+- Filenames are kebab-case.

--- a/docs/build/msbuild-sdk.md
+++ b/docs/build/msbuild-sdk.md
@@ -1,0 +1,182 @@
+# MSBuild SDK & build integration
+
+> **Audience:** *App authors* setting up an NScript project; *Contributors* working on the SDK or build pipeline.
+
+## TL;DR
+
+NScript ships an MSBuild SDK (`NScript.Sdk`, packaged as `Mcqdb.NScript.Sdk`) that wires the custom compiler (`csc.cmd`) and the JS-emit step (`nscript.cmd`) into `dotnet build`. A project consumes the SDK by importing `Sdk.props` and `Sdk.targets` (or, in newer projects, via `<Project Sdk="Mcqdb.NScript.Sdk/1.0.4-beta1">`). Setting `<GenerateJs>True</GenerateJs>` triggers the `ScriptGenerate` target after `Build`, which runs `cs2jsc` over the compiled DLL and emits `<AssemblyName>.js` to `<JsOutputPath>`. Release configuration auto-enables `Minify`, `Uglify`, and `JsOptimize`.
+
+## Reference — SDK files
+
+| File | Purpose |
+|---|---|
+| `Sources/Compiler/NScript.Sdk/Sdk/Sdk.props` | Imported early; sets defaults (`OutputType=Library`, `TargetFramework=netstandard2.1`, `NoStandardLib=true`, `JsOutputPath=./`) |
+| `Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets` | Imported late; defines `AfterCompile` → `ScriptGenerate` target chain |
+| `Sources/Compiler/NScript.Sdk/Sdk/csc.cmd` | Wrapper that invokes `JsCsc.exe` with the right toolset path |
+| `Sources/Compiler/NScript.Sdk/Sdk/nscript.cmd` | Wrapper that invokes `cs2jsc.exe` |
+
+## Reference — MSBuild properties
+
+| Property | Default | Purpose |
+|---|---|---|
+| `<GenerateJs>` | `false` | When `True`, run the `ScriptGenerate` target after compile to emit JS |
+| `<JsOutputPath>` | `./` | Output directory for emitted `.js` (and `.map`) |
+| `<NoStandardLib>` | `true` | Don't reference the .NET BCL — NScript uses its own `mscorlib` clone |
+| `<TargetFramework>` | `netstandard2.1` | The custom CSC targets `netstandard2.1` even though NScript output is JS |
+| `<CscToolPath>` | (set by SDK) | Path to NScript's compiler binaries |
+| `<CscToolExe>` | `csc.cmd` (or `csc.exe`) | The compiler entry point |
+| `<NScriptExe>` | `nscript.cmd` | The JS emitter entry point |
+| `<Minify>` | `true` in Release, else `false` | Short-name identifier substitution |
+| `<Uglify>` | `true` in Release, else `false` | Drop comments, whitespace, optional braces |
+| `<JsOptimize>` | `true` in Release, else `false` | Devirtualisation, accessor inlining, function dedup ([ADRs 0023, 0024](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)) |
+| `<SourceMapRoot>` | (unset) | Base path for source-map generation; pass `-sourceMapRoot` to `cs2jsc`. See [debugging/source-maps.md](../debugging/source-maps.md). |
+| `<PluginConfig>` | (unset) | Path to a `PluginConfig.xml` registering converter plugins ([compiler/plugins.md](../compiler/plugins.md)) |
+
+## Reference — `ScriptGenerate` target chain
+
+```mermaid
+flowchart LR
+    A[dotnet build] --> B[CoreCompile<br/>(custom csc.cmd → JsCsc)]
+    B --> C[AfterCompile<br/>(SDK-provided)]
+    C -->|GenerateJs == True| D[ScriptGenerate]
+    D --> E[Invoke nscript.cmd<br/>→ cs2jsc.exe]
+    E --> F[(JsOutputPath/<br/>AssemblyName.js)]
+```
+
+`ScriptGenerate` has incremental-build inputs/outputs:
+- Inputs: the compiled DLL + `@(ReferencePath)`
+- Output: `$(JsOutputPath)\$(AssemblyName).js`
+
+If neither has changed since the last build, `ScriptGenerate` is skipped.
+
+## Quick start — minimal NScript project
+
+```xml
+<Project>
+  <Import Project="$(NScriptSdkDir)\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <RootNamespace>MyApp</RootNamespace>
+    <AssemblyName>MyApp</AssemblyName>
+    <GenerateJs>True</GenerateJs>
+    <JsOutputPath>./wwwroot/js</JsOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(NScriptSdkDir)\..\Framework\mscorlib\NScript.MsCorlib.csproj" />
+    <ProjectReference Include="$(NScriptSdkDir)\..\Framework\System.Web\System.Web.csproj" />
+    <ProjectReference Include="$(NScriptSdkDir)\..\Framework\System.Web.Html\System.Web.Html.csproj" />
+  </ItemGroup>
+
+  <Import Project="$(NScriptSdkDir)\Sdk\Sdk.targets" />
+</Project>
+```
+
+```bash
+dotnet build -c Release
+# Output: ./wwwroot/js/MyApp.js (minified, uglified, optimised)
+```
+
+## Examples
+
+### Real-world setup — TodoApp
+
+The `Test/Framework/TodoApp/TodoApp.csproj` is the canonical "complete app" example. Highlights:
+
+```xml
+<PropertyGroup>
+  <GenerateJs>True</GenerateJs>
+  <JsOutputPath>../TestWebApplication/GeneratedScripts</JsOutputPath>
+  <NoWarn>0824;0169</NoWarn>
+  <NScriptExe>$(NScriptToolsetDir)\bin\$(Configuration)\$(CompilerNetFramework)\nscript.exe</NScriptExe>
+</PropertyGroup>
+
+<ItemGroup>
+  <None Include="PluginConfig.xml" />
+  <EmbeddedResource Include="RazorTemplates\AppShell.skin.cshtml" />
+  <EmbeddedResource Include="RazorTemplates\AppShell.css" />
+</ItemGroup>
+```
+
+Notes:
+- `EmbeddedResource` is required for Razor `.skin.cshtml` and CSS files — `RazorSkinParser` reads them from the assembly's resources at conversion time.
+- `<None Include="PluginConfig.xml" />` ensures the file is part of the project but doesn't get copied — the SDK looks for it at the project root.
+- The explicit `<NScriptExe>` override is the in-tree path; downstream consumers using the NuGet package don't need this.
+
+### Enabling source maps
+
+```xml
+<PropertyGroup>
+  <GenerateJs>True</GenerateJs>
+  <SourceMapRoot>file:///source/MyApp</SourceMapRoot>
+</PropertyGroup>
+```
+
+`cs2jsc` emits a `.map` file alongside the `.js` and writes a `//# sourceMappingURL=` line. See [debugging/source-maps.md](../debugging/source-maps.md) for the source-map dev server.
+
+### Tweaking optimisation independently
+
+```xml
+<PropertyGroup>
+  <Configuration>Release</Configuration>
+  <Minify>true</Minify>
+  <Uglify>false</Uglify>     <!-- Keep whitespace + comments for diagnostics -->
+  <JsOptimize>true</JsOptimize>
+</PropertyGroup>
+```
+
+Each flag is independently controllable. A common debugging combo is `Minify=true; Uglify=false; JsOptimize=true` — short names (so it matches production runtime behavior) but readable layout.
+
+## Known gotchas
+
+### `dotnet build` doesn't run `ScriptGenerate` unless `GenerateJs=True`
+
+A library project that's referenced by a JS-emitting app doesn't need `GenerateJs` itself — only the entry assembly does. The DLL with `$$BstInfo$$` is what `cs2jsc` consumes; emitting `.js` per library would produce many disconnected files.
+
+### `<NoStandardLib>true</NoStandardLib>` is not optional
+
+The custom `csc.cmd` requires it. Without it, MSBuild also references the real `System.dll`, which collides with NScript's `System` namespace types.
+
+### `TargetFramework=netstandard2.1` is a contract
+
+NScript's `mscorlib` clone targets `netstandard2.1`. Don't change this in a project file — `csc.cmd` won't recognise newer TFMs and types will fail to resolve.
+
+### Framework tests need `Configuration=Debug` of the *toolset*
+
+`Test/Framework/Directory.build.props` points `CscToolPath` to `NScriptToolSet/bin/Debug/`. If you only ran `dotnet build -c Release`, `Test/Framework/*` projects fail to find the compiler. Always do `dotnet build NScript_Full.sln -c Debug` once before running framework tests.
+
+### `<JsOutputPath>` directories must exist
+
+`Sdk.targets` includes `<MakeDir>` for `$(JsOutputPath)` but only inside `ScriptGenerate`. Some app `.csproj` files add their own `EnsureJsOutputDirectory` target with `BeforeTargets="ScriptGenerate"` for portability — see TodoApp.csproj.
+
+### Wrapper `csc.cmd` / `nscript.cmd` are Windows-shaped
+
+The SDK ships `.cmd` wrappers. On non-Windows hosts you'd need shell equivalents — the project doesn't currently target Linux/macOS. (Tracked separately; not in scope for the docs.)
+
+### Incremental builds depend on input/output timestamps
+
+`ScriptGenerate` uses `Inputs="...DLL;@(ReferencePath)"` and `Outputs="...js"`. If you edit a `.cs` file but the resulting DLL has the same timestamp (rare but possible with deterministic builds), `ScriptGenerate` may be skipped. Force rebuild with `dotnet build /t:Rebuild` if in doubt.
+
+### `<Minify>` defaults differ in Release
+
+In Release configuration, `Minify`, `Uglify`, and `JsOptimize` all default to `true`. If you want unminified Release output for debugging, you must explicitly set them to `false`.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `MSB4019: The imported project "Sdk.props" was not found` | `<NScriptSdkDir>` not set or NuGet package missing; check `Mcqdb.NScript.Sdk` reference |
+| `error CS0518: Predefined type 'System.Object' is not defined` | `<NoStandardLib>true</NoStandardLib>` missing — BCL conflict |
+| Build succeeds but no `.js` output | `<GenerateJs>True</GenerateJs>` missing |
+| `BstInfo resource not found` from `cs2jsc` | The DLL was compiled by stock `csc.exe`, not the NScript `csc.cmd` — check `<CscToolPath>` |
+| `ScriptGenerate` skipped on every build | Inputs/outputs check determined nothing changed; `dotnet build /t:Rebuild` to force |
+| Plugin from `PluginConfig.xml` not loaded | `<PluginConfig>` MSBuild property missing or path wrong |
+
+## Cross-links
+
+- [Getting started](../getting-started/README.md) — first-project walkthrough
+- [Compiler pipeline](../compiler/pipeline.md) — what `ScriptGenerate` actually invokes
+- [Compiler plugins](../compiler/plugins.md) — `PluginConfig.xml` shape
+- [Source maps](../debugging/source-maps.md) — `<SourceMapRoot>` configuration
+- [Testing](../testing/README.md) — Debug-vs-Release toolset requirements
+- [ADR 0006 — Compiler pipeline](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md)

--- a/docs/compiler/pipeline.md
+++ b/docs/compiler/pipeline.md
@@ -1,0 +1,185 @@
+# Compiler pipeline
+
+> **Audience:** *Contributors* working on the NScript compiler — anyone touching `Sources/Compiler/`.
+
+## TL;DR
+
+NScript is a **two-stage compiler**, not a source-to-source transpiler. Stage 1 (`NScript.Csc.Lib`) subclasses Roslyn's `CSharpCompiler` and uses a [minimal Roslyn fork](../adr/0002-maintain-a-minimal-roslyn-fork-for-nscript-hooks.md) to capture bound method bodies, serialise them into NScript's AST format, and embed them as a `$$BstInfo$$` resource in the emitted DLL. Stage 2 (`Cs2Jsc`) loads the DLL via `ClrContext` (Mono.Cecil), extracts the AST resource, reconstructs an NScript CLR AST via `BondToAst`, lowers to JST (JavaScript AST), and emits JS via `cs2jsc`. The DLL is the **durable handoff artifact**. Pipeline canonicalised in [ADR 0006](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md).
+
+## Reference — pipeline diagram
+
+```mermaid
+flowchart TB
+    subgraph Stage1[Stage 1 — Roslyn compilation \(NScript.Csc.Lib\)]
+      A[".cs source files"] --> B["Roslyn CSharpCompilation<br/>\(forked: OnBoundExpressionGenerated\)"]
+      B --> C["BoundExpression capture"]
+      C --> D["SymbolSerializer<br/>(NScript AST → bytes)"]
+      D --> E["Embed as $$BstInfo$$<br/>resource in DLL"]
+      E --> F[("Compiled .dll<br/>with embedded AST")]
+    end
+
+    subgraph Stage2[Stage 2 — JS emission \(Cs2Jsc\)]
+      F --> G["ClrContext<br/>\(Mono.Cecil load\)"]
+      G --> H["Extract $$BstInfo$$<br/>and $$ResInfo$$"]
+      H --> I["BondToAst<br/>(AST reconstruction)"]
+      I --> J["NScript.Converter<br/>(CLR AST → JST)"]
+      J --> K["JST optimiser<br/>(devirtualise, dedup, DCE)"]
+      K --> L["cs2jsc emit"]
+      L --> M[("Output .js + .map")]
+    end
+```
+
+## Reference — project map
+
+| Project | Role |
+|---|---|
+| `NScript.Csc.Lib` | Roslyn subclass; capture bound bodies; embed `$$BstInfo$$` resource |
+| `JsCsc` / `JsCsc.Lib` | The `csc.exe`-equivalent CLI that drives Stage 1 |
+| `NScript.CLR` | Mono.Cecil-based assembly loader (`ClrContext`) — loads compiled DLLs into the converter |
+| `NScript.Converter` | The core compiler: bound AST → JST. Hosts `Builder`, `RuntimeScopeManager`, `MethodConverter`, `TypeScopeManager`. |
+| `NScript.Converter.Plugins` | Built-in plugins: `XwmlTemplatingPlugin`, `TestGenerator`. |
+| `NScript.JST` | JST (JavaScript AST) — canonical IR with visitor-pattern traversal. |
+| `NScript.JSParser` | Parser used by `[Script]` body resolution and Razor expression parsing. |
+| `Cs2Jsc` | The CLI orchestrator: loads DLLs, runs the converter, emits JS files. |
+| `XwmlParser` | XML-based template parser (XWML frontend). |
+| `RazorSkinParser` | `.skin.cshtml` template parser (Razor frontend, [ADR 0017](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)). |
+| `NScript.Template.Compiler` | Shared template-compiler infrastructure used by both frontends. |
+| `CssParser` | Strict CSS class parser used by template diagnostics ([ADR 0016](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)). |
+| `Autoprefixer` | Vendor-prefix injection over parsed CSS. |
+| `SourceMap` / `SourceMap.Server` | Source-map generation and the WI-15 source-map dev server. See [debugging/source-maps.md](../debugging/source-maps.md). |
+| `NScript.Lib` / `NScript.Utils` | Shared utilities and reference-data lookup. |
+| `NScript.Sdk` | MSBuild SDK that wires `JsCsc` into `dotnet build`. See [build/msbuild-sdk.md](../build/msbuild-sdk.md). |
+
+## Reference — handoff resources
+
+| Resource | Producer | Consumer | Contents |
+|---|---|---|---|
+| `$$BstInfo$$` | `NScript.Csc.Lib::SerializationHelper` | `NScript.Converter::ConverterContext` | Serialised NScript CLR AST for every method body in the assembly |
+| `$$ResInfo$$` | `NScript.Csc.Lib::Csc` | `NScript.Converter::ConverterContext` | Serialised resource bundle (strings, embedded files via `[Resources]`) |
+
+The DLL is the *only* coupling between Stage 1 and Stage 2 — there is no shared in-memory state, no Roslyn handle, no source-text dependency. This makes incremental builds trivial: Stage 2 only re-runs for changed DLLs.
+
+## Reference — the Roslyn fork
+
+NScript depends on a [narrow surgical fork](../adr/0002-maintain-a-minimal-roslyn-fork-for-nscript-hooks.md) of the Roslyn C# compiler. The diff against upstream is intentionally small ([ADR 0005](../adr/0005-constrain-nscript-to-a-small-roslyn-integration-contract.md)):
+
+1. `CSharpCompilation.OnBoundExpressionGenerated` — callback fired for each bound method body.
+2. `MethodCompiler.OnBoundExpressionGenerated` — propagation through the compiler pipeline.
+3. `CommonCompiler.OnBeforeCompilation` — early hook for resource injection.
+4. `InternalsVisibleTo("NScript.csc.lib")` — exposes Roslyn internals to the subclass.
+5. Disabled assembly signing for private builds.
+
+The forked binaries live in `Dependencies/Roslyn/` and are checked into the repo. The fork source is a git submodule at `roslyn/` on branch `features/physhi-updated`. See [ADR 0003](../adr/0003-define-how-nscript-consumes-and-updates-forked-roslyn-binaries.md) and [ADR 0004](../adr/0004-define-when-and-how-to-refresh-the-checked-in-roslyn-drop.md) for refresh procedures.
+
+## Reference — JST optimisation passes
+
+Once the converter has produced JST, several passes run before emit:
+
+1. **Demand-driven conversion + DCE** ([ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) — only types/methods reachable from `[EntryPoint]` are converted; unreached identifiers are eliminated.
+2. **Devirtualisation + accessor inlining** ([ADR 0023](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)) — non-virtual methods become static functions; trivial getters/setters inline at call sites.
+3. **Identifier resolution** ([ADR 0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md)) — every JST identifier is replaced with a resolved `IIdentifier` object before emission.
+4. **Minification** — short identifier substitution.
+5. **Function deduplication** ([ADR 0024](../adr/0024-deduplicate-structurally-identical-functions-after-minification.md)) — post-minification, structurally identical function bodies share a single emitted definition.
+
+## Quick start — build and trace one file through the pipeline
+
+```bash
+# Build full solution Debug (required for framework tests, useful for tracing)
+dotnet build NScript_Full.sln -c Debug
+
+# Build a single .NScriptproj
+dotnet build Test/Framework/TodoApp/TodoApp.csproj -c Debug
+
+# Inspect the embedded resource on a Stage-1 output DLL:
+ildasm /text Test/Framework/TodoApp/bin/Debug/netstandard2.1/TodoApp.dll \
+  | grep -A2 "BstInfo"
+
+# Force-trace Stage 2 emission (env var honored by Cs2Jsc):
+NSCRIPT_TRACE_EMIT=1 \
+  NScriptToolSet/bin/Debug/cs2jsc.exe \
+  --in Test/Framework/TodoApp/bin/Debug/netstandard2.1/TodoApp.dll \
+  --out /tmp/todoapp.js
+```
+
+The trace flag dumps the JST tree before and after each optimisation pass. Useful for understanding why a particular call site emits the way it does.
+
+## Examples
+
+### Tracing what reaches the JS output
+
+A common contributor question: "why didn't this method appear in the emitted JS?" Answer: demand-driven conversion ([ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) walks from `[EntryPoint]` and only emits transitively reachable identifiers. To trace:
+
+1. Verify the entry point: `grep -r "EntryPoint" Test/Framework/TodoApp/`
+2. Check whether your method is called from a reachable call site.
+3. Look at the converter's reachability log: set `NSCRIPT_TRACE_DCE=1` and re-run.
+
+If a method should be reachable but isn't, the most common cause is that the call site lives inside a `[Conditional("DEBUG")]` method whose caller compiled in Release.
+
+### Adding a new built-in optimisation pass
+
+New passes plug into `NScript.Converter::Builder` after the JST is built. The pattern:
+
+```csharp
+public class MyOptimisationPass : IConverterPass
+{
+    public void Run(ConverterContext ctx)
+    {
+        foreach (var fn in ctx.AllFunctions)
+        {
+            // mutate fn.Body via JST visitor
+        }
+    }
+}
+```
+
+Register in `Builder.cs` and add tests under `Test/Compiler/NScriptTest/`.
+
+## Known gotchas
+
+### Stage 1 must complete before Stage 2 reads the DLL
+
+If you're invoking the compiler manually, run `JsCsc` first to produce the DLL with `$$BstInfo$$`. Calling `Cs2Jsc` against a DLL produced by stock `csc.exe` produces "missing AST resource" errors.
+
+### `ClrContext` uses Mono.Cecil, not `System.Reflection`
+
+The DLL loader is Mono.Cecil-based. This matters for contributors: don't reach for `Assembly.Load` / `Type.GetType` inside the converter. Use `ClrContext` accessors. Reflection-based lookups will be slower and inconsistent with how the rest of the converter sees types.
+
+### Framework tests require a Debug build first
+
+`Test/Framework/Directory.build.props` points `CscToolPath` to `NScriptToolSet/bin/Debug/`. If you've only built Release, framework tests fail to compile their source files. Always run `dotnet build -c Debug` once before framework tests.
+
+### The Roslyn fork must be refreshed deliberately
+
+Don't update `Dependencies/Roslyn/` casually. The drop is binary; it must be regenerated from the `roslyn/` submodule on `features/physhi-updated` and validated through the full build + integration test suite. See [ADR 0004](../adr/0004-define-when-and-how-to-refresh-the-checked-in-roslyn-drop.md).
+
+### Identifier renames after JST construction break codegen plugins
+
+Codegen plugins ([compiler/plugins.md](plugins.md)) emit JST nodes that reference identifiers. The minifier renames symbols *after* plugin emission. If a plugin emits a raw string identifier (instead of resolving via `RuntimeScopeManager`), the rename desyncs and the plugin's output references the wrong name. [ADR 0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md) is non-negotiable.
+
+### `$$BstInfo$$` format is internal
+
+The serialisation format is not stable across NScript versions. Don't try to parse it externally. If you need to inspect AST, use `Cs2Jsc --dump-ast` against the DLL.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `BstInfo resource not found in DLL` | DLL was compiled by stock `csc.exe`, not `JsCsc` |
+| `Cannot deserialize BstInfo: version mismatch` | DLL compiled with a different NScript version than the one running `Cs2Jsc` |
+| Method missing from JS output | Demand-driven DCE eliminated it — check reachability from `[EntryPoint]` |
+| `Identifier 'X' not resolved` from a plugin | Plugin emitted a raw string instead of going through `RuntimeScopeManager.Resolve` |
+| Roslyn-side compile error mentions `OnBoundExpressionGenerated` | Forked binaries missing or corrupt; rebuild from `roslyn/` submodule |
+
+## Cross-links
+
+- [ADR 0002 — Roslyn fork](../adr/0002-maintain-a-minimal-roslyn-fork-for-nscript-hooks.md)
+- [ADR 0005 — Roslyn integration contract](../adr/0005-constrain-nscript-to-a-small-roslyn-integration-contract.md)
+- [ADR 0006 — Compiler pipeline](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md)
+- [ADR 0013 — Multi-frontend architecture](../adr/0013-define-nscript-as-a-multi-frontend-translation-architecture.md)
+- [ADR 0021 — Resolved identifiers](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md)
+- [ADR 0022 — DCE](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)
+- [ADR 0023 — Devirtualisation](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)
+- [ADR 0024 — Function dedup](../adr/0024-deduplicate-structurally-identical-functions-after-minification.md)
+- [Compiler plugins](plugins.md)
+- [MSBuild SDK](../build/msbuild-sdk.md)
+- [Source maps](../debugging/source-maps.md)

--- a/docs/compiler/plugins.md
+++ b/docs/compiler/plugins.md
@@ -1,0 +1,231 @@
+# Compiler plugins (`IConverterPlugin`)
+
+> **Audience:** *Contributors* extending the converter pipeline with custom code-generation, template processors, or runtime emit hooks.
+
+## TL;DR
+
+The converter is extensible via `IConverterPlugin`-derived plugin interfaces. There are three plugin shapes: **`IMethodConverterPlugin`** (intercept method bodies), **`ITypeConverterPlugin`** (intercept type emission), and **`IRuntimeConverterPlugin`** (contribute method references and emit code outside any specific type). Plugins are registered via `PluginConfig.xml` (XML-based, not reflection-discovered). Built-in plugins: `XwmlTemplatingPlugin` (XWML templates), `RazorTemplatingPlugin` (Razor `.skin.cshtml`), and `TestGenerator` (QUnit registration emission). All JST identifier creation must follow the [JST codegen rules](#reference--jst-codegen-rules) — raw string identifiers will be silently broken by the minifier ([ADR 0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md)).
+
+## Reference — plugin interfaces
+
+| Interface | When invoked | Use for |
+|---|---|---|
+| `IConverterPlugin` (base) | Once at startup via `Initialize(ClrContext, RuntimeScopeManager)` and `ParseArgs(args)` | Wire-up; common to all plugin shapes |
+| `IMethodConverterPlugin` | Per method, with `IntrestLevel` selecting *when* in the method emission | Pre/post statements, encapsulation, or full overwrite of a method body |
+| `ITypeConverterPlugin` | Per type, with the same `IntrestLevel` enum | Pre/post statements, encapsulation, or full overwrite of a type definition |
+| `IRuntimeConverterPlugin` | Twice (pass1 + passN) for method refs + once for pre/post JS | Emit code that doesn't belong to any user-defined type (test runners, bootstrappers) |
+
+## Reference — `IntrestLevel` enum (sic)
+
+Note the project misspelling — `IntrestLevel` not `InterestLevel`. Honor the existing identifier in your plugin code.
+
+| Value | Effect |
+|---|---|
+| `None` | Plugin doesn't care about this method/type |
+| `PreEmitStatements` | Plugin's statements run *before* the body's emitted statements |
+| `PostEmitStatements` | Plugin's statements run *after* the body's emitted statements |
+| `Encapsulate` | Plugin wraps the body's emitted statements (receives them as input, returns wrapped) |
+| `Overwrite` | Plugin replaces the body's emitted statements entirely |
+
+A plugin returns `IntrestLevel` from `GetInterestLevel(...)` and the matching method (`GetPreInsertionStatements`, `GetPostInsertionStatements`, `GetEncapsulationStatements`, `GetOverwrite`) is called.
+
+## Reference — plugin registration (`PluginConfig.xml`)
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<Plugins>
+  <Plugin Assembly="XwmlParser" ClassName="XwmlParser.XwmlTemplatingPlugin" />
+  <Plugin Assembly="RazorSkinParser" ClassName="NScript.RazorSkin.RazorTemplatingPlugin" />
+  <Plugin Assembly="NScript.Converter.Plugins" ClassName="NScript.Converter.Plugins.TestGenerator" />
+</Plugins>
+```
+
+- `Assembly` — assembly file name (no `.dll`).
+- `ClassName` — fully qualified type implementing one of the plugin interfaces.
+
+`Cs2Jsc` ships with a default `PluginConfig.xml` registering only `XwmlTemplatingPlugin` (see `Sources/Compiler/Cs2Jsc/PluginConfig.xml`). Razor and `TestGenerator` are opt-in per project via `<PluginConfig>` in the project file. Project-specific configs replace the default.
+
+## Reference — built-in plugins
+
+| Plugin | Assembly | Implements | Purpose |
+|---|---|---|---|
+| `XwmlTemplatingPlugin` | `XwmlParser` | `IMethodConverterPlugin` + `IRuntimeConverterPlugin` | Detects `[TemplateFile(*.html)]` types, parses XWML templates, emits skin factory + binder code via `IBindingStrategy` ([ADR 0019](../adr/0019-extract-ibindingstrategy-from-skininstance.md)). Registered globally in `Cs2Jsc/PluginConfig.xml`. |
+| `RazorTemplatingPlugin` | `RazorSkinParser` | `IMethodConverterPlugin` + `IRuntimeConverterPlugin` | As above for `.skin.cshtml` templates ([ADR 0017](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)). Registered per-project in `PluginConfig.xml`. |
+| `TestGenerator` | `NScript.Converter.Plugins` | `IRuntimeConverterPlugin` | Scans for `[TestFixture]` / `[Test]` attributes from `SunlightUnit`, emits `QUnit.module()` + `QUnit.test()` calls. Opt-in per-project via `PluginConfig.xml`. See [testing/README.md](../testing/README.md). |
+
+## Reference — JST codegen rules
+
+These rules are mandatory ([ADR 0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md), reiterated in `CLAUDE.md`):
+
+1. **All identifiers must be resolved through the scope system.** Never use raw string names for variables, fields, methods, or types. The compiler renames everything during minification. Use `RuntimeScopeManager.Resolve()`, `ResolveStatic()`, `ResolveType()`, or `ResolveFactory()`.
+
+2. **Object literal field keys:** Use `InlineObjectInitializer.AddInitializer(IIdentifier, Expression)` with a resolved field identifier, NOT the `(string, Expression)` overload. String keys produce unminified names that don't match runtime field access.
+
+3. **Type constructors (parameterless):** Use `ResolveType(typeDef)[0]` + `new` syntax. `ResolveFactory()` only works for constructors WITH parameters — parameterless constructors don't get factory functions in NScript.
+
+4. **`[JsonType]` attribute:** Adds `importedExtension` wrapper on field access. Don't use for types created as object literals in codegen — the wrapper won't match. Use typed instances (`new Type()`) instead.
+
+5. **Raw body function expressions:** If unavoidable (complex computed expressions), use `enforceSuggestion=true` on the `IdentifierScope` so parameter names match the raw body text. Prefer fully resolved JST expressions where possible.
+
+## Quick start — a minimal `IMethodConverterPlugin`
+
+```csharp
+using System.Collections.Generic;
+using NScript.CLR;
+using NScript.Converter;
+using NScript.Converter.TypeSystemConverter;
+using NScript.JST;
+using Mono.Cecil;
+
+namespace MyApp.Plugins
+{
+    public class TraceLogPlugin : IMethodConverterPlugin
+    {
+        private RuntimeScopeManager scopes;
+
+        public void Initialize(ClrContext clrContext, RuntimeScopeManager rsm)
+        {
+            this.scopes = rsm;
+        }
+
+        public void ParseArgs(IList<Tuple<string, string>> args) { }
+
+        public IntrestLevel GetInterestLevel(MethodDefinition m, ConverterContext ctx)
+        {
+            return m.HasCustomAttribute("MyApp.TracedAttribute")
+                ? IntrestLevel.PreEmitStatements
+                : IntrestLevel.None;
+        }
+
+        public List<Statement> GetPreInsertionStatements(MethodConverter mc)
+        {
+            // Resolve `console.log` via the scope system, NOT a raw string
+            var consoleLog = scopes.ResolveStatic("console", "log");
+            var msg = new StringLiteral(mc.MethodDefinition.FullName);
+            var call = new CallExpression(consoleLog, new[] { msg });
+            return new List<Statement> { new ExpressionStatement(call) };
+        }
+
+        public List<Statement> GetPostInsertionStatements(MethodConverter mc) => new();
+        public List<Statement> GetEncapsulationStatements(MethodConverter mc, List<Statement> body) => body;
+        public List<Statement> GetOverwrite(MethodConverter mc) => null;
+    }
+}
+```
+
+Register in `PluginConfig.xml`:
+
+```xml
+<Plugin Assembly="MyApp.Plugins" ClassName="MyApp.Plugins.TraceLogPlugin" />
+```
+
+## Examples
+
+### `IRuntimeConverterPlugin` — emit a bootstrap call
+
+```csharp
+public class BootstrapPlugin : IRuntimeConverterPlugin
+{
+    private ClrContext clrContext;
+    private RuntimeScopeManager scopes;
+
+    public void Initialize(ClrContext c, RuntimeScopeManager r) { clrContext = c; scopes = r; }
+    public void ParseArgs(IList<Tuple<string, string>> args) { }
+
+    public List<MethodReference> GetMethodsToEmitPass1() => new();
+    public List<MethodReference> GetMethodsToEmitPassN() => new();
+    public List<Statement> GetPreJavascript() => new();
+
+    public List<Statement> GetPostJavascript()
+    {
+        // Emit a call to MyApp.AppShell.Boot() at end of file
+        var bootMethod = clrContext.ResolveMethod("MyApp", "MyApp.AppShell", "Boot");
+        var bootCall = new CallExpression(scopes.Resolve(bootMethod), new Expression[0]);
+        return new List<Statement> { new ExpressionStatement(bootCall) };
+    }
+}
+```
+
+`GetMethodsToEmitPass1` / `GetMethodsToEmitPassN` let a plugin force inclusion of method references that the demand-driven DCE pass ([ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) wouldn't otherwise reach. Two passes exist because pass1 contributes refs that may transitively pull in further refs — passN runs once those have been resolved.
+
+### `ITypeConverterPlugin` — wrap a type definition
+
+```csharp
+public IntrestLevel GetInterestLevel(TypeDefinition t)
+    => t.HasCustomAttribute("MyApp.WrappedAttribute") ? IntrestLevel.Encapsulate : IntrestLevel.None;
+
+public List<Statement> GetEncapsulationStatements(TypeConverter tc, List<Statement> typeBody)
+{
+    // Wrap the emitted type in an IIFE
+    var iife = new FunctionExpression(parameters: new[] { /*…*/ }, body: typeBody);
+    var call = new CallExpression(iife, new Expression[0]);
+    return new List<Statement> { new ExpressionStatement(call) };
+}
+```
+
+## Known gotchas
+
+### Plugin discovery is XML-based, not attribute-discovered
+
+There is no `[Plugin]` attribute scan. If your `PluginConfig.xml` doesn't list the plugin, `Cs2Jsc` won't load it — even if the assembly is in the same folder. This is intentional ([CLAUDE.md](../../CLAUDE.md)) — it keeps the plugin set explicit and reproducible.
+
+### `IntrestLevel` (sic) is the spelling
+
+The enum is misspelled in the source. Don't "fix" it locally — that breaks every plugin in the tree. The fix would be a coordinated rename across the converter and all plugins.
+
+### `Initialize` is called *before* any conversion happens
+
+Stash `ClrContext` and `RuntimeScopeManager` here. Don't try to resolve types from `Initialize` — type resolution lookups depend on the converter having walked the assembly graph, which happens later. Resolve lazily in `GetInterestLevel` / `GetPreInsertionStatements`.
+
+### `GetMethodsToEmitPass1` vs `GetMethodsToEmitPassN`
+
+If your runtime plugin needs to force a method reference to be emitted, returning it from `GetMethodsToEmitPass1` is usually right. Use `PassN` only if your decision depends on what pass1 contributed (e.g. you need to walk the result of pass1 to compute references).
+
+### Raw string identifiers will be silently broken
+
+```csharp
+// ❌ WRONG — minifier will rename `console`
+var bad = new MemberAccess(new RawIdentifier("console"), "log");
+
+// ✅ RIGHT
+var good = scopes.ResolveStatic("console", "log");
+```
+
+The bug surfaces only at runtime (`undefined is not a function`). Always go through the scope manager. See [ADR 0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md).
+
+### Object literal field keys with strings break `[JsonType]` consumers
+
+```csharp
+// ❌ WRONG — emits unminified key 'foo' that doesn't match obj.foo at runtime
+ioi.AddInitializer("foo", value);
+
+// ✅ RIGHT
+ioi.AddInitializer(scopes.ResolveField(typeDef, "Foo"), value);
+```
+
+### Plugins run inside the DCE pass
+
+If your plugin's contributed method references depend on method-body inspection, ensure the methods you're inspecting are *reachable* — DCE may have already pruned them. The pass1/passN split exists precisely to handle this.
+
+### `Encapsulate` is rarely the right choice
+
+`PreEmitStatements` + `PostEmitStatements` covers most cases (logging, instrumentation). Use `Encapsulate` only when you genuinely need to wrap the body (try/catch injection, IIFE wrapping). `Overwrite` is for full takeover (template-emitted methods, `[Script]` body replacement).
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| Plugin appears not to fire | Missing entry in `PluginConfig.xml`; assembly path wrong; `GetInterestLevel` returns `None` |
+| `Cannot resolve type 'X'` from plugin | Resolution attempted in `Initialize` before assembly graph walk; defer to per-method/per-type entry points |
+| Emitted JS calls minified name that doesn't exist | Plugin used raw string identifier instead of `RuntimeScopeManager.Resolve` |
+| `Cannot find member 'foo'` at runtime | Object literal key is a string, not a resolved `IIdentifier` |
+| Plugin's contributed method refs missing from output | DCE eliminated them; return them from `GetMethodsToEmitPass1` to force inclusion |
+
+## Cross-links
+
+- [Compiler pipeline](pipeline.md) — where plugins fit
+- [ADR 0021 — Resolved identifiers](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md)
+- [ADR 0022 — DCE](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)
+- [Razor templates](../templates/razor.md), [XWML templates](../templates/xwml.md)
+- [Testing](../testing/README.md) — `TestGenerator` plugin
+- [MSBuild SDK](../build/msbuild-sdk.md) — how `PluginConfig.xml` is wired in

--- a/docs/debugging/source-maps.md
+++ b/docs/debugging/source-maps.md
@@ -1,0 +1,187 @@
+# Source maps & browser debugging
+
+> **Audience:** *App authors* debugging compiled NScript apps in browser DevTools; *contributors* working on the source-map dev server.
+
+## TL;DR
+
+NScript emits standard JavaScript source maps alongside the generated `.js` (V3 format), allowing browser DevTools to set breakpoints in original `.cs` files and step through C# source rather than compiled JS. The maps include a `sourcesLong` extension carrying full filesystem paths used by the **`SourceMap.Server`** ASP.NET Core middleware (`SourceMapFileHandler`), which serves the original `.cs` files back to DevTools when requested. Configure with `<SourceMapRoot>` in the project file and register the handler with `MapSourceMapFiles(prefix, options)` in your test/dev host. The path-resolution layer enforces an `AllowedSourceRoots` allow-list to defend against arbitrary-file-read via tampered maps.
+
+## Reference — emission knobs
+
+| MSBuild property | Purpose |
+|---|---|
+| `<SourceMapRoot>` | Base path / URL prefix written into the emitted `.map` `sourceRoot` field. Often `file:///source/MyApp/` for local dev or `/sourcemap/MyApp/` when the source-map dev server is in use. |
+| `<JsOutputPath>` | Directory where `.js` and the matching `.map` land. The emitter writes both files plus `//# sourceMappingURL=` line in the `.js`. |
+
+## Reference — source-map dev server (`SourceMap.Server`)
+
+| Type | File | Purpose |
+|---|---|---|
+| `SourceMapFileHandler` | `Sources/Compiler/SourceMap.Server/SourceMapFileHandler.cs` | ASP.NET Core endpoint extension `MapSourceMapFiles(prefix, options)` |
+| `SourceMapFileHandlerOptions` | `Sources/Compiler/SourceMap.Server/SourceMapFileHandlerOptions.cs` | `MapsDirectory`, `AllowedSourceRoots`, `MaxMapFileSizeBytes`, `MaxSourceFileSizeBytes` |
+| `SourceMapSources` | `Sources/Compiler/SourceMap.Server/SourceMapSources.cs` | Helpers for resolving `sourcesLong` entries into local file paths |
+
+The handler accepts requests of the form `/{prefix}/{mapName}/{*sourceName}`:
+
+1. Loads `{MapsDirectory}/{mapName}.map`.
+2. Looks up `sourceName` in the map's `sources` array.
+3. Resolves the matching `sourcesLong` entry into an absolute path.
+4. Validates the path is under one of `AllowedSourceRoots`.
+5. Streams the file back if every check passes; otherwise returns 404.
+
+A 404 (not 403) is the deliberate response for every failure mode — file missing, path outside allow-list, oversized map. This keeps the handler from leaking whether a path *exists*.
+
+## Reference — request flow
+
+```mermaid
+sequenceDiagram
+    participant DT as Browser DevTools
+    participant Host as ASP.NET Core host
+    participant Handler as SourceMapFileHandler
+    participant FS as File system
+
+    DT->>Host: GET /js/MyApp.js
+    Host-->>DT: ...; //# sourceMappingURL=MyApp.map
+    DT->>Host: GET /js/MyApp.map
+    Host-->>DT: { version:3, sources:[...], sourcesLong:[...] }
+    DT->>Host: GET /sourcemap/MyApp/MyService.cs
+    Host->>Handler: HandleAsync(mapName=MyApp, source=MyService.cs)
+    Handler->>FS: Read MapsDirectory/MyApp.map
+    Handler->>Handler: Resolve sourcesLong[i] → absolute path
+    Handler->>Handler: Validate against AllowedSourceRoots
+    Handler->>FS: Stream original .cs file
+    Handler-->>DT: 200 OK with C# source content
+    DT->>DT: Show .cs in Sources panel; breakpoints work
+```
+
+## Quick start — enable source maps
+
+### 1. Project file
+
+```xml
+<PropertyGroup>
+  <GenerateJs>True</GenerateJs>
+  <SourceMapRoot>/sourcemap/MyApp/</SourceMapRoot>
+</PropertyGroup>
+```
+
+After build you'll see:
+
+```
+wwwroot/js/
+  MyApp.js
+  MyApp.map
+```
+
+### 2. Host setup (test web app or dev server)
+
+```csharp
+using OwaSourceMapper.Server;  // namespace differs from project/assembly name SourceMap.Server
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+// Serve the JS itself
+app.UseStaticFiles();
+
+// Serve original sources back to DevTools
+app.MapSourceMapFiles("/sourcemap", new SourceMapFileHandlerOptions
+{
+    MapsDirectory = Path.Combine(app.Environment.ContentRootPath, "wwwroot/js"),
+    AllowedSourceRoots = new[]
+    {
+        Path.GetFullPath(Path.Combine(app.Environment.ContentRootPath, "../../"))
+    },
+});
+
+app.Run();
+```
+
+### 3. Open DevTools
+
+- Chromium / Edge: open Sources panel; you should see your `.cs` files under the original folder structure.
+- Firefox: same, but enable "Show Original Sources" in DevTools settings if not visible.
+
+Set a breakpoint in a `.cs` file. When the JS hits the corresponding location, DevTools pauses at the C# line, with locals named per the C# variable names (where preserved by the compiler).
+
+## Examples
+
+### Per-test-host wiring
+
+For framework tests served by `Test/Framework/TestWebApplication`, the source-map server can be added so QUnit failures show in the original `.cs`:
+
+```csharp
+endpoints.MapSourceMapFiles("/sourcemap", new SourceMapFileHandlerOptions
+{
+    MapsDirectory = Path.Combine(env.ContentRootPath, "GeneratedScripts"),
+    AllowedSourceRoots = new[] { Path.GetFullPath(Path.Combine(env.ContentRootPath, "../..")) },
+    MaxMapFileSizeBytes = 32L * 1024 * 1024,  // larger maps for big test bundles
+});
+```
+
+### Disabling source maps in Release
+
+Source-map emission is on by default whenever `<GenerateJs>True</GenerateJs>` is set. To suppress for production builds:
+
+```xml
+<PropertyGroup>
+  <SourceMapRoot></SourceMapRoot>  <!-- empty disables -->
+  <Uglify>true</Uglify>
+</PropertyGroup>
+```
+
+The `.map` file isn't emitted, and the `//# sourceMappingURL=` line is omitted.
+
+## Known gotchas
+
+### `SourceMapRoot` must match the URL the browser uses
+
+If your site serves `MyApp.js` from `/static/js/` but `SourceMapRoot` is `file:///source/MyApp/`, DevTools will look for `.cs` files on the local filesystem (which works only for the developer who built the binary). For shared dev/staging servers, set `SourceMapRoot` to the `/sourcemap/...` path served by the dev server.
+
+### `AllowedSourceRoots` must be set explicitly for non-trivial deployments
+
+The default allow-list is `MapsDirectory`'s parent hierarchy — fine for "build and run on the same machine" but wrong as soon as your CI builds elsewhere and ships maps + JS without the source tree. Set `AllowedSourceRoots` to the actual source root *on the hosting machine*, or accept that source-map browsing won't work in that environment.
+
+### 404 means "any failure", not "missing file"
+
+`SourceMapFileHandler` returns 404 for: file not found, map not found, path outside allow-list, oversized map, malformed map, mismatched source name. This is deliberate — it prevents DevTools from probing for which files exist. Diagnose via server logs (the handler logs the actual reason at Information level), not by HTTP status.
+
+### Map file size cap defaults to 16 MB
+
+Big template-heavy apps can produce maps larger than 16 MB. Bump `MaxMapFileSizeBytes` if you see 404s on a known-good map and the log shows "map exceeds size limit."
+
+### `sourcesLong` is an NScript-specific extension
+
+Standard source maps use `sources` (relative names) and `sourceRoot` (URL prefix). NScript additionally writes `sourcesLong` with absolute paths so the dev server can locate files without needing `sourceRoot` to be a real filesystem path. Other tooling that consumes the map ignores `sourcesLong`.
+
+### Breakpoints in heavily inlined methods may not stop
+
+Devirtualisation + accessor inlining ([ADR 0023](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)) and function dedup ([ADR 0024](../adr/0024-deduplicate-structurally-identical-functions-after-minification.md)) can collapse multiple call sites into a single emitted function. DevTools may not be able to map back to one specific original line. Disable optimisations (`<JsOptimize>false</JsOptimize>`) when you need to debug into trivial accessors.
+
+### Browser caching of `.map` files
+
+DevTools aggressively caches source maps. After rebuilding, hard-refresh DevTools (close and reopen) to pick up new mappings — a regular page refresh isn't enough.
+
+### The legacy `SrcMapper.ashx` still ships
+
+`Sources/Compiler/SourceMap/SrcMapper.ashx` is the older WebForms handler. The ASP.NET Core `SourceMapFileHandler` replaces it for new hosts. Don't mix; pick one per deployment.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| DevTools shows JS, not C#, in Sources panel | `<SourceMapRoot>` not set, or `.map` file 404s — check Network tab |
+| `.map` loads but `.cs` files all 404 | `AllowedSourceRoots` missing/wrong, or sources not on the hosting machine |
+| Breakpoint placed in `.cs` doesn't trigger | Optimisations inlined the code; disable `<JsOptimize>` for the debug build |
+| `sourceMappingURL` comment present but DevTools doesn't load it | Browser source-map setting disabled, or map file exceeds DevTools' own size limits |
+| Source-map server returns 200 with empty body | `MaxSourceFileSizeBytes` exceeded — increase the cap |
+| Wrong line shown when breakpoint hits | Stale `.map` cached by DevTools — close/reopen to refresh |
+
+## Cross-links
+
+- [ADR 0006 — Compiler pipeline](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md)
+- [ADR 0023 — Devirtualisation](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)
+- [ADR 0024 — Function dedup](../adr/0024-deduplicate-structurally-identical-functions-after-minification.md)
+- [Compiler pipeline](../compiler/pipeline.md) — where source maps are produced
+- [MSBuild SDK](../build/msbuild-sdk.md) — `<SourceMapRoot>` configuration
+- [Testing](../testing/README.md) — wiring source maps into framework-test hosts

--- a/docs/framework/core.md
+++ b/docs/framework/core.md
@@ -1,0 +1,106 @@
+# Framework Core — supported BCL surface
+
+> **Audience:** *App authors*.
+
+## TL;DR
+
+NScript ships its own `mscorlib.dll` and `System.Core.dll` (under `Sources/Framework/mscorlib/` and `Sources/Framework/System.Core/`). These are *not* the official .NET BCL — they are a curated subset shaped for translation to JavaScript, with a few NScript-specific additions. This page summarises what is available, what behaves identically to .NET, and the well-known gotchas.
+
+## Reference — what is in `mscorlib`
+
+The full file list lives under `Sources/Framework/mscorlib/`. Highlights:
+
+| Area | Types |
+|---|---|
+| Primitives & boxing | `Object`, `String`, `Boolean`, `Char`, `Byte`, `SByte`, `Int16`, `UInt16`, `Int32`, `UInt32`, `Int64`, `UInt64`, `Single`, `Double`, `Decimal`, `Number`, `Nullable<T>`, `ValueTuple` |
+| Time | `DateTime`, `DateFormatInfo`, `NumberFormatInfo`, `CultureInfo` |
+| Delegates / events | `Delegate`, `MulticastDelegate`, `Action`, `Action<...>` (up to 8 args), `Func<...>`, `EventHandler`, `EventArgs`, `EventBinder`, `EventTarget` |
+| Collections | `Array`, `NativeArray`, `Collections.Generic.List<T>`, `Dictionary<TKey,TValue>`, `StringDictionary<T>`, `IEnumerable<T>`, `IEnumerator<T>`, `HashSet<T>`, LINQ enumerable extensions in `System.Linq` |
+| Exceptions | `Exception`, `ArgumentException`, `InvalidOperationException`, `NotSupportedException`, `NotImplementedException`, `Error`, `ErrorEvent` |
+| Async | `Threading.Tasks.Task`, `Task<T>`, `IAsyncStateMachine`, `Promise`, async/await machinery in `Runtime.CompilerServices` |
+| Strings | `StringBuilder`, `String.Format`, `RegularExpression`, `String.Replace` (`StringReplaceCallback`) |
+| Math | `Math`, `Number` |
+| Reflection (limited) | `Type`, `RuntimeFieldHandle`, `RuntimeTypeHandle`, `Activator` |
+| Misc | `Guid`, `IntPtr`, `Environment`, `Diagnostics.Debug`, `Threading.Thread` (extremely limited — JS is single-threaded) |
+
+`System.Core` adds extended LINQ and async streams scaffolding. `Microsoft.CSharp` adds the late-binding plumbing used by `dynamic` (see [interop/dynamic.md](../interop/dynamic.md)).
+
+## Quick start
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class CountVowels
+{
+    public static int Run(IEnumerable<string> words)
+    {
+        return words
+            .SelectMany(w => w.ToCharArray())
+            .Count(c => "aeiou".IndexOf(c) >= 0);
+    }
+}
+```
+
+This compiles cleanly: generics, LINQ, lambdas, and string indexing all work as in .NET.
+
+## What works identically to .NET
+
+- Generic types and methods, including constraints
+- Lambdas and closures
+- LINQ-to-objects (`Where`, `Select`, `OrderBy`, `GroupBy`, `Aggregate`, `ToList`, `ToArray`, `Distinct`, `First`/`Single`/etc.)
+- `async` / `await` (Task-based, lowered into a state machine; see ADR 0006)
+- Pattern matching (`is` patterns, switch expressions for C# 8 — see [csharp8-todos.md](../../csharp8-todos.md))
+- Null-coalescing (`??`, `??=`)
+- Range and index operators (`..`, `^`)
+- `using` / `using var` for `IDisposable`
+- Tuples and value tuples
+- `String.Format` and interpolated strings
+
+## Known gotchas
+
+### `List<T>.RemoveAt(0)` is O(n)
+
+`List<T>` is implemented over a JS native array. `RemoveAt(0)` lowers to `Array.splice(0, 1)`, which shifts every subsequent element. For high-frequency eviction (queue-like usage), prefer a small ring buffer or batch removal. Reference: WI-11 `HttpLogSink` redesign.
+
+### Integer arithmetic is JS double semantics
+
+All numeric primitives compile through JavaScript `Number` (IEEE-754 double). Beyond `2^53` you lose integer precision. `Int64` / `UInt64` use a polyfill but are still backed by doubles in many operations — do not assume bit-exact 64-bit semantics. `Decimal` is similarly non-faithful: it does not give .NET-style decimal arithmetic.
+
+### `Activator.CreateInstance` works only with parameterless types known at compile time
+
+NScript codegen generates a factory function only for constructors that take parameters (see ADR 0007 / 0008). Parameterless constructors are invoked via `new Type()` from resolved type identifiers. `Activator.CreateInstance(typeof(Foo))` works for compile-time-known types but cannot enumerate types or load them by name at runtime.
+
+### No reflection
+
+There is a `Type` class with `FullName` / `TypeId` / `BaseType`, but enumerating fields, methods, or invoking by name is not supported. Code that depends on `MethodInfo.Invoke`, `FieldInfo.SetValue`, or `Assembly.GetTypes()` will not compile or will fail at runtime. If you need polymorphic dispatch, use interfaces or delegates.
+
+### `string[]` for property bags, not anonymous types
+
+When passing key/value data through interop or to `Logger.*`, use a flat `string[]` of alternating keys and values. C# anonymous objects survive Roslyn but get their property names minified by NScript, breaking JSON serialisation and interop. See [framework-logging.md](../framework-logging.md) for the rationale.
+
+### `DateTime` semantics
+
+`DateTime` wraps a JS `Date`. Methods like `AddDays`, `ToString(format)` work, but `DateTime.Kind`, time-zone-aware conversions, and `DateTimeOffset` are not faithful — the JS `Date` model is a single UTC moment plus host time-zone display. Rely on UTC for any cross-system contract.
+
+### `InternalsVisibleTo` works at the Roslyn level only
+
+The `InternalsVisibleToAttribute` is present in `mscorlib` but marked `[NonScriptable]` — Roslyn honors it for compilation, but it has no runtime effect.
+
+## Diagnostics
+
+| Compile error | Likely cause |
+|---|---|
+| `The type or namespace name 'X' could not be found` referencing a BCL type | NScript's `mscorlib` does not export it — check `Sources/Framework/mscorlib/` |
+| `dynamic` cannot be used | Not supported. See [interop/dynamic.md](../interop/dynamic.md) |
+| Method `extern` produces an empty JS function | Missing `[Script("...")]` body — see [interop/attributes.md](../interop/attributes.md) |
+| Generated JS calls a method that is undefined at runtime | Likely a `[NonScriptable]` member compiled into a call site that should have been gated by `[Conditional]` |
+
+## Cross-links
+
+- [ADR 0007 — Runtime type model](../adr/0007-define-the-javascript-runtime-type-model.md)
+- [ADR 0008 — Class/interface mapping to JS](../adr/0008-define-how-class-and-interface-hierarchies-map-to-javascript.md)
+- [ADR 0011 — Arrays as a wrapped substrate](../adr/0011-treat-arrays-as-a-special-wrapped-runtime-substrate.md)
+- [Limitations & unsupported C# features](../language/limitations.md)
+- [csharp8-todos.md](../../csharp8-todos.md) — current C# 8 status

--- a/docs/framework/sunlight-core.md
+++ b/docs/framework/sunlight-core.md
@@ -1,0 +1,255 @@
+# Sunlight.Framework (core)
+
+> **Audience:** *App authors* building MVVM apps.
+
+## TL;DR
+
+`Sunlight.Framework` is the **canonical reactive contract** for NScript ([ADR 0014](../adr/0014-standardize-the-observable-framework-as-the-reactive-binding-contract.md)). It is the platform's MVVM substrate: observable objects and collections, data binders, IoC, an event bus, an async-aware task scheduler, ambient call context, structured logging, and the layout-batch coordinator. Templates ([XWML](../templates/xwml.md), [Razor](../templates/razor.md)) and UI controls ([Sunlight.Framework.UI](sunlight-ui.md)) are layered on top of it.
+
+## Reference — what is in `Sunlight.Framework`
+
+| Subsystem | Location | Purpose |
+|---|---|---|
+| Observables | `Observables/` | `ObservableObject`, `ObservableCollection<T>`, `INotifyPropertyChanged`, `INotifyCollectionChanged`, `AttachedProperty<T>`, `ExtensibleObservableObject`, `ObservableCollectionTransformer`, `HeaderInjectableTransformer` |
+| Binders | `Binders/` | `DataBinder`, `OneTimeDataBinder`, `OneWayBinder`, `TargetBinder`, `SourcePropertyBinder`, `IConverter`, `IValueConverter`, `ValueConverter`, `DataBindingMode` |
+| IoC | `IoC/` + `IocContainer.cs` | `IocContainer`, `IocHelper` |
+| Events | `EventBus.cs` | Type-keyed pub/sub |
+| Async | `TaskScheduler.cs`, `Lazy.cs`, `LazyAsync.cs`, `Factory.cs` | Cooperative scheduler, lazy initialisation, factory wrapper |
+| Ambient context | `CallContext.cs` | W3C-traceparent-compatible call context (`TraceId`, `SpanId`, `ActionId`, `Depth`) |
+| Logging | `Logger.cs` + `Logging/` | `Logger`, `NamedLogger`, `ILogSink`, `ConsoleSink`, `HttpLogSink`, `LogEvent`, `LogLevel` (see [framework-logging.md](../framework-logging.md)) |
+| Layout batching | `LayoutBatcher.cs` | `requestAnimationFrame` coordinator for layout-sensitive DOM reads (see [ADR 0015](../adr/0015-defer-layout-sensitive-dom-reads-and-batch-them.md)) |
+| Helpers | `ExceptionHelpers.cs` | `ThrowOnArgumentNull`, etc. |
+| Properties | `Properties/` | `AttachedProperty<T>` extension methods (`SetValue` / `GetValue` on `INotifyPropertyChanged`) |
+
+## Quick start — an `ObservableObject`
+
+```csharp
+using Sunlight.Framework.Observables;
+
+public class TodoItem : ObservableObject
+{
+    private string title = "";
+    public string Title
+    {
+        get { return this.title; }
+        set
+        {
+            if (this.title == value) return;
+            this.title = value;
+            this.FirePropertyChanged("Title");
+        }
+    }
+}
+```
+
+`FirePropertyChanged("Title")` notifies every subscriber — including bindings produced from a Razor / XWML template — that `Title` has changed. Subscribers cache by exact property name string; renames are not transparent.
+
+### Subscribe directly
+
+```csharp
+var item = new TodoItem();
+item.AddPropertyChangedListener("Title",
+    (sender, propName) => Console.WriteLine("title changed"));
+
+item.Title = "Buy milk";   // fires
+```
+
+`AnyPropertyListener` is the equivalent for "any property". Both are stored on the object as a `StringDictionary<Action<...>>`; there is no per-property allocation until a listener is added.
+
+### `ObservableCollection<T>`
+
+```csharp
+var todos = new ObservableCollection<TodoItem>();
+todos.CollectionChanged += (s, e) => RefreshList();
+todos.Add(new TodoItem());
+todos.RemoveAt(0);
+```
+
+`CollectionChangedAction` covers `Add`, `Remove`, `Replace`, `Reset`. Bound list views (`ListView` in `Sunlight.Framework.UI`) consume these directly.
+
+## Reference — Binders
+
+| Type | Mode | Use |
+|---|---|---|
+| `OneTimeDataBinder` | `OneTime` | Read once at template bind time; never tracks changes |
+| `OneWayBinder` | `OneWay` | Source → target; subscribes to `INotifyPropertyChanged` |
+| `TargetBinder` | `TwoWay` (target side) | Combines a source binder with a write-back path |
+| `SourcePropertyBinder` | helper | Reads from a property path on a source object |
+| `ValueConverter` / `IValueConverter` | both | Inserts a transform between source and target |
+
+`DataBindingMode` is the enum: `OneTime`, `OneWay`, `TwoWay`. Templates default to `OneTime` unless [ADR 0020](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md)'s analyzer determines the property is observable.
+
+In Razor templates these binders are largely transparent — the compile-time DAG ([ADR 0018](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)) generates the equivalent reactive plumbing. You construct them by hand only when wiring custom controls.
+
+## Reference — IoC
+
+`IocContainer` is a typed service-locator with two flavours of registration: per-resolve factory and singleton.
+
+```csharp
+var ioc = new IocContainer();
+
+// Singleton — first call creates, subsequent calls return same instance
+ioc.RegisterSingleton<IClock>(c => new SystemClock());
+
+// Per-resolve — factory invoked on every Get
+ioc.Register<IRequestHandler>(c => new HttpRequestHandler(c.Get<IClock>()));
+
+var clock = ioc.Get<IClock>();
+```
+
+Generics on `IocContainer` are erased through `[IgnoreGenericArguments]`; the registry key is the runtime `TypeId` of `T`. As a consequence: do not register two services with the same closed-generic shape unless you intend the second to overwrite the first.
+
+## Reference — `EventBus`
+
+Process-wide pub/sub keyed on the message type:
+
+```csharp
+public class FilterChanged { public string Filter; }
+
+bus.Subscribe<FilterChanged>(msg => RefreshView(msg.Filter));
+bus.Publish(new FilterChanged { Filter = "open" });
+```
+
+`oneTimeValues` lets you publish a "sticky" value that any subscriber added later sees once. Use `OneTimePublish<T>(T)` for the late-subscriber pattern.
+
+## Reference — `TaskScheduler`
+
+Cooperative scheduler that wraps `setTimeout`, `setInterval`, `setImmediate`, and `requestAnimationFrame`. Uses:
+
+- `TaskScheduler.QueueImmediate(Action)` — runs after the current sync stack
+- `TaskScheduler.Delay(int ms, Action)` — runs after a delay
+- `TaskScheduler.RequestAnimationFrame(Action)` — runs on the next paint
+- All scheduled work captures the ambient `CallContext` and restores it before invoking the callback
+
+The scheduler is what makes `async`/`await` correlate trace/span ids across async boundaries. Don't hand-roll `Globals.SetTimeout` for in-app work — you'll lose call-context propagation.
+
+## Reference — `CallContext`
+
+Ambient context that flows across async boundaries. Analogous to .NET `AsyncLocal<T>`, but JS-single-threaded so a static `Current` is safe for synchronous code:
+
+```csharp
+var ctx = new CallContext("trace-abc", "span-1", parentSpan: null, depth: 0, actionId: 1);
+using (ctx.Activate())
+{
+    // CallContext.Current returns ctx here; survives await
+    DoWork();
+}
+```
+
+`EventBinder` roots a new `CallContext` for each user gesture (DOM event whose target is an `Element`). Async I/O completion events (IndexedDB, XHR onload) explicitly skip rooting so they run *under the action that issued the request*.
+
+## Reference — `LayoutBatcher`
+
+Layout-sensitive DOM reads (`OffsetWidth`, `GetBoundingClientRect`, …) interleaved with writes cause forced reflow. `LayoutBatcher` batches reads via `requestAnimationFrame` and resolves continuations through `setImmediate`:
+
+```csharp
+public class CardView : UIElement
+{
+    public Task<double> ActualWidthAsync => LayoutBatcher.ReadAsync(this.Element, e => e.OffsetWidth);
+}
+```
+
+The split rAF (measure) + setImmediate (dispatch) is what prevents same-frame layout thrash from resolver code. See [ADR 0015](../adr/0015-defer-layout-sensitive-dom-reads-and-batch-them.md).
+
+## Reference — `Logger`
+
+See the dedicated page: [Structured client logging](../framework-logging.md). Highlights:
+
+- `Logger.ForCategory("MyApp.MyComponent")` returns a cached `NamedLogger`
+- Property bags use `string[]` flat key/value arrays (NScript minifies field names)
+- `Trace` / `Debug` are `[Conditional("DEBUG")]` — stripped from Release at the *caller's* compilation
+- `ILogSink` is the extension point; built-ins are `ConsoleSink` and `HttpLogSink`
+
+## Examples
+
+### MVVM with binders by hand
+
+```csharp
+public class TitleViewModel : ObservableObject
+{
+    string title = "";
+    public string Title
+    {
+        get { return this.title; }
+        set { if (this.title != value) { this.title = value; FirePropertyChanged("Title"); } }
+    }
+}
+
+var vm = new TitleViewModel();
+var titleEl = Document.GetElementById("title");
+
+new OneWayBinder(
+    source: vm,
+    sourcePath: "Title",
+    target: titleEl,
+    targetSetter: (el, v) => ((Element)el).InnerHTML = (string)v);
+
+vm.Title = "Inbox";   // titleEl.innerHTML now reads "Inbox"
+```
+
+In practice you write a template ([Razor](../templates/razor.md) preferred); binders are illustrative.
+
+### Lazy initialisation with creation callback
+
+```csharp
+var lazyService = new Lazy<IDataService>(() => container.Get<IDataService>());
+lazyService.OnCreated += () => Console.WriteLine("service constructed");
+var s = lazyService.Value;   // factory runs, OnCreated fires once
+```
+
+### Pub/sub through `EventBus`
+
+```csharp
+public class UserSignedIn { public string UserId; }
+
+bus.Subscribe<UserSignedIn>(m => Logger.ForCategory("Auth").Info("signed in",
+    new string[] { "userId", m.UserId }));
+
+bus.Publish(new UserSignedIn { UserId = "u1" });
+```
+
+## Known gotchas
+
+### `FirePropertyChanged` uses string names
+
+If you rename a property, you must update every `FirePropertyChanged("OldName")` call site. There is no `nameof` analyzer wiring; misspellings are silent (no warning, no exception, just no notification).
+
+### `ObservableCollection<T>.RemoveAt(0)`
+
+Inherits the `List<T>.RemoveAt(0)` O(n) characteristic; see [framework/core.md](core.md#known-gotchas).
+
+### Singleton resolution before construction
+
+`IocContainer.Get<T>` constructs lazily on first access. If two singletons cyclically depend on each other, the second `Get<T>` call inside the first factory hits an under-construction state. Break cycles with `Func<T>` parameters or `Lazy<T>`.
+
+### `EventBus.Subscribe<T>` has no automatic unsubscribe
+
+Subscribers are held by the bus until `UnSubscribe<T>` is called — this is a leak source for view-scoped subscribers. Dispose subscriptions in your view tear-down.
+
+### `CallContext` reset must zero coupled fields
+
+If you roll a custom helper that resets `CallContext.Current`, also reset `eventDispatchDepth`. Resetting only `current` lets the outer `OnEventDispatchEnd` silently restore stale `prev` (WI-21 incident).
+
+### `LayoutBatcher` and EventBinder gating
+
+`LayoutBatcher` continuations resolve through `setImmediate`, which is gated by `EventBinder.OnEventDispatch` for user-gesture rooting. Async I/O continuations explicitly skip rooting; do not invent your own dispatch path that bypasses `EventBinder` (you will create orphan call-context roots).
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| Property change does not propagate to view | Missing `FirePropertyChanged` or wrong property-name string |
+| Memory grows when navigating between views | `EventBus` subscriptions or `AddPropertyChangedListener` not torn down |
+| Stack overflow in property setter | Setter calls `FirePropertyChanged` without the `if (old == new) return;` guard |
+| Trace/Debug logs missing in Release | Expected — `[Conditional("DEBUG")]` stripped them |
+| Forced reflow in profile | Layout reads not routed through `LayoutBatcher` |
+
+## Cross-links
+
+- [ADR 0014 — Observable framework as reactive contract](../adr/0014-standardize-the-observable-framework-as-the-reactive-binding-contract.md)
+- [ADR 0015 — Defer layout-sensitive DOM reads](../adr/0015-defer-layout-sensitive-dom-reads-and-batch-them.md)
+- [ADR 0018 — Compile-time DAG binding](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)
+- [ADR 0020 — Auto-detect binding mode](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md)
+- [Sunlight UI](sunlight-ui.md) layered on top
+- [Razor templates](../templates/razor.md), [XWML templates](../templates/xwml.md)
+- [Structured client logging](../framework-logging.md)

--- a/docs/framework/sunlight-ui.md
+++ b/docs/framework/sunlight-ui.md
@@ -1,0 +1,181 @@
+# Sunlight.Framework.UI (controls)
+
+> **Audience:** *App authors*.
+
+## TL;DR
+
+`Sunlight.Framework.UI` provides the **UIElement** base class with two parallel subclass families — `UIPanel` (typed `Children` collection) and `UISkinableElement` (template materialisation via `Skin` / `SkinInstance`) — plus `ListView` (a direct `UIElement` subclass for collection rendering). The `Skin` / `SkinInstance` system materialises a [Razor](../templates/razor.md) or [XWML](../templates/xwml.md) template against a data context, and the binding-strategy attributes (`AutoFire`, `DefaultDataBinding`, `NonBindable`) shape how templates resolve properties.
+
+## Reference — class hierarchy
+
+```mermaid
+classDiagram
+  ContextBindableObject <|-- UIElement
+  UIElement <|-- UIPanel
+  UIElement <|-- UISkinableElement
+  UIElement <|-- ListView
+  UISkinableElement <|-- ListViewItem
+  ContextBindableObject : INotifyPropertyChanged
+  UIElement : Element element
+  UIElement : IocContainer Container
+  UIElement : event OnClick
+  UIPanel : ObservableCollection~UIElement~ Children
+  UISkinableElement : Skin Skin
+  UISkinableElement : SkinInstance SkinInstance
+  ListView : ObservableCollection ObservableList
+  ListView : Skin ItemSkin
+```
+
+| Class | Purpose |
+|---|---|
+| `UIElement` | Base for every control. Wraps a DOM `Element`, exposes `CssClass` (synced with `Element.ClassName`), bound events (`OnClick`, …), and is itself an `ObservableObject` so its properties can be data-bound. |
+| `UIPanel` | Adds a typed `Children` `ObservableCollection<UIElement>` that mirrors DOM children. Subclasses pick layout. |
+| `UISkinableElement` | Adds `Skin` + `SkinInstance` properties. Setting `Skin` triggers materialisation against the current data context using `IBindingStrategy` (see [ADR 0019](../adr/0019-extract-ibindingstrategy-from-skininstance.md)). |
+| `ListView` | A `<ul>`-tagged `UIElement` bound to either `FixedList` (`IList`) or `ObservableList` (`IObservableCollection`). Each item is rendered through `ItemSkin`. Optional `HeaderSkin`. `TopN` caps the visible count. |
+| `ListViewItem` | The per-item control inside a `ListView`. |
+
+## Reference — `Skin` / `SkinInstance` / `IBindingStrategy`
+
+A `Skin` is the *factory* for a template instance. Materialising it produces a `SkinInstance` — the live DOM subtree with bindings hooked into the source object.
+
+```csharp
+public class Skin
+{
+    public Skin(Type skinableType, Type dataContextType,
+                Func<Skin, Document, SkinInstance> factoryMethod, string id);
+
+    public string Id { get; }
+    public Type SkinableType { get; }
+    public Type DataContextType { get; }
+}
+```
+
+`SkinInstance` delegates the actual binding work to an `IBindingStrategy`:
+
+- `LegacyBinderStrategy` — runs the [XWML](../templates/xwml.md) binder pipeline at runtime.
+- `GraphBindingStrategy` — runs the compile-time DAG produced by the [Razor](../templates/razor.md) frontend ([ADR 0018](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)).
+
+Application code generally does not construct strategies directly — the template compiler emits the appropriate factory.
+
+## Reference — Sunlight.Framework.UI attributes
+
+| Attribute | Target | Effect | ADR |
+|---|---|---|---|
+| `[AutoFire(params string[] alsoFire)]` | Property | Compiler auto-emits a `FirePropertyChanged("X")` (and one per name in `alsoFire`) when the setter completes. Eliminates the boilerplate `if (old==new) return; old=new; FirePropertyChanged(...)`. | [0014](../adr/0014-standardize-the-observable-framework-as-the-reactive-binding-contract.md) |
+| `[DefaultDataBinding(Mode = DataBindingMode.OneWay)]` | Property | Sets the default binding mode for templates referencing this property. `IsStrict = true` rejects mismatched modes at compile time. `DefaultValue` initialises the property when bound. | [0020](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md) |
+| `[NonBindable]` | Property | Excludes from template binding analysis. Useful when a property is on an `ObservableObject` but should not be reachable from `{Foo}` syntax. | — |
+| `[Skin]` | Type | Marks a class as a control whose skin is loaded by `SkinFactory`. | — |
+| `[SkinPart]` / `[TemplatePart]` | Field | Names a placeholder inside the skin that the host control will receive a reference to after materialisation. | — |
+| `[TemplateBehavior]` | Type | Wires extra runtime behavior into a template at materialisation time. | — |
+| `[TemplateFile]` | Type | Points at the `.html` (XWML) or `.skin.cshtml` (Razor) file backing the control. | — |
+| `[TagName("ul")]` | Type | Pre-declares the DOM tag a control wraps; `ListView` declares `[TagName("ul")]` so `new ListView(Document.CreateElement("ul"))` is the canonical construction. | — |
+| `[CssClass]` / `[CssName]` | Property / class | Marks CSS class members; `CssClass` integrates with strict-CSS template diagnostics ([ADR 0016](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)). | 0016 |
+| `[DomAttribute]` | Property | Marks a property whose setter writes through to the DOM `Element`'s attribute / property. | — |
+
+## Quick start — a custom control
+
+```csharp
+using Sunlight.Framework.Observables;
+using Sunlight.Framework.UI;
+using Sunlight.Framework.UI.Attributes;
+using System.Web.Html;
+
+[TagName("button")]
+public class ToggleButton : UIElement
+{
+    public ToggleButton(Element element) : base(element) { }
+
+    [AutoFire]
+    public bool IsOn { get; set; }
+
+    [AutoFire("DisplayText")]
+    public string Label { get; set; }
+
+    public string DisplayText
+    {
+        get { return this.IsOn ? this.Label + " (on)" : this.Label; }
+    }
+}
+```
+
+`[AutoFire]` on `IsOn` and `Label` removes manual `FirePropertyChanged` calls. The `("DisplayText")` argument additionally fires `DisplayText` whenever `Label` changes — that's how a derived display value is kept fresh without manual subscription.
+
+## Examples
+
+### Bind a `ListView` to an `ObservableCollection`
+
+```csharp
+var list = new ListView(Document.CreateElement("ul"));
+list.ObservableList = todos;             // ObservableCollection<TodoItem>
+list.ItemSkin = SkinFactory.Resolve<TodoItem>("TodoItemSkin");
+container.AppendChild(list.Element);
+```
+
+When `todos.Add(...)` fires, `ListView` reacts via `INotifyCollectionChanged` and instantiates a fresh `ListViewItem` from `ItemSkin` for the new entry. `TopN` caps the rendered count for very long lists; items past `TopN` are excluded entirely (no virtualisation — they are simply not in the DOM until `TopN` is increased).
+
+### Use `[DefaultDataBinding]` to set a strict mode
+
+```csharp
+public class FilterViewModel : ObservableObject
+{
+    [DefaultDataBinding(Mode = DataBindingMode.TwoWay, IsStrict = true)]
+    [AutoFire]
+    public string Filter { get; set; }
+}
+```
+
+A template that binds `{Filter}` in OneWay mode against this property will fail compilation: `IsStrict = true` requires an exact match.
+
+### Hide a property from binding analysis
+
+```csharp
+public class CartViewModel : ObservableObject
+{
+    [AutoFire] public ObservableCollection<CartItem> Items { get; set; }
+
+    [NonBindable]
+    public IocContainer Container { get; set; }
+}
+```
+
+`Container` is on the type for IoC reasons but should never be discovered by `{Container}` template syntax.
+
+## Known gotchas
+
+### `Children.Add` only — no manual `Element.AppendChild`
+
+`UIPanel.Children` is the source of truth. The internal `ChildrenCollectionChanged` handler mirrors changes to the DOM `Element`. If you call `panel.Element.AppendChild(child.Element)` directly, the `Children` collection will be out of sync and removal won't work as expected.
+
+### `ListView.TopN` is a hard cap, not a virtualisation hint
+
+Items past `TopN` are not in the DOM. There is no automatic load-on-scroll. If you need virtualisation, build it as a separate control.
+
+### `[AutoFire]` on a property without a setter is a no-op
+
+The compiler emits the FirePropertyChanged hook in the setter body. A computed property (`get` only) has no setter to instrument; use `[AutoFire("ComputedName")]` on the dependency setter instead.
+
+### `Skin` materialisation is synchronous
+
+`SkinInstance` is built synchronously when `Skin` is set. Heavy templates can spike the main thread. For large dynamic surfaces, prefer streaming via `ListView` (which materialises items on demand as the collection mutates).
+
+### `OnClick` (and other event properties) routes through `EventBinder`
+
+This is by design — it's how `CallContext` roots a new action per user gesture (see [Sunlight Core](sunlight-core.md#reference--callcontext)). If you bypass it with raw `Element.AddEventListener` you opt out of trace propagation.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| Property change in viewmodel doesn't refresh the rendered template | Property missing `[AutoFire]` (or manual `FirePropertyChanged` call) |
+| Template binds to wrong/raw value | Missing `[DefaultDataBinding]` mode hint and binding analyzer fell back to `OneTime` |
+| `ListView` items duplicate when collection updates | `ObservableList` and `FixedList` set simultaneously, or the same `ItemSkin` materialised twice |
+| `Skin` set but `SkinInstance` is null | `dataContextType` mismatch with `DataContext` — strategy refused to build |
+
+## Cross-links
+
+- [Sunlight Core](sunlight-core.md) — observables, binders, IoC, logging
+- [Razor templates](../templates/razor.md), [XWML templates](../templates/xwml.md)
+- [ADR 0014 — Reactive contract](../adr/0014-standardize-the-observable-framework-as-the-reactive-binding-contract.md)
+- [ADR 0016 — XWML strict CSS / binding diagnostics](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)
+- [ADR 0019 — `IBindingStrategy` extraction](../adr/0019-extract-ibindingstrategy-from-skininstance.md)
+- [ADR 0020 — Auto-detect binding mode](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md)

--- a/docs/framework/web.md
+++ b/docs/framework/web.md
@@ -1,0 +1,151 @@
+# Framework Web & DOM
+
+> **Audience:** *App authors*.
+
+## TL;DR
+
+`System.Web` and `System.Web.Html` are NScript's typed bindings to the browser environment. `System.Web` covers the global helpers (`encodeURIComponent`, `JSON`, timers, `XMLHttpRequest`, `WebSocket`, `Performance`); `System.Web.Html` covers the DOM (`Document`, `Element`, all common element subclasses, events). Both are thin façades modelled via the `[ImportedType]` / `[Extended]` attribute pattern (see [ADR 0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md) and [interop/json-and-imported-types.md](../interop/json-and-imported-types.md)).
+
+## Reference — `System.Web`
+
+| Type | Purpose |
+|---|---|
+| `Globals` | `[GlobalMethods]` static class. Hosts `EncodeURIComponent`, `DecodeURIComponent`, `EncodeURI`, `DecodeURI`, `SetTimeout`, `ClearTimeout`, `SetInterval`, etc. |
+| `Window` | The browser window. Lives in `System.Web.Html`. |
+| `JSON` | `JSON.Parse(string)` / `JSON.Stringify(object)` — the standard JS `JSON` global with .NET-shaped names. |
+| `Blob`, `URL` | Standard `Blob` and `URL` constructors. `URL.CreateObjectURL`, `RevokeObjectURL`. |
+| `WebSocket` | Browser WebSocket API. |
+| `XMLHttpRequest` | XHR with `ReadyState` enum, `OnReadyStateChange`, `Open`, `Send`, response props. |
+| `Performance` | `performance.now()` and the timing API. |
+
+## Reference — `System.Web.Html`
+
+| Type | Purpose |
+|---|---|
+| `Document` | Static-style accessors for the `document` global: `GetElementById`, `CreateElement`, `Body`, `QuerySelector`, etc. |
+| `Element` (base) | Common DOM element surface: `InnerHTML`, `ClassName`, `Style`, `AddEventListener`, attribute getters / setters, `OffsetWidth`, `OffsetHeight`, `GetBoundingClientRect`, etc. |
+| Element subclasses | `DivElement`, `InputElement`, `AnchorElement`, `ImageElement`, `CanvasElement`, `TableElement` / `TableRowElement` / `TableCellElement`, `FormElement`, `SelectElement`, `OptionElement`, `TextAreaElement`, `IFrameElement`, `MediaElement`, `AudioElement`, `VideoElement`, `ScriptElement`, `MapElement`, `AreaElement` |
+| Events | `ElementEvent` (base), `MutableEvent`, `MessageEvent`, `ErrorEvent`, `TouchEvent`, `WheelEvent`, `GestureEvent`, `CustomEvent` |
+| Form / file APIs | `FormData`, `FileInput`, `File`, `FileReader`, `DataTransfer` |
+| Layout | `ClientRect`, `Style`, `TokenList`, `NodeCollection`, `DomList<T>`, `Selection`, `Orientation` |
+| Geo / graphics | `GeoLocation/`, `Graphics/` (canvas helpers) |
+
+The full file list is under `Sources/Framework/System.Web/` and `Sources/Framework/System.Web.Html/`.
+
+## Quick start
+
+### Mutate the DOM
+
+```csharp
+using System.Web.Html;
+
+var container = Document.GetElementById("app");
+container.InnerHTML = "<h1>Hello!</h1>";
+container.ClassName = "ready";
+```
+
+### Listen to events
+
+```csharp
+using System.Web.Html;
+
+var btn = Document.GetElementById("save");
+btn.AddEventListener("click", evt =>
+{
+    evt.PreventDefault();
+    DoSave();
+});
+```
+
+### Fetch JSON via XHR
+
+```csharp
+using System.Web;
+
+void LoadItems(Action<string[]> onSuccess)
+{
+    var xhr = new XMLHttpRequest();
+    xhr.Open("GET", "/api/items", true);
+    xhr.OnReadyStateChange = () =>
+    {
+        if (xhr.ReadyState != ReadyState.Done) return;
+        if (xhr.Status != 200) return;
+        var ids = (string[])JSON.Parse(xhr.ResponseText);
+        onSuccess(ids);
+    };
+    xhr.Send(null);
+}
+```
+
+### Cross the EventBinder boundary
+
+DOM events on `Element` subclasses route through `Sunlight.Framework.EventBinder`, which is what `[CallContext]` uses to root a new ambient context per user gesture. If you bypass `Element.AddEventListener` (e.g. by using `[Script]` to hand-roll `addEventListener`), call-context propagation may break. Always prefer the typed `AddEventListener` overload. See [ADR 0014](../adr/0014-standardize-the-observable-framework-as-the-reactive-binding-contract.md).
+
+## Examples
+
+### Use `Globals` static helpers
+
+```csharp
+using System.Web;
+
+string url = Globals.EncodeURI("/path with spaces?x=1");
+int handle = Globals.SetTimeout(() => Console.WriteLine("tick"), 100);
+Globals.ClearTimeout(handle);
+```
+
+`Globals` is annotated `[GlobalMethods]`, so calls compile to bare JS function calls (`encodeURI(...)`) rather than `Globals.encodeURI(...)`.
+
+### Read layout-sensitive measurements
+
+Layout reads (`OffsetWidth`, `GetBoundingClientRect`, …) trigger forced reflow if interleaved with writes. Batch them via the `Sunlight.Framework.LayoutBatcher` async-property pattern when reading at scale; see [ADR 0015](../adr/0015-defer-layout-sensitive-dom-reads-and-batch-them.md) and the `framework/sunlight-core.md` section on `LayoutBatcher`.
+
+### File upload via `FormData`
+
+```csharp
+var form = new FormData();
+form.Append("file", fileInput.Files[0]);
+form.Append("description", "screenshot");
+
+var xhr = new XMLHttpRequest();
+xhr.Open("POST", "/upload", true);
+xhr.Send(form);
+```
+
+## Known gotchas
+
+### `Element` is not `[JsonType]`
+
+`Element` and its subclasses are `[ImportedType]` façades — they wrap real native DOM objects. Do not pass them through `structuredClone`, `JSON.stringify`, IndexedDB `put()`, or any path that expects a plain data record. Use a `[JsonType]` DTO for serialisable data; see [interop/json-and-imported-types.md](../interop/json-and-imported-types.md).
+
+### Property access compiles to property access — no defensive nulls
+
+`element.InnerHTML = ...` is a direct property write. If `element` is `null` (the lookup failed), you'll get a TypeError at runtime, not a `NullReferenceException`. Consider `if (element != null)` or use `Document.QuerySelector` and check the result.
+
+### Event handler `this` in lambdas
+
+C# lambdas capture the outer `this`. The compiler binds DOM event handlers so the lambda's `this` is *not* the element that fired the event. If you need the firing element, read `evt.Target` (or the more specific `evt.CurrentTarget`).
+
+### `CustomEvent` does not survive `[Conditional]` argument stripping
+
+`Logger.Debug("event", new string[]{"type", evt.Type})` — if the `evt` capture lives only inside the call, `[Conditional("DEBUG")]` strips the entire call site in Release including the `evt.Type` read. Don't rely on Trace/Debug calls for event-side effects.
+
+### `[Script]` attributes on extern methods
+
+Many `System.Web` methods are `extern` with a `[Script]` body. If you reference these methods from outside the `System.Web` assembly via reflection-style helpers, the body is still inlined — but if you copy/paste-clone a method without copying its `[Script]` attribute, the resulting method is a no-op.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `Cannot read properties of null (reading 'innerHTML')` | `Document.GetElementById` returned null (DOM not ready, or wrong id) |
+| `JSON.parse: unexpected token` | XHR returned HTML / 4xx body instead of JSON; check `xhr.Status` first |
+| `evt.target` is undefined in handler | Bound the listener with raw `[Script]` instead of typed `AddEventListener` |
+| Layout thrash / slow scroll | Read/write/read interleave; route layout reads through `LayoutBatcher` |
+
+## Cross-links
+
+- [ADR 0010 — Imported types pattern](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md)
+- [ADR 0015 — Layout-batched DOM reads](../adr/0015-defer-layout-sensitive-dom-reads-and-batch-them.md)
+- [Interop attributes reference](../interop/attributes.md)
+- [JsonType / ImportedType patterns](../interop/json-and-imported-types.md)
+- [Sunlight Core](sunlight-core.md) for `EventBinder`, `CallContext`, and `LayoutBatcher`

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -8,7 +8,7 @@ NScript compiles your C# project into a single JavaScript file. You write `.cs` 
 
 ## Prerequisites
 
-- **.NET 8.0 SDK 8.0.416** — pinned by `global.json` at the repo root. Other 8.0.x SDKs may work but are not the supported configuration.
+- **.NET SDK 10.0.100** — pinned by `global.json` at the repo root (`rollForward: latestMinor`). Newer 10.0.x SDKs are accepted; older majors are not the supported configuration.
 - **A web server to host the generated JS** — `npx serve`, IIS Express, `python -m http.server`, anything that serves static files.
 - **A modern browser** — Chrome / Edge / Firefox. NScript's runtime targets evergreen browsers; no IE11 support.
 
@@ -36,7 +36,7 @@ namespace HelloWorld
 }
 ```
 
-The `[EntryPoint]` attribute on the type containing the `static Main` method is how NScript identifies the application root. Without it, demand-driven dead-code elimination (see [ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) will strip your program.
+The `[EntryPoint]` attribute on the `static Main` method is how NScript identifies the application root (the attribute targets methods — see `Sources/Framework/mscorlib/Runtime/CompilerServices/EntryPointAttribute.cs`). Without it, demand-driven dead-code elimination (see [ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) will strip your program.
 
 ### Project file
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,139 @@
+# Getting started with NScript
+
+> **Audience:** *App authors* — first time picking up NScript.
+
+## TL;DR
+
+NScript compiles your C# project into a single JavaScript file. You write `.cs` files, run `dotnet build`, and a `.js` artifact lands in your web app's script directory. This page walks you from a fresh checkout to a "Hello, World" page in the browser, then lists the day-1 surprises that catch new contributors.
+
+## Prerequisites
+
+- **.NET 8.0 SDK 8.0.416** — pinned by `global.json` at the repo root. Other 8.0.x SDKs may work but are not the supported configuration.
+- **A web server to host the generated JS** — `npx serve`, IIS Express, `python -m http.server`, anything that serves static files.
+- **A modern browser** — Chrome / Edge / Firefox. NScript's runtime targets evergreen browsers; no IE11 support.
+
+NScript itself ships as a custom MSBuild SDK (`Mcqdb.NScript.Sdk`) plus a set of NuGet runtime libraries. You do not call the compiler directly — `dotnet build` does it for you.
+
+## Quick start: Hello, World
+
+The repo includes Visual Studio project templates under `NScriptToolSet/Templates/ProjectTemplate/`. The minimum NScript program is:
+
+```csharp
+namespace HelloWorld
+{
+    using System.Web.Html;
+    using System.Runtime.CompilerServices;  // for [EntryPoint]
+
+    public class Program
+    {
+        [EntryPoint]
+        public static void Main()
+        {
+            var container = Document.GetElementById("app");
+            container.InnerHTML = "<h1>Hello, World from C#!</h1>";
+        }
+    }
+}
+```
+
+The `[EntryPoint]` attribute on the type containing the `static Main` method is how NScript identifies the application root. Without it, demand-driven dead-code elimination (see [ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) will strip your program.
+
+### Project file
+
+```xml
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <NoStdLib>True</NoStdLib>
+    <GenerateJs>True</GenerateJs>
+    <JsOutputPath>..\WebApplication\Scripts</JsOutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="$(NScriptToolSetPath)\lib\mscorlib.dll" />
+    <Reference Include="$(NScriptToolSetPath)\lib\System.Core.dll" />
+    <Reference Include="$(NScriptToolSetPath)\lib\System.Web.dll" />
+    <Reference Include="$(NScriptToolSetPath)\lib\System.Web.Html.dll" />
+    <Reference Include="$(NScriptToolSetPath)\lib\Sunlight.Framework.dll" />
+    <Reference Include="$(NScriptToolSetPath)\lib\Sunlight.Framework.UI.dll" />
+  </ItemGroup>
+</Project>
+```
+
+`<NoStdLib>True</NoStdLib>` is critical: NScript ships its own `mscorlib.dll` whose surface is documented in [framework/core.md](../framework/core.md). The default .NET corlib has types and methods NScript cannot translate. (Projects using the `Mcqdb.NScript.Sdk` MSBuild SDK get the equivalent `<NoStandardLib>true</NoStandardLib>` set automatically — see [build/msbuild-sdk.md](../build/msbuild-sdk.md).)
+
+### Host page
+
+```html
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Hello</title></head>
+<body>
+    <div id="app"></div>
+    <script src="Scripts/HelloWorld.js"></script>
+</body>
+</html>
+```
+
+### Build
+
+```bash
+dotnet build HelloWorld.csproj -c Debug
+```
+
+The build runs `csc` to produce a DLL with the embedded NScript bound AST resource (`$$BstInfo$$`), then runs `nscript.exe` over that DLL to emit the `.js` file. See [compiler/pipeline.md](../compiler/pipeline.md) for the full flow.
+
+## Day-1 pitfalls
+
+These are the surprises that bite every new NScript contributor at least once:
+
+### 1. `[EntryPoint]` is required — silently
+
+Without `[EntryPoint]` the emitted JavaScript runs nothing. There is no startup error: the file is simply (almost) empty because demand-driven DCE pruned everything. If you `console.log` shows nothing on page load, this is the first thing to check.
+
+### 2. `<NoStdLib>True</NoStdLib>` is not optional
+
+If you forget it, the C# compiler will resolve `string`, `int`, etc. to the *default* .NET BCL surface and your code will compile fine — but the NScript stage will then fail to find type definitions in its embedded AST resources, often with cryptic resolution errors. Always set `<NoStdLib>True</NoStdLib>` in NScript projects.
+
+### 3. C# field names get minified
+
+Anything compiled by NScript has its private fields and (with `-uglify`) sometimes property names rewritten to short tokens (`_a`, `_b`, …). This breaks anonymous-object property bags as JSON keys, broken JSON.stringify of `[JsonType]` objects with the wrong attribute set, and any code that grabs a property by string name. See [interop/json-and-imported-types.md](../interop/json-and-imported-types.md) for the typed escape hatches and `framework-logging.md` for the `string[]` flat-array pattern.
+
+### 4. Framework tests need a Debug compiler build
+
+`Test/Framework/*` projects are compiled by the NScript compiler from `NScriptToolSet/bin/Debug/`. If you only built Release, the framework tests will use a stale or missing compiler. Run:
+
+```bash
+dotnet build NScript_Full.sln -c Debug
+```
+
+before working on framework-side tests. See [testing/README.md](../testing/README.md).
+
+### 5. `dynamic`, `yield return`, reflection, P/Invoke — none of these compile
+
+NScript's supported C# subset is documented in [language/limitations.md](../language/limitations.md). The compiler error for these is usually clear, but the common surprise is that `IEnumerable<T>` LINQ chains work fine while `yield return` in your own iterator method does not.
+
+### 6. `extern` methods need a `[Script]` body
+
+Methods declared `extern` are NScript's primary inline-JS escape hatch. Without `[Script("...")]` they emit nothing and crash at runtime. See [ADR 0009](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md) and the [interop attributes reference](../interop/attributes.md).
+
+### 7. `Logger.Trace` / `Logger.Debug` are stripped in Release
+
+`[Conditional("DEBUG")]` is applied by the *caller's* compilation. If your project's Release config does not define `DEBUG` (the default), every call to `Trace` / `Debug` — including argument evaluation — is removed. This is the documented behavior, but the first time you hit "where did my logs go?" it's usually this. See [Structured client logging](../framework-logging.md).
+
+## Where to next
+
+| You want to… | Read |
+|---|---|
+| Understand the supported BCL surface | [framework/core.md](../framework/core.md) |
+| Manipulate the DOM | [framework/web.md](../framework/web.md) |
+| Build a data-bound view | [framework/sunlight-core.md](../framework/sunlight-core.md) + [templates/razor.md](../templates/razor.md) |
+| Call into native JavaScript | [interop/attributes.md](../interop/attributes.md) |
+| Debug your generated JavaScript | [debugging/source-maps.md](../debugging/source-maps.md) |
+| Contribute to the compiler | [compiler/pipeline.md](../compiler/pipeline.md) |
+
+## Cross-links
+
+- [ADR 0006 — Two-stage compilation pipeline](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md)
+- [ADR 0022 — Demand-driven conversion and dead-code elimination](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)
+- [Build & MSBuild SDK](../build/msbuild-sdk.md)

--- a/docs/interop/attributes.md
+++ b/docs/interop/attributes.md
@@ -1,0 +1,201 @@
+# Interop attributes reference
+
+> **Audience:** *App authors* and *framework binders*.
+
+## TL;DR
+
+NScript ships ~20 attributes in `System.Runtime.CompilerServices` (the `mscorlib` clone, *not* the BCL `System.Runtime.CompilerServices`) that control how the compiler emits, names, and wraps types and members. They fall into five families: **inline JS bodies** (`Script`, `Mixin`), **type model** (`ImportedType`, `JsonType`, `Extended`, `NonScriptable`, `GlobalMethods`), **naming** (`ScriptName`, `ScriptAlias`, `ScriptNamespace`, `IgnoreNamespace`, `PreserveCase`, `PreserveName`), **emission control** (`ScriptSkip`, `IntrinsicProperty`, `IntrinsicField`, `AlternateSignature`, `IgnoreGenericArguments`), and **enum/resource shape** (`NamedValues`, `NumericValues`, `Resources`). See [ADR 0009](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md) and [ADR 0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md) for the design rationale.
+
+## Reference — full attribute table
+
+| Attribute | Targets | Effect | ADR |
+|---|---|---|---|
+| `[Script("body")]` | Method, Constructor | Replaces the method body with the inline JS string at conversion time. The body is parsed into JST and resolved against the surrounding scope so identifiers must exist (see [ADR 0012](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)). | [0009](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md) |
+| `[Mixin("expr")]` | Class | Emits a single JS expression for the whole class — used for trivial pass-through types. | — |
+| `[Extended]` | Type | Marks a type as "extended" — generally an attribute that influences the converter; not present at runtime. Always paired with `[NonScriptable]`. | — |
+| `[NonScriptable]` | Type | Type is invisible to the JS emitter — no class, no metadata. Used for compiler-only attributes and helpers. | — |
+| `[ImportedType]` | Type | Type is a façade for a real native JS type (`Element`, `Date`, `Promise` …). Member accesses compile to direct property/method calls; no instance is allocated by NScript. | [0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md) |
+| `[JsonType]` | Type | Type represents a plain JSON record. Member access wraps in `importedExtension` to unbox the JS-side property. Use for serialisable DTOs. | [0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md), [interop/json-and-imported-types](json-and-imported-types.md) |
+| `[PseudoInterfaceType]` | Type | Interface is structural — no runtime metadata is emitted; assignability is duck-typed. Useful for typing native callback shapes. | [0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md) |
+| `[GlobalMethods]` | Class | Static class whose methods compile to bare global calls (`encodeURI(...)` rather than `Globals.encodeURI(...)`). | [0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md) |
+| `[ScriptName("name")]` | Type, Method, Property, Field, Event | Renames the symbol in emitted JS but keeps namespace/context. Use when the JS API uses a different identifier (e.g. `[ScriptName("addEventListener")] AddEventListener`). | — |
+| `[ScriptAlias("alias")]` | Method, Property | Emits the symbol at the *global* scope. Different from `ScriptName` which preserves enclosing context. | — |
+| `[ScriptNamespace("name")]` | Type, Assembly | Overrides the .NET namespace for emission purposes. `[ScriptNamespace("")]` flattens to global. | — |
+| `[IgnoreNamespace]` | Type | Equivalent to `[ScriptNamespace("")]`. The type's name is emitted without namespace prefix. | — |
+| `[PreserveCase]` | Member | Skip the default first-letter-lowercasing of member names (`Foo` stays `Foo` instead of becoming `foo`). | — |
+| `[PreserveName]` | Member, Class | Skip minification renaming for this symbol. Required for names that are observed externally (DOM event names, JSON field names, etc.). | [0021](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md) |
+| `[ScriptSkip]` | Method | Method call is elided in emitted JS — the receiver is substituted for the call expression. Used for identity / no-op casts. | — |
+| `[IntrinsicProperty]` | Property | Property accesses compile to direct field access (`obj.X` not `obj.get_X()`). The property must have only get/set bodies that map 1:1 to a JS field of the same name. | — |
+| `[IntrinsicField]` | Field | Symmetric to `[IntrinsicProperty]` — the field is referenced by literal name. | — |
+| `[AlternateSignature]` | Method, Constructor | Method is an extern overload for tooling — the body is unused; one canonical overload supplies the JS. | — |
+| `[IgnoreGenericArguments]` | Method, Type | Generic type arguments are not emitted into the JS instantiation site. Used when the JS implementation is type-erased. | — |
+| `[NamedValues]` | Enum | Enum values emit as their *name* strings (`"Red"`) rather than ordinals. | — |
+| `[NumericValues]` | Enum | Enum values emit as numeric literals (default behavior — explicit form). | — |
+| `[Resources]` | Class | Marks a static class whose string fields are populated from external `.resx`/resource bundles at compile time. | — |
+| `[EntryPoint]` | Method | Marks the static `Main()` entry-point. The method's containing class becomes the application root. | — |
+
+## Reference — common compositions
+
+Most NScript-specific attributes carry both `[Extended]` and `[NonScriptable]`. The pattern is intentional:
+
+- `[NonScriptable]` keeps the *attribute type itself* out of the emitted JS (it's purely a compiler hint).
+- `[Extended]` opts the type into the converter's "extended attribute" lookup table — without it, the converter ignores it.
+
+When you write a custom converter plugin (see [compiler/plugins.md](../compiler/plugins.md)) that defines its own attribute, follow the same pattern.
+
+## Reference — naming attribute decision tree
+
+```mermaid
+flowchart TB
+    Q1{Need to change<br/>the emitted name?}
+    Q1 -- no --> Done1[Use the C# identifier as-is]
+    Q1 -- yes --> Q2{Is this a global<br/>symbol \(no namespace\)?}
+    Q2 -- yes --> A1["[ScriptAlias(\"globalName\")]"]
+    Q2 -- no --> Q3{Just want to skip<br/>case-lowering?}
+    Q3 -- yes --> A2["[PreserveCase]"]
+    Q3 -- no --> Q4{Want to skip<br/>minification?}
+    Q4 -- yes --> A3["[PreserveName]"]
+    Q4 -- no --> A4["[ScriptName(\"name\")]"]
+```
+
+## Quick start
+
+### Inline JS for a single method
+
+```csharp
+using System.Runtime.CompilerServices;
+
+public static class JsHelpers
+{
+    [Script("return value === undefined;")]
+    public static extern bool IsUndefined(object value);
+}
+```
+
+The body must parse as valid JST. Identifiers like `value` resolve against the parameter list. See [ADR 0012](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md) for resolution rules.
+
+### Wrap a native JS API
+
+```csharp
+using System.Runtime.CompilerServices;
+
+[ImportedType, IgnoreNamespace, ScriptName("Date")]
+public sealed class JsDate
+{
+    public extern JsDate();
+    public extern int GetTime();
+
+    [PreserveCase] public extern int Year { get; }
+}
+
+// Usage compiles to: var d = new Date(); d.getTime();
+var d = new JsDate();
+int t = d.GetTime();
+```
+
+`[IgnoreNamespace]` removes `MyApp.JsDate` → `Date`; `[ScriptName("Date")]` is needed only if the *class name* (not just namespace) differs.
+
+### Mark a type as a global helper
+
+```csharp
+[GlobalMethods, NonScriptable]
+public static class Globals
+{
+    [PreserveCase] public extern static string EncodeURI(string s);
+}
+
+// Usage: Globals.EncodeURI("/x") compiles to: encodeURI("/x")
+```
+
+`[NonScriptable]` here is correct even on a class with bodies — `[GlobalMethods]` rewrites every call site, so the class itself is never instantiated.
+
+## Examples
+
+### Field-name interop
+
+```csharp
+[JsonType, IgnoreNamespace]
+public class TodoDto
+{
+    [PreserveCase] public string Title { get; set; }
+    [PreserveCase] public bool Completed { get; set; }
+}
+```
+
+`[PreserveCase]` keeps `Title` and `Completed` as PascalCase to match a server-side schema. Without it, the emitter lowercases to `title` / `completed`.
+
+### Skip-call optimisation
+
+```csharp
+[ScriptSkip]
+public static T As<T>(this object o) where T : class => (T)o;
+
+// Usage: x.As<Foo>().Bar() compiles to: x.bar()
+```
+
+Useful for identity casts, fluent extension methods that just return their receiver, and type-tag wrappers.
+
+### Alternate signatures for tooling
+
+```csharp
+public class Logger
+{
+    [AlternateSignature] public extern void Log(string msg);
+    [AlternateSignature] public extern void Log(string msg, params object[] args);
+
+    public void Log(string msg, object[] args = null) { /* canonical body */ }
+}
+```
+
+The `extern` overloads provide IntelliSense surfaces; the non-extern version is what the compiler emits.
+
+## Known gotchas
+
+### `[Extended]` + `[NonScriptable]` is the norm
+
+Almost every interop attribute carries both. If you create a custom one and forget `[Extended]`, the converter silently ignores it. If you forget `[NonScriptable]`, the attribute type itself appears in the emitted JS (wasted bytes and a confusing class definition).
+
+### `[Script]` body identifiers must resolve
+
+`[Script("doFoo()")]` where `doFoo` is not a parameter, local, member, or `[GlobalMethods]` static is a *compile* failure ([ADR 0012](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)). To call a true global that's not modelled, route through a `[GlobalMethods]` declaration first.
+
+### `[ScriptName]` vs `[ScriptAlias]`
+
+`ScriptName` only renames *within the existing context* — `MyApp.Foo` becomes `MyApp.Bar`. `ScriptAlias` *also lifts to global scope* — `MyApp.Foo` becomes plain `Bar`. They're often confused; pick based on whether the JS API namespace matches your C# namespace.
+
+### `[PreserveName]` defends against minifier renaming, not casing
+
+The minifier ([ADR 0024](../adr/0024-deduplicate-structurally-identical-functions-after-minification.md)) renames symbols to short tokens. `[PreserveName]` opts out. It does *not* affect first-letter lowering — that's `[PreserveCase]`. Apply both if you want exactly the C# identifier in emitted JS.
+
+### `[IntrinsicProperty]` requires 1:1 mapping
+
+`[IntrinsicProperty] public int X { get; set; }` works because the get/set are pass-throughs to a backing field. If your getter does *anything* (computed value, side effect), `[IntrinsicProperty]` will produce wrong code — drop the attribute and let the converter emit `get_X()` / `set_X()` calls.
+
+### `[ImportedType]` instances cannot be serialized
+
+Field accesses on `[ImportedType]` types go through native property gets, not through NScript metadata. Passing them to `JSON.Stringify`, `structuredClone`, or `IndexedDB` is fine *only if the underlying native object is plain data* — but `Element`, `Date`, `RegExp` etc. are not. See [interop/json-and-imported-types.md](json-and-imported-types.md).
+
+### `[JsonType]` types should not be created in codegen plugins
+
+Per the project [JST codegen rules](../compiler/plugins.md), `[JsonType]` adds an `importedExtension` wrapper on field access — if you hand-build a JST object literal, the wrapper won't match. Use a real `new TypedDto()` allocation instead.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `Cannot resolve name 'foo'` in `[Script]` body | Identifier in the inline body has no matching parameter, member, or global |
+| Property access compiles to `obj.get_X()` not `obj.X` | Missing `[IntrinsicProperty]` |
+| Method call appears in JS but you wanted it elided | Missing `[ScriptSkip]` |
+| Symbol renamed by minifier, breaking external interop | Missing `[PreserveName]` |
+| Custom interop attribute is silently ignored by converter | Missing `[Extended]` |
+| `[Mixin]` produces nothing at runtime | Class is correctly marked but nothing referenced it; demand-driven conversion ([ADR 0022](../adr/0022-demand-driven-conversion-and-dead-code-elimination.md)) elided it |
+
+## Cross-links
+
+- [ADR 0009 — Inline `[Script]` for JS dependencies](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md)
+- [ADR 0010 — Imported types pattern](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md)
+- [ADR 0012 — Inline script resolution](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)
+- [ADR 0021 — Resolved identifiers in codegen](../adr/0021-require-resolved-identifiers-for-all-generated-javascript-symbols.md)
+- [JsonType / ImportedType deep dive](json-and-imported-types.md)
+- [`[Script]` blocks and dynamic JS](dynamic.md)
+- [Compiler plugins](../compiler/plugins.md)

--- a/docs/interop/dynamic.md
+++ b/docs/interop/dynamic.md
@@ -1,0 +1,155 @@
+# `[Script]` blocks and dynamic JS interop
+
+> **Audience:** *App authors* and *binders* writing inline JavaScript that needs to reach back into NScript symbols.
+
+## TL;DR
+
+Inline JavaScript bodies live on `[Script("...")]` attributes attached to `extern` methods or constructors. They are *not* opaque text — `JsniResolver` parses them as JavaScript, scopes them against the surrounding declaration, and resolves identifiers against parameters, locals, members of the enclosing type, types in scope, and a controlled set of registered globals ([ADR 0009](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md), [ADR 0012](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)). Cross-type symbol references use the JSNI-style `@{[Assembly]Namespace.Type::Member}` syntax, which is rewritten to the minified runtime name. Unresolved identifiers fail compilation.
+
+## Reference — directive table
+
+| Directive | Form | Purpose |
+|---|---|---|
+| Bare identifier | `value`, `evt` | Parameter or local |
+| Member of enclosing type | `this.field` | Member of the `[Script]`-bearing declaration |
+| Same-type static via JSNI | `@{Type::Member}` | Static member of the same enclosing type |
+| Cross-type via JSNI | `@{[Assembly]Namespace.Type::Member}` | Static or instance reference in another assembly. Compiles to the resolved (often minified) runtime name. |
+| Bracket access | `obj['x']` | Always literal-property access; opt out of resolution |
+
+## Reference — JSNI symbol syntax
+
+The form `@{[AssemblyName]Namespace.TypeName::MemberName}` mirrors GWT's JSNI but adapts to NScript's resolver pipeline:
+
+- `[AssemblyName]` — required when the target lives in a different assembly. Omit for same-assembly references (`@{Type::Member}`).
+- `Namespace.TypeName` — fully qualified type name as the resolver sees it (post-`[ScriptNamespace]`/`[IgnoreNamespace]` shaping).
+- `::Member` — the member's C# name. The resolver substitutes the emitted (possibly minified) JS name at compile time.
+
+This is what makes inline JS *minification-safe*: even if `CallContext.current` is renamed to `ab`, the JSNI reference `@{[Sunlight.Framework]Sunlight.Framework.CallContext::current}` resolves to `ab` in the emitted code.
+
+## Quick start
+
+### A method-local helper
+
+```csharp
+using System.Runtime.CompilerServices;
+
+public static class JsHelpers
+{
+    [Script("return value === undefined;")]
+    public static extern bool IsUndefined(object value);
+}
+```
+
+`value` resolves to the method parameter. The body emits as the function body of `IsUndefined` after parameter renaming.
+
+### Reading another type's static field
+
+```csharp
+[Script("return !!@{[Sunlight.Framework]Sunlight.Framework.CallContext::current};")]
+public static extern bool HasAmbientContext();
+```
+
+The JSNI form ensures the `current` field reference survives minification.
+
+### Two-callback Promise wiring
+
+```csharp
+[Script(@"
+    var ctx = @{[Sunlight.Framework]Sunlight.Framework.CallContext::current};
+    return p.then(
+        function(v) { @{[Sunlight.Framework]Sunlight.Framework.CallContext::current} = ctx; return v; },
+        function(e) { @{[Sunlight.Framework]Sunlight.Framework.CallContext::current} = ctx; throw e; }
+    );
+")]
+public static extern Promise WrapPromise(Promise p);
+```
+
+Real example from `Sunlight.Framework.CallContext` — captures the ambient context, restores it inside the `.then` continuations so async paths see the call-site context.
+
+## Examples
+
+### Calling an unmodelled global
+
+If you need a global that has no `[GlobalMethods]` C# façade, you can route through `[Script]`:
+
+```csharp
+[Script("return Math.sign(x);")]
+public static extern int Sign(double x);
+```
+
+`Math` is in the resolver's known-globals list. If you reach for something that isn't (`window.cdnLib.foo()`), declare a `[GlobalMethods]` class for it instead — the resolver will reject unknown bare identifiers.
+
+### Exposing diagnostic hooks
+
+```csharp
+[Script(@"
+    if (typeof window !== 'undefined') {
+        window.__myApp = window.__myApp || {};
+        window.__myApp.dump = function() { return @{[MyApp]MyApp.State::Snapshot}(); };
+    }
+")]
+private static extern void ExposeDebugProbe();
+```
+
+Since NScript wraps emitted code in an IIFE, this is the canonical way to expose a debug surface to DevTools / Playwright.
+
+### Boundary check that can't be expressed in C#
+
+```csharp
+[Script("return !!(evt && evt.target && evt.target.tagName);")]
+private static extern bool IsUserGestureEvent(object evt);
+```
+
+Real example again — distinguishes a DOM-Element-based event from an `EventTarget`-based one (IndexedDB success, etc.) by string-truthy `tagName` access. Cleaner than nested null-checks plus `instanceof`.
+
+## Known gotchas
+
+### Unresolved identifiers fail compilation, not runtime
+
+`[Script("doFoo()")]` where `doFoo` is neither a parameter, member, type, nor a known global produces a build error from `JsniResolver`. This is a feature ([ADR 0012](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)) — typos and missing dependencies surface during compile rather than as `ReferenceError` in production.
+
+### `this` in a `[Script]` body refers to the JS receiver, not C# `this`
+
+Inside an instance method's `[Script]` body, `this` is the JavaScript receiver of the emitted function. NScript instance methods compile to functions with explicit `this` parameter; if the method is called as a free function, `this` is `undefined`. Prefer JSNI references (`@{Type::Member}`) when you need stable member access.
+
+### `extern` is required on the C# declaration
+
+`[Script("...")]` is only valid on `extern` methods or constructors — there is no body for the C# compiler to compile, so it must be `extern`. Forgetting `extern` produces a CS0500 from Roslyn before NScript ever sees the method.
+
+### Bracket access disables resolution
+
+`obj['x']` is treated as plain literal-property lookup. The resolver does not try to bind `'x'` against any member. Use this when you need to access a property whose name might collide with a renamed C# member.
+
+### Multi-line bodies must be raw strings
+
+C# verbatim-string `@"..."` is the standard pattern for multi-line `[Script]` bodies. Beware: `"` inside the body must be doubled (`""`).
+
+### Resolver runs against the current scope, not the call site
+
+Identifiers resolve based on the enclosing declaration's scope, not where the method is *called*. A `[Script]` body cannot see the caller's locals.
+
+### Trace/Debug calls inside `[Script]` bodies are not stripped by `[Conditional]`
+
+`[Conditional("DEBUG")]` strips at the *caller* — but a `[Script]` body is opaque to the C# compiler. If you embed a debug log inside the JS string, it survives Release builds. Drive logging from outside the `[Script]` body (in C#) instead.
+
+### Performance: every `[Script]` body parses at compile time
+
+The JS parser runs over each `[Script]` body. Long, repetitive bodies are fine but slow incremental compiles. Extract shared helpers into a regular C# method that calls a smaller `[Script]` block.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `Cannot resolve identifier 'foo'` from `[Script]` body | Identifier missing from parameters/members/types/known-globals; add a `[GlobalMethods]` declaration if it's a real global |
+| `JSNI member 'X' not found on type 'T'` | Wrong member name in `@{[Asm]NS.T::X}`; check casing and that `X` exists on `T` |
+| `Assembly 'X' not referenced` from JSNI | The target type lives in an assembly not on the project's reference list |
+| `[Script]` body compiles but emits wrong runtime calls | Likely a missing JSNI reference — bare identifier matched a parameter rather than the intended member; switch to JSNI |
+| Identifier renamed by minifier breaks call into JS | `[Script]` body uses a bare identifier instead of JSNI; or the target needs `[PreserveName]` |
+
+## Cross-links
+
+- [ADR 0009 — Inline `[Script]` for JS dependencies](../adr/0009-prefer-inline-script-attribute-for-javascript-dependencies.md)
+- [ADR 0012 — Inline script resolution](../adr/0012-parse-and-resolve-script-blocks-against-types-members-and-known-globals.md)
+- [Interop attributes reference](attributes.md)
+- [JsonType / ImportedType deep dive](json-and-imported-types.md)
+- [Compiler plugins (resolver internals)](../compiler/plugins.md)

--- a/docs/interop/json-and-imported-types.md
+++ b/docs/interop/json-and-imported-types.md
@@ -1,0 +1,211 @@
+# `[ImportedType]`, `[JsonType]`, and `[PseudoInterfaceType]`
+
+> **Audience:** *App authors* and *binders* writing typed wrappers around native JS APIs or JSON payloads.
+
+## TL;DR
+
+NScript models native JavaScript objects via three attributes that all sit at the type level and all carry compile-only semantics ([ADR 0010](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md)):
+
+- `[ImportedType]` — the type *is* a real JS object (`Element`, `Date`, `Promise`). Member access compiles to direct field/method calls. NScript never allocates an instance — `new T()` calls the underlying JS constructor.
+- `[JsonType]` — the type is a plain JSON record (e.g. `ClientRect`, `IDBObjectStoreParameters`). Field reads go through a runtime `importedExtension` shim so that JS-side property names (which may differ from the C# names) resolve correctly.
+- `[PseudoInterfaceType]` — the type is a structural interface. No runtime metadata is emitted; assignability is by shape, not nominal. Useful for callback signatures.
+
+## Reference — runtime emission shape
+
+| Attribute | C# `obj.X` compiles to | C# `new T()` compiles to | C# `obj is T` |
+|---|---|---|---|
+| `[ImportedType]` | `obj.x` (or `obj.X` with `[PreserveCase]`) | `new T(...)` (calls native constructor) | Direct `instanceof` against the native global |
+| `[JsonType]` | `importedExtension(obj, 'x')` (unwraps the JSON value) | `{}` (empty object literal) | Always `true` for any non-null object — JSON has no class identity |
+| `[PseudoInterfaceType]` | `obj.x` (no metadata, structural) | Compile error — pseudo-interfaces aren't constructible | Always `true` for any non-null object |
+| (default — neither) | `obj.get_X()` | `new $T(...)` (NScript-managed) | NScript metadata check |
+
+## Reference — when to choose which
+
+```mermaid
+flowchart TB
+    Q1{Does this type<br/>represent a real<br/>native JS object?}
+    Q1 -- yes --> Q2{Is it a function-shaped<br/>callback or option<br/>structural type?}
+    Q2 -- yes --> A1["[PseudoInterfaceType]"]
+    Q2 -- no --> A2["[ImportedType]"]
+    Q1 -- no --> Q3{Is it a plain<br/>data record passed<br/>to/from JSON, IndexedDB,<br/>or a config bag?}
+    Q3 -- yes --> A3["[JsonType]"]
+    Q3 -- no --> A4["No interop attribute —<br/>regular NScript class"]
+```
+
+## Quick start
+
+### `[ImportedType]` — wrap a real native JS class
+
+```csharp
+using System.Runtime.CompilerServices;
+
+[ImportedType, IgnoreNamespace]
+public sealed class Promise
+{
+    public extern Promise(Action<Action<object>, Action<object>> executor);
+    [PreserveCase] public extern Promise Then(Action<object> onFulfilled);
+    [PreserveCase] public extern Promise Catch(Action<object> onRejected);
+}
+
+// Usage:
+var p = new Promise((resolve, reject) => resolve("done"));
+p.Then(v => Console.WriteLine(v));
+
+// Emits:
+// var p = new Promise(function(resolve, reject) { resolve("done"); });
+// p.then(function(v) { Console.WriteLine(v); });
+```
+
+`[PreserveCase]` is needed because NScript lowercases method names by default; native APIs don't.
+
+### `[JsonType]` — typed shape over a JSON object
+
+```csharp
+[JsonType]
+public sealed class ClientRect
+{
+    public extern double Top { get; }
+    public extern double Left { get; }
+    public extern double? Width { get; }
+    public extern double? Height { get; }
+}
+
+// Usage from a DOM call:
+ClientRect r = element.GetBoundingClientRect();
+double area = r.Width.Value * r.Height.Value;
+```
+
+`extern` properties on `[JsonType]` — there is no body to emit. The compiler produces field access (`r.width`) wrapped in `importedExtension` to handle missing-key cases.
+
+### `[PseudoInterfaceType]` — callback shape
+
+```csharp
+[PseudoInterfaceType]
+public interface IDragHandler
+{
+    void OnDragStart(MouseEvent e);
+    void OnDragEnd(MouseEvent e);
+}
+
+// Any object literal with these methods satisfies the interface — no class declaration needed.
+```
+
+## Examples
+
+### Reading from a `[JsonType]` returned by a native call
+
+```csharp
+[JsonType, IgnoreNamespace]
+public class IDBObjectStoreParameters
+{
+    public extern bool? AutoIncrement { get; set; }
+    public extern string KeyPath { get; set; }
+}
+
+// Construct as plain literal:
+var opts = new IDBObjectStoreParameters { AutoIncrement = true, KeyPath = "id" };
+db.CreateObjectStore("todos", opts);
+// Emits: db.createObjectStore("todos", { autoIncrement: true, keyPath: "id" });
+```
+
+The object literal initializer pattern is the only legal construction form for `[JsonType]` — there's no constructor body.
+
+### Mixing `[ImportedType]` and `[JsonType]`
+
+```csharp
+[ImportedType, IgnoreNamespace, ScriptName("XMLHttpRequest")]
+public sealed class XMLHttpRequest
+{
+    public extern XMLHttpRequest();
+    [PreserveCase] public extern void Open(string method, string url, bool async);
+    [PreserveCase] public extern void Send(object body);
+    [PreserveCase] public extern string ResponseText { get; }
+}
+
+[JsonType]
+public class TodoDto
+{
+    [PreserveCase] public string Id { get; set; }
+    [PreserveCase] public string Title { get; set; }
+}
+
+// Combined usage:
+var xhr = new XMLHttpRequest();
+xhr.Open("GET", "/api/todos/1", true);
+xhr.Send(null);
+// Later:
+TodoDto todo = (TodoDto)JSON.Parse(xhr.ResponseText);
+Console.WriteLine(todo.Title);
+```
+
+`[ImportedType]` for the live XHR object; `[JsonType]` for the parsed payload. The cast to `TodoDto` is a no-op at runtime — it's purely for static typing.
+
+### `[PseudoInterfaceType]` for option bags
+
+```csharp
+[PseudoInterfaceType]
+public interface IFetchOptions
+{
+    string Method { get; }
+    Dictionary<string, string> Headers { get; }
+    string Body { get; }
+}
+
+// Any anonymous-shaped object satisfies this:
+DoFetch("/api/save", new { Method = "POST", Body = "..." });
+```
+
+Useful for option records where you don't want the overhead of `[JsonType]`'s `importedExtension` wrapping.
+
+## Known gotchas
+
+### `[JsonType]` field access is wrapped — codegen plugins must mirror it
+
+Field reads on `[JsonType]` types compile to `importedExtension(obj, 'fieldName')` not bare `obj.fieldName`. If you write a converter plugin that emits an `InlineObjectInitializer` and tag the type as `[JsonType]`, your direct `obj.fieldName` access from generated JS will not match. Use a regular NScript class with a real constructor instead. This is documented in [JST codegen rules](../compiler/plugins.md) but bites people often.
+
+### `[ImportedType]` instances are not serializable across some boundaries
+
+`structuredClone(element)` — `element` is an `[ImportedType]` `Element`, but cloning fails because DOM nodes aren't structured-cloneable. The attribute does *not* certify cloneability; it just says "this is a native object." Check the underlying object class before using it with structured-clone-based APIs (postMessage, IndexedDB, Worker transfer).
+
+### Casting between `[JsonType]` types is always a no-op
+
+`(TodoDto)anyJsonObject` always succeeds at runtime. `[JsonType]` has no class identity. If you need real type discrimination, encode a `Type` field and check it explicitly:
+
+```csharp
+if ((string)JSON.Parse(s).Type == "Todo") { ... }
+```
+
+### `[PseudoInterfaceType]` cannot be used as a generic constraint with `is`
+
+`obj is IFoo` where `IFoo` is `[PseudoInterfaceType]` is always `true` (or `obj != null`) — there's no runtime metadata to test. Don't pivot logic on pseudo-interface checks.
+
+### `extern` properties / methods only — no bodies
+
+`[ImportedType]` and `[JsonType]` types' members must be `extern`. The compiler can't emit a body for a member of a type it doesn't allocate or own. Trying to add a body produces a converter error.
+
+### `[JsonType]` properties named with `[PreserveCase]` to match server payload
+
+If your JSON server returns `{"Title": "..."}`, you must add `[PreserveCase]` to the matching C# property — otherwise the emitter will look for `title` and get `undefined`.
+
+### `null`-checks against `[JsonType]` results
+
+`importedExtension` returns `undefined` for missing keys, which boxes to `null` in C# nullable types but to `0` / empty string in non-nullable value types. Use `double?`, `int?`, `string` (which already nulls), and check explicitly.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `obj.title is undefined` reading a JSON property | Server casing mismatch — add `[PreserveCase]` |
+| `(MyDto)obj` returns the wrong-shaped object | `[JsonType]` casts are no-ops; runtime never validates the shape |
+| Plugin-generated literal doesn't satisfy `[JsonType]` consumer | `importedExtension` wrapper missing on the consumer side; switch to a real class with constructor |
+| `new T()` on a `[PseudoInterfaceType]` fails to compile | Pseudo-interfaces are not constructible; create an anonymous-typed object literal |
+| Native API call gets `obj.foo` not `obj.Foo` | Missing `[PreserveCase]` on the wrapper member |
+| `Cannot find name 'someProp'` at runtime | The wrapper declares a property name that the underlying JS object doesn't use; adjust `[ScriptName]` |
+
+## Cross-links
+
+- [ADR 0010 — Imported types pattern](../adr/0010-model-native-javascript-types-through-attributed-clr-facades.md)
+- [Interop attributes reference](attributes.md)
+- [`[Script]` blocks and dynamic JS](dynamic.md)
+- [Framework Web & DOM](../framework/web.md)
+- [Compiler plugins (JST codegen rules)](../compiler/plugins.md)

--- a/docs/language/limitations.md
+++ b/docs/language/limitations.md
@@ -1,0 +1,166 @@
+# C# language support and limitations
+
+> **Audience:** *App authors* deciding whether a given C# feature will compile cleanly to JavaScript under NScript.
+
+## TL;DR
+
+NScript supports the C# 8 surface area for non-ref, non-reflective code targeting `netstandard2.1`. The translatable subset includes classes, interfaces, generics, LINQ, lambdas, async/await (compiled through state machines into Promises), pattern matching basics, indices/ranges, and null-coalescing. The hard exclusions are anything that requires the .NET runtime: `dynamic`, reflection, P/Invoke, `unsafe` / pointers, and iterator methods (`yield return` / `yield break`). Some C# 8 features are partially implemented or open work — see [csharp8-todos.md](../../csharp8-todos.md) at the repo root.
+
+## Reference — feature support matrix
+
+| Feature | Status | Notes |
+|---|---|---|
+| Classes, structs (as classes), interfaces | ✅ Supported | Structs are emitted as classes; value semantics not preserved across assignment. See [ADR 0008](../adr/0008-define-how-class-and-interface-hierarchies-map-to-javascript.md). |
+| Generics (open and closed) | ✅ Supported | Type arguments are first-class at runtime via JS function type metadata ([ADR 0007](../adr/0007-define-the-javascript-runtime-type-model.md)). |
+| `IgnoreGenericArguments` opt-out | ✅ Supported | Skips type-argument emission at instantiation sites; used for type-erased natives. |
+| Inheritance, virtual dispatch, abstract members | ✅ Supported | Prototype-chain wiring; non-virtual methods are devirtualised ([ADR 0023](../adr/0023-devirtualize-non-virtual-methods-and-inline-trivial-accessors.md)). |
+| Interfaces with explicit metadata | ✅ Supported | Metadata maps emitted via `baseInterfaces` ([ADR 0008](../adr/0008-define-how-class-and-interface-hierarchies-map-to-javascript.md)). |
+| `[PseudoInterfaceType]` | ✅ Supported | Structural interfaces with no runtime metadata. |
+| LINQ-to-Objects | ✅ Supported | Compiled lambdas; `IEnumerable<T>` operators are framework code. |
+| Lambdas, closures | ✅ Supported | JS function expressions; closure capture matches C# semantics. |
+| `async` / `await` | ✅ Supported | State machine compilation; awaitables back onto JS Promises (`Task` ↔ `Promise`). |
+| `Task<T>`, `Promise<T>` | ✅ Supported | `Task` is `[ImportedType]` aliased to JS `Promise`. |
+| `IObservable<T>` (Rx) | ⚠️ Partial | `Sunlight.Framework.Observables` provides the reactive contract used by templates; it's *not* a port of System.Reactive. |
+| Pattern matching (basic — `is Type`, `case`) | ✅ Supported | Type tests compile to `instanceof` plus metadata checks. |
+| Switch expressions | ⚠️ Partial | Some forms; see [csharp8-todos.md](../../csharp8-todos.md). |
+| Property patterns / positional patterns | ❌ Open work | Listed in C# 8 todos. |
+| Indices and ranges (`x[^1]`, `x[1..3]`) | ⚠️ Partial | On the C# 8 todo list. |
+| Null-coalescing `??`, `??=` | ✅ Supported | `??=` is supported. |
+| Null-conditional `?.`, `?[]` | ✅ Supported | Compiled to JS short-circuit chains. |
+| Tuples, deconstruction | ✅ Supported | `ValueTuple` emits as a class; deconstruction is sugar over field reads. |
+| Local functions | ✅ Supported | Including static local functions. |
+| `using` declarations | ❌ Open work | Listed in C# 8 todos. |
+| Nullable reference types (NRT) | ⚠️ Annotation-only | NScript respects `?` for code-gen but does not enforce non-null at runtime. |
+| Default interface methods | ❌ Open work | Listed in C# 8 todos. |
+| `dynamic` | ❌ Not supported | No DLR equivalent on the JS target. Use `[Script]` or `object` casts. |
+| Reflection (`Type.GetMethod`, `Activator.CreateInstance` with args, `RuntimeTypeHandle`) | ❌ Not supported | Limited surface only — `typeof(T)` works for the runtime type model; full reflection does not. See [framework/core.md](../framework/core.md). |
+| Iterators (`yield return`, `yield break`) | ❌ Not supported | The state-machine lowering for iterators isn't ported. Build collections eagerly or use Observables. |
+| Asynchronous streams (`IAsyncEnumerable<T>`) | ❌ Open work | Listed in C# 8 todos. |
+| `unsafe`, pointers, `stackalloc` | ❌ Not supported | No native memory model on the JS target. |
+| P/Invoke, `[DllImport]` | ❌ Not supported | No interop boundary — use `[Script]` for native JS instead. |
+| `lock` / monitors | ⚠️ No-op | JS is single-threaded; `lock` compiles but provides no synchronisation. |
+| `try` / `catch` / `finally` | ✅ Supported | Compiled to JS `try`/`catch`/`finally`. |
+| `throw` expressions | ⚠️ Bug | Listed as open issue in [csharp8-todos.md](../../csharp8-todos.md). Use `throw` *statements* until fixed. |
+| `params T[]` | ✅ Supported | Variadic JS calls. |
+| Operator overloading | ✅ Supported | Operators emit as static methods. |
+| Extension methods | ✅ Supported | Static methods invoked with instance syntax. |
+| `string` interpolation `$"…"` | ✅ Supported | Including verbatim `@$"…"`. |
+| Numeric `decimal` | ⚠️ Maps to `number` | No 128-bit decimal in JS; loss of precision past 2^53. |
+| Numeric `long` / `ulong` | ⚠️ Maps to `number` | Loss of precision past 2^53. Use `BigInt` via `[Script]` for large integers. |
+| `DateTime`, `TimeSpan` | ⚠️ Limited | Maps to JS `Date`; only the subset shipped in `mscorlib` is available. See [framework/core.md](../framework/core.md). |
+
+## Reference — feature → emission summary
+
+```mermaid
+flowchart LR
+    A[C# Source] --> B{Roslyn frontend}
+    B -- Bound expressions --> C[BondToAst]
+    C --> D[JST]
+    D --> E{cs2jsc emit}
+    E --> F[JavaScript]
+
+    subgraph Lowered features
+      L1[async/await<br/>→ state machine]
+      L2[lambdas<br/>→ JS functions]
+      L3[generics<br/>→ runtime type args]
+      L4[LINQ<br/>→ method chains]
+    end
+
+    B -.-> L1
+    B -.-> L2
+    B -.-> L3
+    B -.-> L4
+```
+
+All C# constructs lower into the JST tree first; cs2jsc emits from JST to JavaScript.
+
+## Examples
+
+### What works
+
+```csharp
+public async Task<List<TodoDto>> LoadAsync()
+{
+    var resp = await fetchClient.GetAsync("/api/todos");
+    var json = await resp.Content.ReadAsStringAsync();
+    return ((TodoDto[])JSON.Parse(json))
+        .Where(t => !t.Completed)
+        .OrderBy(t => t.Title)
+        .ToList();
+}
+```
+
+LINQ + async + lambdas + generics — all standard NScript output.
+
+### What doesn't (yet)
+
+```csharp
+// ❌ yield return — iterators not supported
+public IEnumerable<int> Counter()
+{
+    for (int i = 0; i < 10; i++) yield return i;
+}
+
+// ❌ dynamic
+public void Print(dynamic x) => Console.WriteLine(x.Value);
+
+// ❌ throw expression (open bug)
+var name = input ?? throw new ArgumentNullException(nameof(input));
+```
+
+For iterators, return a materialised `List<T>` or expose an `ObservableCollection<T>`. For `dynamic`, cast to `object` and route through `[Script]` if you genuinely need member access on an untyped JS value. For `throw` expressions, expand to a statement form until [csharp8-todos.md](../../csharp8-todos.md) closes the bug.
+
+## Known gotchas
+
+### Structs do not have value semantics
+
+A `struct Point { int X; int Y; }` compiles to a JS class. Assignment copies the *reference*, not the fields. Code that relies on struct copy semantics (e.g. mutating a `List<Point>` element via `list[i].X = 5`) will not behave like .NET. Prefer immutable patterns (`with`-style copies) or use classes explicitly.
+
+### `long` precision silently lost above 2^53
+
+There is no `long` in JavaScript. NScript emits `number`. Computations beyond `Number.MAX_SAFE_INTEGER` (≈ 9 × 10¹⁵) lose precision with no error. For larger ranges, route through `BigInt` via `[Script]`.
+
+### `lock` compiles but is a no-op
+
+JS is single-threaded; `lock(obj) { ... }` emits as a bare block. This is silent — the code runs, but you don't get critical-section semantics. There is no scenario where you need a lock in NScript.
+
+### `decimal` is `number`
+
+`decimal d = 0.1m + 0.2m;` produces `0.30000000000000004` in JS. If you need exact-decimal arithmetic for currency, do the math in cents (integers) or pull a JS bignum library via `[Script]`.
+
+### Reflection is limited to the runtime type model
+
+`typeof(T)`, `obj.GetType()`, basic `IsAssignableFrom` work. `Type.GetMethod`, `MethodInfo.Invoke`, `Activator.CreateInstance(type, args)`, `Expression`-tree reflection — none of those work. Code that needs them (DI containers, serializers, mappers) must be specialised for NScript's metadata model — usually via `IocContainer` (registration-driven, not reflection-driven) or attribute-driven plugins.
+
+### `[Conditional("DEBUG")]` strips at the *caller's* compilation
+
+If you ship a Release-built framework, `Logger.Debug(...)` calls inside *your app* (Debug-built) still emit, but calls from inside the Release framework are stripped. Mix-and-match builds are normal — be aware that diagnostic depth depends on which assembly's call site is doing the logging.
+
+### NRT annotations don't enforce at runtime
+
+`string?` vs `string` is a compile-time hint. The emitter doesn't generate null-checks. Treat NRT as documentation; defensive checks are still on you for boundaries.
+
+### `Task` and `Promise` are the same runtime object
+
+NScript's `Task` is an `[ImportedType]` over JS `Promise`. `await task` and `await promise` are interchangeable. There is no separate scheduler — `Task.Run` doesn't fork a thread; it just defers via a microtask.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `'yield' is not supported` | Iterator method — rewrite as eager list or `ObservableCollection<T>` |
+| `dynamic is not supported` | Use `object` + cast / `[Script]` instead |
+| `Cannot invoke method 'Foo' via reflection` | Reflection isn't supported; build the call site statically |
+| `Activator.CreateInstance with parameters not supported` | Only parameterless `Activator.CreateInstance<T>()` is supported |
+| Wrong arithmetic on large integers | `long` precision loss past 2^53 |
+| `Cannot find type 'IAsyncEnumerable'` | Async streams not yet supported |
+
+## Cross-links
+
+- [csharp8-todos.md](../../csharp8-todos.md) — open C# 8 work items
+- [Getting started](../getting-started/README.md) — day-1 pitfalls
+- [Framework Core](../framework/core.md) — BCL surface details
+- [Interop attributes](../interop/attributes.md) — opt-outs and emission control
+- [`[Script]` and dynamic JS](../interop/dynamic.md) — escape hatch for unsupported APIs
+- [ADR 0007 — Runtime type model](../adr/0007-define-the-javascript-runtime-type-model.md)
+- [ADR 0008 — Class & interface mapping](../adr/0008-define-how-class-and-interface-hierarchies-map-to-javascript.md)

--- a/docs/templates/razor.md
+++ b/docs/templates/razor.md
@@ -1,0 +1,193 @@
+# Razor skin templates
+
+> **Audience:** *App authors*.
+
+## TL;DR
+
+Razor templates are NScript's **modern template frontend** ([ADR 0017](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)). A `.skin.cshtml` file declares a model type, optional CSS dependencies, and a fragment of HTML interleaved with `@`-prefixed C# expressions, `@if`, `@foreach`, and child-control references. The compiler analyses the model with Roslyn ([ADR 0020](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md)) to auto-classify each binding as OneTime / OneWay / TwoWay, builds a compile-time DAG of reactive nodes ([ADR 0018](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)), and emits JavaScript that materialises a live, deduplicated binding graph at runtime via `GraphBindingStrategy` ([ADR 0019](../adr/0019-extract-ibindingstrategy-from-skininstance.md)).
+
+## Quick start
+
+`TodoItemControl.skin.cshtml`:
+
+```cshtml
+@model TodoApp.ViewModels.TodoItemViewModel
+@styles "TodoApp.RazorTemplates.AppShell.css"
+
+<div class="@Model.CssClass" draggable="true"
+     onclick="@Model.OnSelect" ondragstart="@Model.OnDragStart">
+    <div class="@Model.CheckboxClass" onclick="@Model.ToggleComplete">&#10003;</div>
+    <div class="todo-title">@Model.Title</div>
+    <div class="@Model.StarClass" onclick="@Model.ToggleImportant">@Model.StarText</div>
+</div>
+```
+
+The accompanying viewmodel:
+
+```csharp
+public class TodoItemViewModel : ObservableObject
+{
+    [AutoFire] public string Title { get; set; }
+    [AutoFire("CheckboxClass")] public bool IsCompleted { get; set; }
+    [AutoFire("StarClass", "StarText")] public bool IsImportant { get; set; }
+
+    public string CssClass => this.IsCompleted ? "todo completed" : "todo";
+    public string CheckboxClass => this.IsCompleted ? "btn-check checked" : "btn-check";
+    public string StarClass => this.IsImportant ? "btn-star starred" : "btn-star";
+    public string StarText => this.IsImportant ? "★" : "☆";
+
+    public void ToggleComplete() => this.IsCompleted = !this.IsCompleted;
+    public void ToggleImportant() => this.IsImportant = !this.IsImportant;
+    public void OnSelect() { /* ... */ }
+    public void OnDragStart() { /* ... */ }
+}
+```
+
+The compiler emits a single graph that:
+
+- Reads `Title` once at materialisation (no observed mutation paths) — OneTime.
+- Subscribes to `IsCompleted` so `CssClass` and `CheckboxClass` update reactively — OneWay (auto-detected because `[AutoFire]` is on the dependency).
+- Wires `onclick` handlers as event delegates pointing to viewmodel methods.
+
+## Reference — directives
+
+| Directive | Purpose |
+|---|---|
+| `@model FullyQualifiedTypeName` | Required at top of file. Specifies the data context type. |
+| `@styles "Resource.Name.css"` | Declares a CSS dependency. The CSS file is parsed by `CssParser` and class names are matched strictly against `class="..."` attributes; mismatches surface as compile diagnostics ([ADR 0016](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)). |
+| `@Model.X` | Substitutes the value of `Model.X`. |
+| `@Model.Method(arg)` | Invokes a method (typically as an event handler). |
+| `@(expression)` | Parenthesised expression — required when the expression contains spaces, ternaries, or any token that would confuse the implicit boundary. |
+| `@if (cond) { ... }` | Conditional fragment. Auto-classified OneWay when `cond` references observable properties. |
+| `@foreach (var x in Model.List) { ... }` | Repeats a fragment for each item. When `Model.List` is `IObservableCollection`, additions/removals reactively update the rendered list. |
+| `<TodoItemControl />` | Reference to a child Razor control by class name (auto-discovered from `Sunlight.Framework.UI.Skin` registry). The current `Model` flows through; inside an `@foreach`, the iteration variable becomes the child control's `Model`. |
+
+## Reference — binding modes (auto-detected)
+
+[ADR 0020](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md) — there is no `Mode=` annotation in Razor templates. The compiler classifies each `@Model.X` reference based on:
+
+- **OneTime** — `X` is a constant, a non-observable readonly value, or has no observable inputs.
+- **OneWay** — `X` is on an `INotifyPropertyChanged` source and reads from properties marked `[AutoFire]` or that emit `FirePropertyChanged`.
+- **TwoWay** — the `@Model.X` appears as the value of a writable form field (`<input value="@Model.X">`) AND `X` has an accessible setter on an observable type.
+
+If you need to override (rare), wrap the value in a method on the viewmodel that exposes the desired observability surface — the auto-detector picks up the method's reachable observables.
+
+## Reference — emitter pipeline
+
+```mermaid
+flowchart TB
+    A[".skin.cshtml file"] --> B["RazorSkinPreprocessor<br/>(strip directives, CSS literals)"]
+    B --> C["RoslynAnalysisPhase<br/>(semantic analysis of @-expressions)"]
+    C --> D["TemplateIRBuilder<br/>(IR + Location capture)"]
+    D --> E["ObservableAnalyzer<br/>(binding-mode classification)"]
+    E --> F["GraphTopologyBuilder<br/>(compile-time DAG + dedup)"]
+    F --> G["GraphDescriptorJSTEmitter<br/>(JST emission)"]
+    G --> H["JST → JavaScript<br/>via cs2jsc"]
+```
+
+The IR + DAG model is what enables:
+
+- **Dedup** — two `@Model.X` references in the same template share one DAG node.
+- **Comment markers** in generated JS for traceability between source and emitted code.
+- **Source mapping** — `TemplateIRBuilder` captures source `Location` per IR node so debugger steps land on the right template line ([ADR 0006](../adr/0006-standardize-the-compiler-pipeline-from-bound-csharp-to-javascript.md), source-map work in WI-15).
+
+## Reference — strict CSS
+
+`@styles "X.css"` causes `CssParser` to parse the file at compile time. Every `class="foo bar"` attribute on a literal element is checked against the declared classes. Diagnostics:
+
+| Code path | Message shape |
+|---|---|
+| Class used in template, not declared in any referenced CSS file | "CSS class 'foo' used in template not found in declared stylesheets" |
+| Class declared but never used | (warning) "CSS class 'foo' declared but unused" |
+| Selector cannot be parsed | parse-position-aware error from `CssParser` |
+
+`Autoprefixer` also runs over the declared CSS to inject vendor prefixes; its scope is the parsed CSS, not the template HTML.
+
+## Examples
+
+### Conditional block
+
+```cshtml
+@if (Model.HasItems)
+{
+    <ul>
+        @foreach (var item in Model.Items)
+        {
+            <li>@item.Name</li>
+        }
+    </ul>
+}
+else
+{
+    <p class="empty">No items.</p>
+}
+```
+
+### Two-way input binding
+
+```cshtml
+<input type="text" value="@Model.SearchText" onchange="@Model.OnSearchTextChanged" />
+```
+
+`SearchText` is on an `ObservableObject` and has a setter → auto-classified TwoWay. `OnSearchTextChanged` is a viewmodel method invoked from the DOM `change` event.
+
+### Embedded child control
+
+```cshtml
+@foreach (var todo in Model.CurrentTodos)
+{
+    <TodoItemControl />
+}
+```
+
+The current iteration variable `todo` becomes the `Model` of the child `TodoItemControl`.
+
+### Compound CSS class via ternary
+
+```cshtml
+<div class="@(Model.IsSelected ? "item selected" : "item")">…</div>
+```
+
+`@(...)` is required because the expression contains a space — without parentheses the parser stops at the first whitespace.
+
+## Known gotchas
+
+### Implicit / explicit boundary
+
+`@Model.Foo` and `@Model.Foo.Bar` work, but `@Model.Foo Bar` is parsed as `@Model.Foo` followed by literal text " Bar". When in doubt, use `@(...)`.
+
+### `@foreach` over a non-observable list is OneTime
+
+If `Model.Items` is plain `List<T>` (not `IObservableCollection`), the loop is rendered once at materialisation and never updates. To get reactive list updates, use `ObservableCollection<T>`.
+
+### Razor and XWML coexist
+
+A project can have both `.skin.cshtml` and `.html` (XWML) templates. They produce equivalent runtime structures — `SkinInstance` is the common base. Pick one per control, not per project.
+
+### Child control lookup is by simple name
+
+`<TodoItemControl />` is resolved through the skin registry built from referenced assemblies. Two controls with the same simple name in different namespaces will collide; rename one.
+
+### `@styles` is a compile-time hint, not a runtime CSS loader
+
+The browser still needs to load the CSS file (via a `<link>` tag in the host page or by your bundler). `@styles` only opts the template into strict-class checking; it does not produce a `<link>` element.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `CSS class 'foo' used in template not found` | Class on an element not declared in any referenced CSS file |
+| `Cannot resolve member 'Foo'` | Property/method missing on the `@model` type |
+| Bound value never updates | Source property missing `[AutoFire]` / `FirePropertyChanged`; auto-detector classified as OneTime |
+| Two-way binding writes back blank | Source property has no setter — falls back to OneWay; check `IsStrict` to surface the mismatch |
+| Child control renders nothing | Type name not found in `Skin` registry; check `[Skin]` and assembly references |
+
+## Cross-links
+
+- [ADR 0017 — Razor as second frontend](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)
+- [ADR 0018 — Compile-time DAG binding](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)
+- [ADR 0019 — `IBindingStrategy` extraction](../adr/0019-extract-ibindingstrategy-from-skininstance.md)
+- [ADR 0020 — Auto-detect binding mode](../adr/0020-auto-detect-binding-mode-from-roslyn-semantic-analysis.md)
+- [ADR 0016 — XWML strict CSS / binding diagnostics](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)
+- [XWML templates (legacy)](xwml.md)
+- [Sunlight UI](../framework/sunlight-ui.md) for the host control hierarchy

--- a/docs/templates/xwml.md
+++ b/docs/templates/xwml.md
@@ -1,0 +1,151 @@
+# XWML templates (legacy)
+
+> **Audience:** *App authors* maintaining XWML templates, or porting to Razor.
+
+## TL;DR
+
+XWML is NScript's **original XML-based template language** ([ADR 0016](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)) — a `.html` file declares a `<skin>` element with a `ControlType` and `DataContextType`, and binds properties on the data context to attributes via `{PropertyName}` syntax (with optional `, Mode=OneTime|OneWay|TwoWay`). It is parsed by `XwmlParser` into the same `SkinInstance` runtime substrate that [Razor](razor.md) emits, so XWML and Razor controls coexist freely. Razor is the recommended path for *new* templates ([ADR 0017](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)); this page documents XWML for maintenance.
+
+## Quick start
+
+```xml
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:vm="MyApp.ViewModels!MyApp"
+      xmlns:ctrl="Sunlight.Framework.UI!Sunlight.Framework.UI">
+    <head><meta charset="utf-8" /><title /></head>
+    <body>
+        <skin ControlType="ctrl:UISkinableElement"
+              DataContextType="vm:TodoItemViewModel">
+            <div class="{CssClass}" onclick="{ToggleComplete}">
+                <span class="todo-title">{Title}</span>
+            </div>
+        </skin>
+    </body>
+</html>
+```
+
+The XML namespace `vm:` is declared with the syntax `xmlns:vm="Namespace!AssemblyName"` — left of the bang is the .NET namespace, right is the assembly name. This is XWML-specific (it's how `XwmlParser` resolves type references at compile time).
+
+## Reference — top-level structure
+
+| Element / attribute | Purpose |
+|---|---|
+| `<html xmlns:prefix="...">` | Standard XHTML root with extra prefix declarations for type references |
+| `<skin ControlType="..." DataContextType="...">` | The template root. `ControlType` is the host `UIElement` subclass; `DataContextType` is the type whose properties bind. |
+| `<elementName attr="{Property}">` | Any inner element binds attributes via `{...}` syntax. |
+| `<vm:CustomControl Prop="{Foo}">…</vm:CustomControl>` | A nested custom control — must be discoverable through the namespace declaration. |
+| `id="Part1"` | Names a placeholder; the host control receives a reference via `[SkinPart]` / `[TemplatePart]`. |
+
+## Reference — binding syntax
+
+```text
+{PropertyName}
+{PropertyName, Mode=OneTime}
+{PropertyName, Mode=OneWay}
+{PropertyName, Mode=TwoWay}
+```
+
+| Mode | Behavior | Default for |
+|---|---|---|
+| `OneTime` | Read once at materialisation. No subscription. | non-observable properties |
+| `OneWay` | Subscribes to source `INotifyPropertyChanged`; writes target on every change. | `ObservableObject` properties |
+| `TwoWay` | Source → target plus target → source write-back path. | form input attributes (e.g. `value`, `checked`) on observable properties |
+
+If you omit `Mode=`, XwmlParser picks the default based on the source-property analysis (analogous to Razor's auto-detection, but with explicit override available).
+
+`IsStrict` on `[DefaultDataBinding]` rejects mismatched modes at compile time. See [Sunlight UI](../framework/sunlight-ui.md#reference--sunlightframeworkui-attributes).
+
+## Reference — strict CSS
+
+XWML enforces the same strict-class semantics as Razor: every `class="foo"` token is checked against the parsed declared CSS files. The diagnostic shape mirrors [templates/razor.md](razor.md#reference--strict-css). `CssParser` lives at `Sources/Compiler/CssParser/`; `Autoprefixer` runs the parsed CSS through vendor-prefixing.
+
+## Examples
+
+### One-way property binding
+
+```xml
+<skin ControlType="ctrl:UISkinableElement" DataContextType="vm:CountModel">
+    <div>
+        Count: <span>{Count}</span>
+    </div>
+</skin>
+```
+
+If `CountModel.Count` is `[AutoFire]` (or the type is an `ObservableObject` and the setter calls `FirePropertyChanged`), the span text updates reactively.
+
+### Two-way input binding
+
+```xml
+<input type="text" value="{Name, Mode=TwoWay}" />
+```
+
+Target → source write-back is wired via `change` / `input` events depending on the input element type.
+
+### Custom control with bound part
+
+```xml
+<skin ControlType="vm:TestSkinableWithTestUIElementPart"
+      DataContextType="vm:TestViewModelB">
+    <vm:TestUIElement id="Part1"
+                      TwoWayLooseBinding="{PropInt1, Mode=TwoWay}"
+                      OneWayStrictBinding="{PropStr1, Mode=OneWay}">
+        This is a test.
+    </vm:TestUIElement>
+</skin>
+```
+
+`id="Part1"` makes this child control accessible to the host via `[SkinPart]` / `[TemplatePart]` (see [Sunlight UI attributes](../framework/sunlight-ui.md#reference--sunlightframeworkui-attributes)).
+
+## Coexistence with Razor
+
+XWML (`.html`) and Razor (`.skin.cshtml`) both produce the same `SkinInstance` runtime contract. A project can declare some controls in XWML and others in Razor without bridging code. The `SkinFactory` registry is namespace-flat — both sources register into the same lookup.
+
+[ADR 0017](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md) is explicit: Razor is the second frontend; both are supported. New templates should prefer Razor for:
+
+- Auto-detected binding modes (no `Mode=` clutter).
+- Compile-time DAG dedup ([ADR 0018](../adr/0018-replace-independent-binders-with-compile-time-reactive-binding-graph.md)).
+- Full C# expressions (`@(cond ? a : b)`) instead of attribute-only binding syntax.
+
+XWML retains some advantages:
+
+- More familiar to teams with WPF / Silverlight / XAML background.
+- `id="..."`-based part wiring is sometimes more ergonomic than name-based child-control resolution.
+
+## Known gotchas
+
+### Namespace declaration syntax
+
+`xmlns:vm="MyApp.ViewModels!MyApp"` — the bang is XWML-specific. A standard XML namespace URI (`xmlns:vm="urn:my-app"`) will not resolve types and the parser will emit "type not found" errors.
+
+### `{PropertyName}` is path-flat
+
+Unlike Razor's `@Model.Foo.Bar`, XWML binding paths are typically a single property name. Drill down by exposing a flattened property on the data context.
+
+### `Mode=` is per-binding, not per-attribute
+
+Each `{...}` carries its own mode. Mixing modes inside the same attribute (e.g. concatenating two bindings into a single class string) is not supported — use a viewmodel property that returns the composed result.
+
+### The XWML XML root must be valid XHTML
+
+`XwmlParser` uses an XML reader, not an HTML5 parser. Self-closing tags must be explicit (`<br />`, not `<br>`). Unescaped `&` characters are errors.
+
+### CSS class diagnostics fire even on dynamic values
+
+`class="{CssClass}"` is allowed and the parser cannot inspect the runtime string. But static class names within attributes must be declared in a referenced CSS file. Dynamic classes computed in the viewmodel are not validated.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| "Type 'X' not found" | Wrong namespace declaration (`xmlns:prefix="..."`) — check the `Namespace!Assembly` shape |
+| Binding never updates | Source property is not observable; `Mode=` defaulted to `OneTime` |
+| `[DefaultDataBinding(IsStrict=true)]` mismatch | The template's explicit `Mode=` differs from the property's strict default |
+| `CSS class 'foo' used in template not found` | Class missing from any declared CSS |
+
+## Cross-links
+
+- [ADR 0016 — XWML strict CSS / binding diagnostics](../adr/0016-standardize-xwml-as-the-canonical-template-language-with-strict-css-and-binding-diagnostics.md)
+- [ADR 0017 — Razor as second frontend](../adr/0017-add-razor-skin-templates-as-a-second-template-frontend.md)
+- [Razor templates](razor.md) — recommended for new templates
+- [Sunlight UI](../framework/sunlight-ui.md) — `Skin`, `SkinInstance`, attributes

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,218 @@
+# Testing NScript
+
+> **Audience:** *App authors* writing tests for their own NScript apps; *contributors* working on the NScript compiler test suite.
+
+## TL;DR
+
+NScript has two distinct test categories — they share no infrastructure and run on different stacks.
+
+- **Compiler tests** (`Test/Compiler/`) — standard MSTest projects targeting `net6.0`. Run with `dotnet test`. Verify the C#-to-JS compilation pipeline (parsers, converter, JST emission, CSS parsing).
+- **Framework tests** (`Test/Framework/`) — C# tests using `SunlightUnit` (`[TestFixture]` / `[Test]` attributes) compiled to JS by the NScript Debug compiler, then executed in a real browser via QUnit 2.2.0. Verify runtime behavior (observables, binders, templates, UI).
+
+The `TestGenerator` plugin ([compiler/plugins.md](../compiler/plugins.md)) bridges SunlightUnit attributes into QUnit `module()` / `test()` calls during emission. Full architecture lives in [`Test/docs/browser-testing.md`](../../Test/docs/browser-testing.md).
+
+## Reference — categories
+
+| Category | Path | Stack | Runner | Target framework |
+|---|---|---|---|---|
+| Compiler | `Test/Compiler/*` | MSTest, .NET | `dotnet test` | `net6.0` |
+| Framework | `Test/Framework/*` | SunlightUnit + QUnit 2.2.0 | Browser via `TestPage.htm` (or Playwright for headless) | `netstandard2.1` (compiled to JS) |
+
+## Reference — compiler test projects
+
+| Project | Surface tested |
+|---|---|
+| `NScript.Converter.Test` | C#-to-JS method conversion, snapshot-based regression tests |
+| `NScript.CLR.Test` | Mono.Cecil-based CLR loader, type-system access |
+| `NScript.Csc.Lib.Test` | Forked Roslyn integration, `OnBoundExpressionGenerated` capture, `$$BstInfo$$` round-trip |
+| `NScript.JSParser.Test` | JS parser used by `[Script]` and Razor expressions |
+| `NScript.Utils.Test` | Shared utilities |
+| `NScriptTest` | Whole-pipeline regression tests, source-map checks |
+| `CssParser.Test` | Strict CSS class parser |
+| `RazorSkinParser.Test` | Razor `.skin.cshtml` parsing + binder graph emission |
+| `XwmlParser.Test` | XWML template parser + emitted-binding graph |
+| `SourceMap.Test` | Source-map encoder/decoder library |
+| `SourceMap.Server.Test` | Source-map dev server (WI-15, WI-37); see [debugging/source-maps.md](../debugging/source-maps.md) |
+
+## Reference — framework test pipeline
+
+```mermaid
+flowchart LR
+    A["C# test classes<br/>[TestFixture] / [Test]"] --> B["dotnet build -c Debug<br/>(uses NScriptToolSet/bin/Debug)"]
+    B --> C["TestGenerator plugin<br/>scans for attributes"]
+    C --> D["Emits QUnit.module() /<br/>QUnit.test() registrations"]
+    D --> E["GeneratedScripts/*.js<br/>in TestWebApplication"]
+    E --> F["Browser opens<br/>TestPage.htm"]
+    F --> G["QUnit runs all tests"]
+```
+
+## Reference — `SunlightUnit.Assert` → QUnit mapping
+
+`SunlightUnit.Assert` uses `[ScriptAlias]` ([interop/attributes.md](../interop/attributes.md)) so C# assertion calls translate directly to QUnit:
+
+| C# (SunlightUnit) | Emitted JS (QUnit) |
+|---|---|
+| `assert.Equal(actual, expected, msg)` | `assert.equal(actual, expected, msg)` |
+| `assert.IsTrue(value, msg)` | `assert.ok(value, msg)` |
+| `assert.StrictEqual(actual, expected, msg)` | `assert.strictEqual(actual, expected, msg)` |
+| `assert.DeepEqual(actual, expected, msg)` | `assert.deepEqual(actual, expected, msg)` |
+| `assert.Throws(fn, msg)` | `assert.throws(fn, msg)` |
+
+## Quick start — run the test suite
+
+### Compiler tests
+
+```bash
+# All compiler tests (standard .NET test runner)
+dotnet test NScript_Full.sln -c Release
+
+# Single project
+dotnet test Test/Compiler/CssParser.Test/CssParser.Test.csproj
+
+# Single test by name
+dotnet test Test/Compiler/NScriptTest/NScriptTest.csproj \
+  --filter "FullyQualifiedName~MyMethodName"
+```
+
+### Framework tests
+
+```bash
+# 1. Build the Debug compiler (framework tests require it)
+dotnet build NScript_Full.sln -c Debug
+
+# 2. Serve the test web app
+cd Test/Framework/TestWebApplication
+npx serve .
+
+# 3. Open http://localhost:3000/TestPage.htm in any browser.
+# QUnit runs automatically; status banner shows pass/fail.
+```
+
+## Examples
+
+### Writing a framework test
+
+```csharp
+using SunlightUnit;
+using Sunlight.Framework.Observables;
+
+namespace MyApp.Tests
+{
+    [TestFixture]
+    public class ObservableTests
+    {
+        [Test]
+        public static void FiringPropertyChangedReachesSubscribers(Assert assert)
+        {
+            var vm = new TodoItemViewModel();
+            string lastChanged = null;
+            vm.AddPropertyChangedListener("Title", (sender, name) => lastChanged = name);
+
+            vm.Title = "Buy milk";
+
+            assert.Equal(lastChanged, "Title");
+        }
+    }
+}
+```
+
+The project file (`MyApp.Tests.csproj`) needs:
+
+```xml
+<PropertyGroup>
+  <GenerateJs>True</GenerateJs>
+  <JsOutputPath>../TestWebApplication/GeneratedScripts</JsOutputPath>
+  <PluginConfig>PluginConfig.xml</PluginConfig>
+</PropertyGroup>
+```
+
+And `PluginConfig.xml` registers the `TestGenerator`:
+
+```xml
+<Plugins>
+  <Plugin Assembly="NScript.Converter.Plugins" ClassName="NScript.Converter.Plugins.TestGenerator" />
+</Plugins>
+```
+
+Then add `<script src="GeneratedScripts/MyApp.Tests.js"></script>` to `TestPage.htm` and rebuild.
+
+### Writing a compiler test (snapshot regression)
+
+```csharp
+[TestClass]
+public class MyConverterRegressionTests : RegressionTests
+{
+    [TestMethod]
+    public void Generic_Method_With_Constraints()
+    {
+        // RegressionTests provides input/expected loading + diff + snapshot update.
+        this.RunRegressionTest("GenericMethodWithConstraints");
+    }
+}
+```
+
+The convention is one test per *snapshot pair*: `Inputs/GenericMethodWithConstraints.cs` + `ExpectedOutputs/GenericMethodWithConstraints.js`.
+
+### Headless framework test execution (CI)
+
+For CI runs you need Playwright to launch a real browser, navigate to `TestPage.htm`, and wait for QUnit's banner:
+
+```javascript
+// Pseudocode — see Test/docs/browser-testing.md for full pattern
+const banner = await page.waitForSelector('#qunit-banner.qunit-pass, #qunit-banner.qunit-fail');
+const passed = (await banner.getAttribute('class')).includes('qunit-pass');
+```
+
+Per-test results extract from `#qunit-tests > li` elements.
+
+## Known gotchas
+
+### Framework tests *must* use the Debug-built compiler
+
+`Test/Framework/Directory.Build.props` pins `CscToolPath` to `NScriptToolSet/bin/Debug/`. If you only built Release, you'll see `csc.exe not found` or a stale toolset will silently miss recent changes. Always run `dotnet build -c Debug` once before framework tests.
+
+### `[Test]` methods must be `public static`
+
+The `TestGenerator` plugin emits a `QUnit.test()` registration that calls the method as a free function. Instance methods don't get registered. The test method's signature must be `public static void Foo(Assert assert)`. The containing `[TestFixture]` class can be either `public class` (the convention in `Test/Framework/Sunlight.Framework.Test/`) or `public static class` — both compile.
+
+### `SunlightUnit.Assert` is *not* xUnit's `Assert`
+
+The naming is similar but the semantics map to QUnit. Casing matters (`Equal` not `Equals`); argument order is `actual, expected` (matching QUnit), not `expected, actual` (which is xUnit's order). See the mapping table above.
+
+### Browser cache breaks "fixed it but still failing" loops
+
+Hard-refresh the test page (`Ctrl+Shift+R`) after rebuilding. Generated `.js` files are served with default caching headers; `npx serve` doesn't bust them.
+
+### Compiler tests' snapshot files must be updated explicitly
+
+The MSTest projects use snapshot comparison — when output changes intentionally, you re-run with `--update-snapshots` or use the `RegressionTests.UpdateSnapshot()` helper (depending on the test base class). Don't hand-edit the expected files.
+
+### `TestGenerator` only runs when registered in `PluginConfig.xml`
+
+A test project that forgets the plugin registration will compile to JS but emit no `QUnit.module()` / `QUnit.test()` calls — the file loads silently and runs nothing. Symptom: QUnit reports zero tests.
+
+### Framework tests cannot use C# 8 features the compiler doesn't support
+
+If a test uses `yield return`, `dynamic`, or other [unsupported features](../language/limitations.md), the build fails — but the failure mode is "compiles in stock C# fine, but `nscript.exe` reports the unsupported construct." Don't assume something works because Roslyn accepted it.
+
+### TestLauncher is for debugging, not CI
+
+`Test/TestLauncher` is a console app used to invoke a single compiler test directly, mostly for attaching a debugger to the compilation pipeline. Not part of normal CI runs.
+
+## Diagnostics
+
+| Symptom | Cause |
+|---|---|
+| `csc.exe not found` building framework tests | `dotnet build -c Debug` of root solution missing |
+| QUnit reports `0 assertions, 0 tests run` | `TestGenerator` plugin not registered in `PluginConfig.xml`; or test method isn't `public static` |
+| Framework test passes locally, fails in CI | Browser version mismatch, or stale `GeneratedScripts/` checked in — rebuild before run |
+| Compiler test snapshot mismatch | Either a real regression or intentional output change — diff and update snapshot deliberately |
+| `TestPage.htm` 404s on a script | Generated file missing from `GeneratedScripts/` — check that the test project's `<JsOutputPath>` points there and `GenerateJs=True` |
+
+## Cross-links
+
+- [Test/docs/browser-testing.md](../../Test/docs/browser-testing.md) — complete framework-test architecture and headless-runner script
+- [Compiler plugins](../compiler/plugins.md) — `TestGenerator` internals
+- [MSBuild SDK](../build/msbuild-sdk.md) — `<GenerateJs>` and `<PluginConfig>`
+- [Source maps](../debugging/source-maps.md) — debugging failing JS tests in browser DevTools
+- [Language limitations](../language/limitations.md) — features unavailable in framework tests


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Authors comprehensive user- and contributor-facing documentation for NScript under `docs/`, addressing all 16 sections of the DoD checklist on issue #42 in a single PR (per maintainer guidance: "make this yolo").

Adds:
- 17 new Markdown files (16 content sections + a top-level `docs/README.md` index + `docs/_template.md` page skeleton)
- A `Documentation` section linking from the root `README.md`

Closes #42.

## What's in this PR

| § | File | Topic |
|---|------|-------|
| 1 | `docs/framework/core.md` | Framework Core (BCL surface in `mscorlib` / `System.Core`) |
| 2 | `docs/framework/web.md` | `System.Web` and `System.Web.Html` DOM bindings |
| 3 | `docs/framework/sunlight-core.md` | `Sunlight.Framework` (observables, binders, IoC, scheduler, CallContext, Logger) |
| 4 | `docs/framework/sunlight-ui.md` | `Sunlight.Framework.UI` (`UIElement`, `ListView`, `Skin`, `IBindingStrategy`) |
| 5 | `docs/templates/razor.md` | Razor `.skin.cshtml` (auto-detected modes, DAG binding graph) |
| 6 | `docs/interop/attributes.md` | All ~22 interop attributes with naming-decision tree |
| 7 | `docs/interop/json-and-imported-types.md` | `[ImportedType]`, `[JsonType]`, `[PseudoInterfaceType]` patterns |
| 8 | `docs/interop/dynamic.md` | `[Script]` blocks, JSNI resolution, `dynamic` keyword status |
| 9 | `docs/templates/xwml.md` | XWML templates (legacy) |
| 10 | `docs/compiler/pipeline.md` | Two-stage Roslyn → DLL → cs2jsc pipeline, JST passes |
| 11 | `docs/compiler/plugins.md` | `IConverterPlugin` interfaces, `IntrestLevel` (sic), JST codegen rules |
| 12 | `docs/build/msbuild-sdk.md` | `Mcqdb.NScript.Sdk`, MSBuild properties, `ScriptGenerate` target |
| 13 | `docs/getting-started/README.md` | Prereqs, Hello World, day-1 pitfalls |
| 14 | `docs/language/limitations.md` | Unsupported C# features, partial-support matrix |
| 15 | `docs/testing/README.md` | Compiler tests vs framework tests, SunlightUnit→QUnit mapping |
| 16 | `docs/debugging/source-maps.md` | V3 source maps, `SourceMap.Server`, security model |

Each page follows `docs/_template.md` (TL;DR → Reference → Quick start → Examples → Known gotchas → Diagnostics → Cross-links) and is grounded in real source under `Sources/`, `Test/`, and the 25 ADRs in `docs/adr/`.

## Authoring grounding

- Every attribute listed in `interop/attributes.md` exists under `Sources/Framework/mscorlib/Runtime/CompilerServices/`.
- MSBuild property defaults in `build/msbuild-sdk.md` match `Sdk.props` / `Sdk.targets` exactly.
- The 5 JST codegen rules in `compiler/plugins.md` match project `CLAUDE.md` verbatim.
- The `IntrestLevel` misspelling is intentionally preserved with `(sic)` callout.
- All examples avoid `dynamic`, `yield return`, reflection, P/Invoke (per documented limitations).

## Self-review

Two iterations of self-review using \`code-reviewer:pr-review\` were applied before opening:

**Iteration 1 fixes (8):**
- `docs/compiler/plugins.md` — corrected class name `RazorSkinTemplatingPlugin` → real `RazorTemplatingPlugin`; fixed implementing interfaces (templates implement `IMethodConverterPlugin + IRuntimeConverterPlugin`, not `ITypeConverterPlugin`).
- `docs/framework/sunlight-ui.md` — fixed Mermaid diagram (\`ListView : UIElement\`, not via `UIPanel`).
- `docs/testing/README.md` — replaced `vm.PropertyChanged += …` with the real `AddPropertyChangedListener(propName, callback)` API.
- `docs/testing/README.md` — softened "TestFixture must be public static" to match real fixtures.
- `docs/testing/README.md` — added missing `XwmlParser.Test` and `SourceMap.Test` projects.
- `docs/getting-started/README.md` — clarified `<NoStdLib>` vs SDK-set `<NoStandardLib>`.
- `docs/debugging/source-maps.md` — noted the differing `OwaSourceMapper.Server` namespace.
- `docs/templates/razor.md` — softened unverified "matches by type name across all referenced assemblies" claim.

**Iteration 2 fixes (2):**
- `docs/templates/razor.md` — removed unverified `data-context` HTML-attribute mechanism (real model flow is via `@foreach` iteration variable).
- `docs/debugging/source-maps.md` — corrected misleading "historical namespace" comment.

## DoD checklist on #42

All 16 boxes ticked in the issue body once this PR merges.

## Out of scope

- Publishing to a docs site (DocFX / mkdocs / Docusaurus).
- Rewriting or expanding existing ADRs.