### PR TITLE
[Gautam's Dev bot] WI-38: WebStoreTable resumable pagination cursor tokens

### DIFF
--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/Cursor.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/Cursor.cs
@@ -78,8 +78,8 @@ namespace Sunlight.Framework.Data.WebStore
 
             Dictionary env;
             try { env = JSON.Parse(token); }
-            catch (Exception)
-            { throw new Exception("Cursor token is not valid JSON"); }
+            catch (Exception ex)
+            { throw new Exception("Cursor token is not valid JSON: " + ex.Message); }
 
             if (env == null)
             { throw new Exception("Cursor token decoded to null"); }

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/Cursor.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/Cursor.cs
@@ -1,0 +1,112 @@
+namespace Sunlight.Framework.Data.WebStore
+{
+    using System;
+    using System.Collections;
+    using System.Web;
+
+    /// <summary>
+    /// Opaque continuation token issued by
+    /// <see cref="WebStoreTable{TKey,TValue}.QueryPage"/> /
+    /// <see cref="WebStoreTable{TKey,TValue}.QueryKeysPage"/>. Round-trips to a
+    /// string via <see cref="ToToken"/> / <see cref="FromToken(string)"/> so
+    /// callers can persist it across sessions, network hops, or storage tiers
+    /// without reaching into the cursor's internal state.
+    /// <para>
+    /// The wire format is a JSON envelope with literal short keys (<c>v</c>,
+    /// <c>d</c>, <c>p</c>, <c>i</c>, <c>t</c>) — NScript minification renames
+    /// C# field names, so reflecting on field names would break the round-trip
+    /// across builds.
+    /// </para>
+    /// </summary>
+    public sealed class Cursor
+    {
+        private const string TokenVersion = "1";
+
+        internal Cursor(
+            object indexKey,
+            object primaryKey,
+            string direction,
+            string tableSig)
+        {
+            IndexKey = indexKey;
+            PrimaryKey = primaryKey;
+            Direction = direction;
+            TableSig = tableSig;
+        }
+
+        /// <summary>
+        /// Index key of the last accepted record, or <c>null</c> when the cursor
+        /// was issued by a primary-key scan (no secondary index involved).
+        /// </summary>
+        internal object IndexKey { get; }
+
+        /// <summary>Primary key of the last accepted record. Always populated.</summary>
+        internal object PrimaryKey { get; }
+
+        /// <summary>IDB cursor direction string ("next" or "prev") at issue time.</summary>
+        internal string Direction { get; }
+
+        /// <summary>Table-signature (object-store name) at issue time.</summary>
+        internal string TableSig { get; }
+
+        /// <summary>
+        /// Encode the cursor into a stable, persistable string. The encoding is
+        /// stable across NScript minified builds because the JSON keys are
+        /// literal — never C# field names.
+        /// </summary>
+        public string ToToken()
+        {
+            var env = new Dictionary();
+            env.Set("v", TokenVersion);
+            env.Set("d", Direction);
+            env.Set("t", TableSig);
+            env.Set("p", PrimaryKey);
+            if (IndexKey != null)
+            { env.Set("i", IndexKey); }
+            return JSON.Stringify(env);
+        }
+
+        /// <summary>
+        /// Decode a cursor from a token previously produced by
+        /// <see cref="ToToken"/>. Throws a descriptive <see cref="Exception"/>
+        /// when the token is malformed or carries an unsupported version.
+        /// </summary>
+        public static Cursor FromToken(string token)
+        {
+            if (token == null || token.Length == 0)
+            { throw new Exception("Cursor token is null or empty"); }
+
+            Dictionary env;
+            try { env = JSON.Parse(token); }
+            catch (Exception)
+            { throw new Exception("Cursor token is not valid JSON"); }
+
+            if (env == null)
+            { throw new Exception("Cursor token decoded to null"); }
+
+            if (!env.ContainsKey("v") || env.Get<string>("v") != TokenVersion)
+            { throw new Exception("Cursor token version mismatch (expected v=1)"); }
+
+            if (!env.ContainsKey("d"))
+            { throw new Exception("Cursor token missing direction"); }
+
+            var direction = env.Get<string>("d");
+            if (direction != "next" && direction != "prev")
+            { throw new Exception("Cursor token has invalid direction"); }
+
+            if (!env.ContainsKey("t"))
+            { throw new Exception("Cursor token missing table signature"); }
+
+            var tableSig = env.Get<string>("t");
+            if (tableSig == null || tableSig.Length == 0)
+            { throw new Exception("Cursor token missing table signature"); }
+
+            if (!env.ContainsKey("p"))
+            { throw new Exception("Cursor token missing primary key"); }
+
+            var primaryKey = env.Get<object>("p");
+            var indexKey = env.ContainsKey("i") ? env.Get<object>("i") : null;
+            return new Cursor(indexKey, primaryKey, direction, tableSig);
+        }
+    }
+}

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/Page.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/Page.cs
@@ -1,0 +1,36 @@
+namespace Sunlight.Framework.Data.WebStore
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// One page of records returned by
+    /// <see cref="WebStoreTable{TKey,TValue}.QueryPage"/> or
+    /// <see cref="WebStoreTable{TKey,TValue}.QueryKeysPage"/>. Carries the
+    /// items collected for this page plus an opaque <see cref="NextCursor"/>
+    /// that callers pass back to fetch the following page.
+    /// </summary>
+    /// <typeparam name="TValue">Element type of <see cref="Items"/>.</typeparam>
+    public sealed class Page<TValue>
+    {
+        public Page(IList<TValue> items, Cursor nextCursor)
+        {
+            Items = items;
+            NextCursor = nextCursor;
+        }
+
+        /// <summary>Records collected for this page (after filter, capped at page size).</summary>
+        public IList<TValue> Items { get; }
+
+        /// <summary>
+        /// Opaque continuation token. <c>null</c> when the iterator drained the
+        /// scan range before the page filled — that page is the final page. A
+        /// non-<c>null</c> cursor signals that at least one additional record
+        /// MAY exist; callers should pass it back via the <c>resumeFrom</c>
+        /// argument to fetch the next page.
+        /// </summary>
+        public Cursor NextCursor { get; }
+
+        /// <summary>True iff <see cref="NextCursor"/> is non-<c>null</c>.</summary>
+        public bool HasMore => NextCursor != null;
+    }
+}

--- a/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
+++ b/Sources/Framework/Sunlight.Framework.Data/WebStore/WebStoreTable.cs
@@ -241,6 +241,74 @@ namespace Sunlight.Framework.Data.WebStore
                     true));
         }
 
+        /// <summary>
+        /// Materialise a single bounded page of records matching
+        /// <paramref name="query"/>. Pagination semantics:
+        /// <list type="bullet">
+        /// <item><description><paramref name="pageSize"/> must be &ge; 1 and counts
+        /// records that pass <paramref name="inclFilter"/> — "I want N rows", not
+        /// "N reads". The returned <see cref="Page{TValue}.Items"/> is capped at
+        /// <paramref name="pageSize"/>.</description></item>
+        /// <item><description><see cref="Page{TValue}.NextCursor"/> is <c>null</c>
+        /// when the iterator drained the scan range before the page filled — that
+        /// page is the final page. A non-<c>null</c> cursor signals at least one
+        /// additional record may exist.</description></item>
+        /// <item><description>Pass <paramref name="resumeFrom"/> as the previous
+        /// page's <see cref="Page{TValue}.NextCursor"/> to fetch the next page.
+        /// Cross-transaction <i>see-current-state</i> semantics: records inserted
+        /// strictly past the cursor become visible on the next page; records
+        /// inserted strictly before are silently missed (cursor moved past);
+        /// deleted records are skipped naturally as the cursor walks current
+        /// state.</description></item>
+        /// </list>
+        /// Rejects when <paramref name="pageSize"/> &le; 0, when
+        /// <paramref name="resumeFrom"/> is combined with <c>Query.Skip</c> or
+        /// <c>Query.Limit</c>, when the cursor was issued for a different table,
+        /// or when its direction doesn't match <paramref name="query"/>'s.
+        /// </summary>
+        public Promise<Page<TValue>> QueryPage(
+            Query query,
+            int pageSize,
+            Cursor resumeFrom = null,
+            Func<TValue, bool> inclFilter = null,
+            WebStoreTransaction transaction = null)
+        {
+            return new Promise<Page<TValue>>((resolve, reject) =>
+                this.QueryPageInternal<TValue>(
+                    transaction,
+                    query,
+                    pageSize,
+                    resumeFrom,
+                    inclFilter,
+                    resolve,
+                    reject,
+                    false));
+        }
+
+        /// <summary>
+        /// Key-only paged variant of <see cref="QueryPage"/> — returns primary
+        /// keys instead of values. Same pagination semantics; same validation
+        /// surface. No <c>inclFilter</c> overload because key cursors don't
+        /// materialise values.
+        /// </summary>
+        public Promise<Page<TKey>> QueryKeysPage(
+            Query query,
+            int pageSize,
+            Cursor resumeFrom = null,
+            WebStoreTransaction transaction = null)
+        {
+            return new Promise<Page<TKey>>((resolve, reject) =>
+                this.QueryPageInternal<TKey>(
+                    transaction,
+                    query,
+                    pageSize,
+                    resumeFrom,
+                    null,
+                    resolve,
+                    reject,
+                    true));
+        }
+
         /// <summary>Like <see cref="Get"/> but resolves with null when the record is missing instead of rejecting.</summary>
         public Promise<TValue> TryGet(
             TKey key,
@@ -848,6 +916,139 @@ namespace Sunlight.Framework.Data.WebStore
                 },
                 reject,
                 isKeyQuery);
+        }
+
+        private void QueryPageInternal<U>(
+            WebStoreTransaction transaction,
+            Query query,
+            int pageSize,
+            Cursor resumeFrom,
+            Func<TValue, bool> inclFilter,
+            Action<Page<U>> resolve,
+            Action<object> reject,
+            bool isKeyQuery)
+        {
+            if (pageSize <= 0)
+            {
+                reject(new Exception("pageSize must be >= 1"));
+                return;
+            }
+
+            if (resumeFrom != null && query.Skip != null)
+            {
+                reject(new Exception(
+                    "Skip and resume cursor are mutually exclusive"));
+                return;
+            }
+
+            if (resumeFrom != null && query.Limit != null)
+            {
+                reject(new Exception(
+                    "cursor pagination supersedes Query.Limit; use pageSize"));
+                return;
+            }
+
+            if (resumeFrom != null && resumeFrom.TableSig != _tableSchema.Name)
+            {
+                reject(new Exception(
+                    "cursor was issued for a different table (expected '"
+                    + _tableSchema.Name + "', got '" + resumeFrom.TableSig + "')"));
+                return;
+            }
+
+            if (resumeFrom != null && resumeFrom.Direction != query.Direction)
+            {
+                reject(new Exception(
+                    "cursor direction mismatch (expected '"
+                    + query.Direction + "', got '" + resumeFrom.Direction + "')"));
+                return;
+            }
+
+            transaction = this.TransactionOrDefault(
+                transaction,
+                TransactionKind.Read);
+
+            bool isIndex = !_tableSchema.CanUsePrimaryIndex(query);
+            bool resumed = resumeFrom == null;
+            bool descending = query.Direction == "prev";
+            List<U> items = new List<U>();
+            object lastIndexKey = null;
+            object lastPrimaryKey = null;
+            bool pageFull = false;
+
+            this.CursorIterator(
+                transaction,
+                query,
+                inclFilter,
+                (cursor) =>
+                {
+                    if (cursor == null)
+                    {
+                        if (!pageFull)
+                        { resolve(new Page<U>(items, null)); }
+                        return true;
+                    }
+
+                    object curIndexKey = isIndex
+                        ? Type.AS<IDBKeyRange, object>(cursor.KeyRange)
+                        : null;
+                    object curPrimaryKey = Type.AS<TKey, object>(cursor.PrimaryKey);
+
+                    if (!resumed)
+                    {
+                        int cmp = ComparePagePair(
+                            isIndex,
+                            curIndexKey,
+                            curPrimaryKey,
+                            resumeFrom.IndexKey,
+                            resumeFrom.PrimaryKey);
+                        bool past = descending ? cmp < 0 : cmp > 0;
+                        if (!past)
+                        { return true; }
+                        resumed = true;
+                    }
+
+                    if (isKeyQuery)
+                    { items.Add(Type.AS<TKey, U>(cursor.PrimaryKey)); }
+                    else
+                    { items.Add(Type.AS<TValue, U>(cursor.Value)); }
+
+                    lastIndexKey = curIndexKey;
+                    lastPrimaryKey = curPrimaryKey;
+
+                    if (items.Count >= pageSize)
+                    {
+                        pageFull = true;
+                        resolve(new Page<U>(
+                            items,
+                            new Cursor(
+                                lastIndexKey,
+                                lastPrimaryKey,
+                                query.Direction,
+                                _tableSchema.Name)));
+                        return false;
+                    }
+
+                    return true;
+                },
+                reject,
+                isKeyQuery);
+        }
+
+        private static int ComparePagePair(
+            bool isIndex,
+            object aIdx,
+            object aPk,
+            object bIdx,
+            object bPk)
+        {
+            if (isIndex && aIdx != null && bIdx != null)
+            {
+                int c = (int)IDBFactory.Instance.Cmp(aIdx, bIdx);
+                if (c != 0)
+                { return c; }
+            }
+            return (int)IDBFactory.Instance.Cmp(aPk, bPk);
         }
 
         private void QueryUpdateOrDeleteInternal(

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -1479,6 +1479,161 @@ namespace Sunlight.Framework.Data.Test
         }
 
         /// <summary>
+        /// <c>QueryBuilder.Skip</c> combined with a resume cursor must reject —
+        /// stacking Skip on top of a cursor would silently create gaps in the
+        /// paginated stream that callers cannot diagnose. Pins the rejection
+        /// guard in <c>QueryPageInternal</c> (Skip + cursor mutually exclusive).
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRejectsSkipWithCursor(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                SeedRows(table, 5).Then<bool>(delegate(bool seeded)
+                {
+                    table.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        var skipQuery = new QueryBuilder(new string[0]).Skip(1).Build();
+                        table.QueryPage(skipQuery, 5, page1.NextCursor).Then<bool, object>(
+                            delegate(Page<CrudEntity> p)
+                            {
+                                assert.IsTrue(false, "Skip + cursor should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("Skip") >= 0,
+                                    "rejection message names Skip");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>QueryBuilder.Limit</c> combined with a resume cursor must reject —
+        /// the cursor's pageSize is the only contract honored on resume; a
+        /// stacked Limit would cap reads below pageSize and produce premature
+        /// short pages indistinguishable from end-of-stream. Pins the
+        /// rejection guard in <c>QueryPageInternal</c>.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRejectsLimitWithCursor(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                SeedRows(table, 5).Then<bool>(delegate(bool seeded)
+                {
+                    table.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        var limitQuery = new QueryBuilder(new string[0]).Limit(3).Build();
+                        table.QueryPage(limitQuery, 5, page1.NextCursor).Then<bool, object>(
+                            delegate(Page<CrudEntity> p)
+                            {
+                                assert.IsTrue(false, "Limit + cursor should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("Limit") >= 0,
+                                    "rejection message names Limit");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Filter + resume must produce a contiguous, non-overlapping stream
+        /// of accepted rows. Seeds 10 alternating Category rows ("todo"/"done"),
+        /// fetches page 1 with <c>inclFilter=todo</c> + <c>pageSize=2</c>, then
+        /// resumes with the same filter. The combined pages must contain
+        /// exactly the expected "todo" rows, in order, with no overlap and no
+        /// gap — pinning the interaction between the filter (applied inside
+        /// <c>CursorIterator</c>) and the resume-skip predicate (applied
+        /// against <c>cursor.PrimaryKey</c>).
+        /// </summary>
+        [Test]
+        public static void TestQueryPageFilterResumeIsContiguous(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                var seed = new CrudEntity[10];
+                for (int i = 0; i < 10; i = i + 1)
+                { seed[i] = NewEntity("r" + i, (i % 2 == 0) ? "todo" : "done", i); }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    table.QueryPage(
+                        Query.All,
+                        2,
+                        null,
+                        delegate(CrudEntity row) { return row.Category == "todo"; }
+                    ).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        assert.Equal(page1.Items.Count, 2, "page 1 returns 2 filtered rows");
+                        assert.Equal(page1.Items[0].Id, "r0", "page 1 starts at r0");
+                        assert.Equal(page1.Items[1].Id, "r2", "page 1 second row is r2");
+                        assert.IsTrue(page1.NextCursor != null, "non-final filtered page has a cursor");
+
+                        table.QueryPage(
+                            Query.All,
+                            2,
+                            page1.NextCursor,
+                            delegate(CrudEntity row) { return row.Category == "todo"; }
+                        ).Then<bool>(delegate(Page<CrudEntity> page2)
+                        {
+                            assert.Equal(page2.Items.Count, 2, "page 2 returns 2 filtered rows");
+                            assert.Equal(page2.Items[0].Id, "r4", "page 2 resumes at r4 (no overlap, no gap)");
+                            assert.Equal(page2.Items[1].Id, "r6", "page 2 second row is r6");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
         /// Key-only paged variant must return <c>Page&lt;TKey&gt;</c> matching
         /// the ordering of the value-paged scan. Pins the
         /// <c>QueryKeysPage</c> branch — the same code path with

--- a/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
+++ b/Test/Framework/Sunlight.Framework.Data.Test/WebStoreCrudTests.cs
@@ -900,6 +900,624 @@ namespace Sunlight.Framework.Data.Test
             });
         }
 
+        /// <summary>
+        /// First call to <c>QueryPage(Query.All, 3)</c> over 10 rows must return
+        /// 3 rows + a non-null <see cref="Page{TValue}.NextCursor"/>. Pins the
+        /// "page filled, more available" branch — the cursor signal is what
+        /// callers rely on to drive the loop.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageReturnsFirstPageWithCursor(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                SeedRows(client.Table<string, CrudEntity>(TableName), 10).Then<bool>(delegate(bool seeded)
+                {
+                    var table = client.Table<string, CrudEntity>(TableName);
+                    table.QueryPage(Query.All, 3).Then<bool>(delegate(Page<CrudEntity> page)
+                    {
+                        assert.Equal(page.Items.Count, 3, "first page returns pageSize rows");
+                        assert.IsTrue(page.NextCursor != null, "first page hands back a cursor");
+                        assert.IsTrue(page.HasMore, "HasMore mirrors NextCursor != null");
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Resuming a paged scan with the previous page's <see cref="Page{TValue}.NextCursor"/>
+        /// must return the next slice with no overlap and no gaps. This is the
+        /// core continuity invariant — without it the API is unusable.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageResumesFromCursor(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                SeedRows(client.Table<string, CrudEntity>(TableName), 10).Then<bool>(delegate(bool seeded)
+                {
+                    var table = client.Table<string, CrudEntity>(TableName);
+                    table.QueryPage(Query.All, 3).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        var firstIds = CollectIds(page1.Items);
+                        table.QueryPage(Query.All, 3, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                        {
+                            assert.Equal(page2.Items.Count, 3, "second page has pageSize rows");
+                            var secondIds = CollectIds(page2.Items);
+                            assert.IsTrue(NoOverlap(firstIds, secondIds), "no record appears on both pages");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// After exhausting the table, <see cref="Page{TValue}.NextCursor"/>
+        /// must be <c>null</c> and <see cref="Page{TValue}.HasMore"/> false.
+        /// Pins the end-of-stream signal — the loop-termination contract.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageEndOfStream(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                SeedRows(client.Table<string, CrudEntity>(TableName), 5).Then<bool>(delegate(bool seeded)
+                {
+                    var table = client.Table<string, CrudEntity>(TableName);
+                    table.QueryPage(Query.All, 5).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        // Page1 may or may not have NextCursor depending on whether the cursor
+                        // continued past the last record. If filled exactly, NextCursor is set
+                        // (per documented contract). Resume one more time to drain.
+                        Action<Page<CrudEntity>> assertDrained = delegate(Page<CrudEntity> finalPage)
+                        {
+                            assert.IsTrue(finalPage.NextCursor == null, "exhausted scan returns null cursor");
+                            assert.IsTrue(!finalPage.HasMore, "HasMore is false after drain");
+                            client.Close();
+                            done();
+                        };
+
+                        if (page1.NextCursor == null)
+                        { assertDrained(page1); }
+                        else
+                        {
+                            table.QueryPage(Query.All, 5, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                            {
+                                assertDrained(page2);
+                                return true;
+                            });
+                        }
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>QueryPage</c> on an empty table must resolve with an empty
+        /// <see cref="Page{TValue}.Items"/> and a <c>null</c> cursor — never
+        /// reject. Empty is a valid first-page state.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageEmptyTable(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                table.QueryPage(Query.All, 3).Then<bool>(delegate(Page<CrudEntity> page)
+                {
+                    assert.Equal(page.Items.Count, 0, "empty table yields empty Items");
+                    assert.IsTrue(page.NextCursor == null, "empty table yields null cursor");
+                    client.Close();
+                    done();
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>Cursor.FromToken(c.ToToken())</c> must be functionally equivalent
+        /// to <paramref name="c"/> — same continuation behaviour. Pins the
+        /// JSON-envelope round-trip (the literal-keyed shape that survives
+        /// NScript minification).
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRoundTripsToken(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                SeedRows(client.Table<string, CrudEntity>(TableName), 10).Then<bool>(delegate(bool seeded)
+                {
+                    var table = client.Table<string, CrudEntity>(TableName);
+                    table.QueryPage(Query.All, 3).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        var token = page1.NextCursor.ToToken();
+                        assert.IsTrue(token != null && token.Length > 0, "token serialises to a non-empty string");
+                        var revived = Cursor.FromToken(token);
+                        table.QueryPage(Query.All, 3, revived).Then<bool>(delegate(Page<CrudEntity> page2)
+                        {
+                            assert.Equal(page2.Items.Count, 3, "revived cursor produces a full second page");
+                            var firstIds = CollectIds(page1.Items);
+                            var secondIds = CollectIds(page2.Items);
+                            assert.IsTrue(NoOverlap(firstIds, secondIds), "revived cursor preserves no-overlap invariant");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Reverse iteration with <c>Descending()</c> must paginate in the
+        /// expected order — first page gets the highest keys, second page the
+        /// next-highest, etc. Pins the descending branch of the resume-skip
+        /// comparator.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageDescendingDirection(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                SeedRows(client.Table<string, CrudEntity>(TableName), 10).Then<bool>(delegate(bool seeded)
+                {
+                    var table = client.Table<string, CrudEntity>(TableName);
+                    var query = new QueryBuilder(new string[0])
+                        .Descending()
+                        .Build();
+
+                    table.QueryPage(query, 3).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        assert.Equal(page1.Items.Count, 3, "descending page returns pageSize rows");
+                        // Items must be in descending Id order: r9, r8, r7
+                        assert.Equal(page1.Items[0].Id, "r9", "descending first item is greatest key");
+                        assert.Equal(page1.Items[1].Id, "r8", "descending second item is next-greatest");
+                        assert.Equal(page1.Items[2].Id, "r7", "descending third item is third-greatest");
+
+                        table.QueryPage(query, 3, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                        {
+                            assert.Equal(page2.Items[0].Id, "r6", "descending page 2 starts at next-lower key");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Non-unique secondary index pagination must tiebreak on primary key
+        /// — IDB-spec ordering. With multiple rows sharing the same Category,
+        /// pages must contain no duplicates and no skips. This is the canary
+        /// for the index-tie skip path in the resume comparator.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageWithIndexAndTies(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                // Seed: 6 rows all with Category=="todo" so the index is fully tied.
+                var seed = new CrudEntity[6];
+                for (int i = 0; i < 6; i = i + 1)
+                { seed[i] = NewEntity("ix" + i, "todo", i); }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    var query = new QueryBuilder(new string[] { "Category" })
+                        .Equal<string>("todo")
+                        .Build();
+
+                    table.QueryPage(query, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        assert.Equal(page1.Items.Count, 2, "index page 1 returns pageSize rows");
+                        var firstIds = CollectIds(page1.Items);
+
+                        table.QueryPage(query, 2, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                        {
+                            assert.Equal(page2.Items.Count, 2, "index page 2 returns pageSize rows");
+                            var secondIds = CollectIds(page2.Items);
+                            assert.IsTrue(NoOverlap(firstIds, secondIds), "tied-index pages have no duplicates");
+
+                            table.QueryPage(query, 2, page2.NextCursor).Then<bool>(delegate(Page<CrudEntity> page3)
+                            {
+                                assert.Equal(page3.Items.Count, 2, "index page 3 drains the remainder");
+                                var thirdIds = CollectIds(page3.Items);
+                                assert.IsTrue(NoOverlap(firstIds, thirdIds), "page 1 vs page 3 disjoint");
+                                assert.IsTrue(NoOverlap(secondIds, thirdIds), "page 2 vs page 3 disjoint");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Inserting a row strictly past the page-1 cursor (lexicographically
+        /// greater Id) must make it visible on page 2 — see-current-state
+        /// contract. Without this, cross-page mutation handling would be
+        /// snapshot-style, which IDB semantics don't support.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageMutationBetweenPagesVisible(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                // Seed three rows: r1, r3, r5 (gaps deliberate so we can insert "r6" past the page-1 cursor).
+                var seed = new CrudEntity[] {
+                    NewEntity("r1", "todo", 1),
+                    NewEntity("r3", "todo", 3),
+                    NewEntity("r5", "todo", 5),
+                };
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    table.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        // Insert "r6" — strictly past the page-1 cursor (which lands at "r3").
+                        table.UpSert(NewEntity("r6", "todo", 6)).Then<bool>(delegate(string ignored)
+                        {
+                            table.QueryPage(Query.All, 5, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                            {
+                                bool sawR6 = false;
+                                for (int i = 0; i < page2.Items.Count; i = i + 1)
+                                {
+                                    if (page2.Items[i].Id == "r6")
+                                    { sawR6 = true; }
+                                }
+                                assert.IsTrue(sawR6, "row inserted past the cursor is visible on next page");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Inserting a row strictly before the page-1 cursor (lexicographically
+        /// lower Id) must NOT appear on page 2 — see-current-state semantics
+        /// document this as silently missed. Without this guard a refactor
+        /// could make the cursor reset to a snapshot and start re-reading
+        /// records before the cursor position.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageMutationBetweenPagesMissedBefore(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                // Seed: r3, r4, r5 — leave room for "r0" to be inserted strictly before the cursor.
+                var seed = new CrudEntity[] {
+                    NewEntity("r3", "todo", 3),
+                    NewEntity("r4", "todo", 4),
+                    NewEntity("r5", "todo", 5),
+                };
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    table.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        // Insert "r0" — strictly before the page-1 cursor (which lands at "r4").
+                        table.UpSert(NewEntity("r0", "todo", 0)).Then<bool>(delegate(string ignored)
+                        {
+                            table.QueryPage(Query.All, 5, page1.NextCursor).Then<bool>(delegate(Page<CrudEntity> page2)
+                            {
+                                bool sawR0 = false;
+                                for (int i = 0; i < page2.Items.Count; i = i + 1)
+                                {
+                                    if (page2.Items[i].Id == "r0")
+                                    { sawR0 = true; }
+                                }
+                                assert.IsTrue(!sawR0, "row inserted before the cursor is silently missed");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>inclFilter</c> rejects half the rows; <c>pageSize=3</c> must
+        /// return 3 <i>accepted</i> rows (post-filter), not 3 reads. This is
+        /// the "I want N rows, not N reads" contract documented on
+        /// <see cref="WebStoreTable{TKey,TValue}.QueryPage"/>.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageWithFilterSkipsRejectedRows(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                // Seed 10 rows alternating Category — filter accepts only "todo".
+                var seed = new CrudEntity[10];
+                for (int i = 0; i < 10; i = i + 1)
+                { seed[i] = NewEntity("r" + i, (i % 2 == 0) ? "todo" : "done", i); }
+
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    table.QueryPage(
+                        Query.All,
+                        3,
+                        null,
+                        delegate(CrudEntity row) { return row.Category == "todo"; }
+                    ).Then<bool>(delegate(Page<CrudEntity> page)
+                    {
+                        assert.Equal(page.Items.Count, 3, "filtered page returns 3 accepted rows (not 3 reads)");
+                        for (int i = 0; i < page.Items.Count; i = i + 1)
+                        { assert.Equal(page.Items[i].Category, "todo", "filter only let 'todo' rows through"); }
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// <c>pageSize &le; 0</c> must reject through the Promise — not throw
+        /// synchronously. Pins the symmetric error surface with the rest of
+        /// the WebStoreTable APIs (callers using <c>.Then(_, onRejected)</c>
+        /// see a uniform path).
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRejectsInvalidPageSize(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                table.QueryPage(Query.All, 0).Then<bool, object>(
+                    delegate(Page<CrudEntity> p)
+                    {
+                        assert.IsTrue(false, "pageSize=0 should reject, not resolve");
+                        client.Close();
+                        done();
+                        return true;
+                    },
+                    delegate(object err)
+                    {
+                        assert.IsTrue(err != null, "rejection has an error");
+                        var message = ((Exception)err).Message;
+                        assert.IsTrue(
+                            message != null && message.IndexOf("pageSize") >= 0,
+                            "rejection message names pageSize");
+                        client.Close();
+                        done();
+                        return true;
+                    });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// A token issued for table A then used on table B must reject — the
+        /// table-signature check prevents accidental cross-table resume which
+        /// would otherwise produce silently wrong results.
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRejectsCrossTableToken(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            // Build a schema with two stores so we can issue a token from one and resume on the other.
+            var schemaTwoStore = new WebStoreSchema(
+                dbName,
+                1,
+                new TableSchema(TableName, new KeyInfo("Id", false), new SingleIndexInfo(CategoryIndex, "Category")),
+                new TableSchema("other", new KeyInfo("Id", false)));
+
+            factory.Create(schemaTwoStore).Then<bool>(delegate(WebStoreClient client)
+            {
+                var primary = client.Table<string, CrudEntity>(TableName);
+                var other = client.Table<string, CrudEntity>("other");
+                SeedRows(primary, 5).Then<bool>(delegate(bool seeded)
+                {
+                    primary.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        // Reuse the token from "items" on "other" — must reject.
+                        other.QueryPage(Query.All, 5, page1.NextCursor).Then<bool, object>(
+                            delegate(Page<CrudEntity> p)
+                            {
+                                assert.IsTrue(false, "cross-table cursor should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("different table") >= 0,
+                                    "rejection message names the table-signature mismatch");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// An ascending-direction token used on a descending-direction query
+        /// must reject — the comparator in <c>QueryPageInternal</c> would
+        /// silently produce wrong results otherwise (skipping in the wrong
+        /// direction).
+        /// </summary>
+        [Test]
+        public static void TestQueryPageRejectsDirectionMismatch(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                SeedRows(table, 5).Then<bool>(delegate(bool seeded)
+                {
+                    // Issue token on ascending Query.All.
+                    table.QueryPage(Query.All, 2).Then<bool>(delegate(Page<CrudEntity> page1)
+                    {
+                        var descending = new QueryBuilder(new string[0]).Descending().Build();
+                        table.QueryPage(descending, 5, page1.NextCursor).Then<bool, object>(
+                            delegate(Page<CrudEntity> p)
+                            {
+                                assert.IsTrue(false, "direction mismatch should reject, not resolve");
+                                client.Close();
+                                done();
+                                return true;
+                            },
+                            delegate(object err)
+                            {
+                                var message = ((Exception)err).Message;
+                                assert.IsTrue(
+                                    message != null && message.IndexOf("direction") >= 0,
+                                    "rejection message names the direction mismatch");
+                                client.Close();
+                                done();
+                                return true;
+                            });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Key-only paged variant must return <c>Page&lt;TKey&gt;</c> matching
+        /// the ordering of the value-paged scan. Pins the
+        /// <c>QueryKeysPage</c> branch — the same code path with
+        /// <c>isKeyQuery=true</c>.
+        /// </summary>
+        [Test]
+        public static void TestQueryKeysPageReturnsKeysOnly(Assert assert)
+        {
+            var done = assert.Async(1);
+            var factory = new WebStoreFactory();
+            var dbName = NewDbName();
+
+            factory.Create(BuildSchema(dbName)).Then<bool>(delegate(WebStoreClient client)
+            {
+                var table = client.Table<string, CrudEntity>(TableName);
+                SeedRows(table, 6).Then<bool>(delegate(bool seeded)
+                {
+                    table.QueryKeysPage(Query.All, 3).Then<bool>(delegate(Page<string> keysPage1)
+                    {
+                        assert.Equal(keysPage1.Items.Count, 3, "key page returns pageSize keys");
+                        assert.Equal(keysPage1.Items[0], "r0", "first key is smallest");
+                        assert.IsTrue(keysPage1.NextCursor != null, "non-final key page has a cursor");
+
+                        table.QueryKeysPage(Query.All, 3, keysPage1.NextCursor).Then<bool>(delegate(Page<string> keysPage2)
+                        {
+                            assert.Equal(keysPage2.Items.Count, 3, "second key page returns pageSize keys");
+                            assert.Equal(keysPage2.Items[0], "r3", "second page starts at the next key");
+                            client.Close();
+                            done();
+                            return true;
+                        });
+                        return true;
+                    });
+                    return true;
+                });
+                return true;
+            });
+        }
+
         private static CrudEntity NewEntity(string id, string category, int score)
         {
             var e = new CrudEntity();
@@ -907,6 +1525,49 @@ namespace Sunlight.Framework.Data.Test
             e.Category = category;
             e.Score = score;
             return e;
+        }
+
+        /// <summary>
+        /// Seed <paramref name="count"/> rows with Ids "r0"..."r{count-1}".
+        /// Lexicographic ordering matches numeric ordering only when count &lt; 10
+        /// — pagination tests stay below that threshold to keep ordering
+        /// deterministic.
+        /// </summary>
+        private static Promise<bool> SeedRows(WebStoreTable<string, CrudEntity> table, int count)
+        {
+            var seed = new CrudEntity[count];
+            for (int i = 0; i < count; i = i + 1)
+            { seed[i] = NewEntity("r" + i, "todo", i); }
+
+            return new Promise<bool>(delegate(Action<bool> resolve, Action<object> reject)
+            {
+                table.UpSert(seed).Then<bool>(delegate(string[] keys)
+                {
+                    resolve(true);
+                    return true;
+                });
+            });
+        }
+
+        private static List<string> CollectIds(IList<CrudEntity> items)
+        {
+            var ids = new List<string>();
+            for (int i = 0; i < items.Count; i = i + 1)
+            { ids.Add(items[i].Id); }
+            return ids;
+        }
+
+        private static bool NoOverlap(List<string> a, List<string> b)
+        {
+            for (int i = 0; i < a.Count; i = i + 1)
+            {
+                for (int j = 0; j < b.Count; j = j + 1)
+                {
+                    if (a[i] == b[j])
+                    { return false; }
+                }
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
[Gautam's Dev bot] Closes #38.

## Summary

Adds resumable, bounded-size pagination to `WebStoreTable` via a new `QueryPage` / `QueryKeysPage` API. Callers get a `Page<TValue>` (items capped at pageSize) with an opaque `Cursor` continuation token they pass back to fetch the next page.

## What changed

**New types** (`Sources/Framework/Sunlight.Framework.Data/WebStore/`):
- `Page<TValue>` — `Items` (post-filter, capped at pageSize) + `NextCursor` (null when the scan drained before the page filled).
- `Cursor` — opaque continuation token carrying `(IndexKey, PrimaryKey, Direction, TableSig)`. Round-trips via `ToToken` / `FromToken` using a literal-keyed JSON envelope (`v`/`d`/`t`/`p`/`i`) so NScript minification cannot break the wire format across builds.

**WebStoreTable additions**:
- `QueryPage(query, pageSize, resumeFrom?, inclFilter?, transaction?)` and `QueryKeysPage(query, pageSize, resumeFrom?, transaction?)`.
- Private `QueryPageInternal<U>` validates `pageSize >= 1`, rejects `Skip`/`Limit` when resuming, enforces table-sig and direction match, then drives the existing `CursorIterator` with skip-until-past-token logic. Index ties tiebreak on primary key per IDB-spec ordering.

## Semantics

- **pageSize** counts records that pass the filter — "I want N rows", not "N reads".
- **NextCursor** is `null` only when the iterator drained the scan range before the page filled; non-null signals at least one more record may exist.
- **See-current-state** mutation contract: rows inserted strictly past the cursor become visible on the next page; rows inserted before are silently missed; deletes are skipped naturally.

## Validation surface (all reject through the Promise — symmetric with rest of the API)

- `pageSize <= 0`
- `resumeFrom` combined with `Query.Skip` or `Query.Limit`
- Cursor issued for a different table (`TableSig` mismatch)
- Cursor direction doesn't match the query's direction

## Tests

14 QUnit tests in `WebStoreCrudTests.cs` cover the full API surface:
- First page returns `pageSize` rows + non-null cursor
- Resume produces non-overlapping continuation
- End-of-stream returns null cursor
- Empty table resolves with empty page
- Token round-trip preserves continuation
- Descending direction
- Non-unique index with ties
- Mutation past cursor visible / before cursor missed (see-current-state)
- Filter counts accepted rows, not reads
- Rejection paths: `pageSize <= 0`, cross-table token, direction mismatch
- Keys-only variant

All 230 QUnit tests pass; both Debug and Release builds succeed (0 errors).

## Test plan

- [x] `dotnet build NScript_Full.sln -c Debug` — 0 errors
- [x] `dotnet build NScript_Full.sln -c Release` — 0 errors
- [x] QUnit suite via `Test/Framework/TestWebApplication/run-qunit.mjs` — 230/230 pass