### PR TITLE
Bump NuGet packages (vuln fix + patch/minor)

### DIFF
--- a/Sources/Compiler/Autoprefixer/Autoprefixer.csproj
+++ b/Sources/Compiler/Autoprefixer/Autoprefixer.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.3.0" />
     <PackageReference Include="Microsoft.ClearScript.Core" Version="7.1.4" />
     <!-- <PackageReference Include="Microsoft.CSharp" Version="4.7.0" /> -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" /> -->
   </ItemGroup>
 </Project>

--- a/Sources/Compiler/Cs2Jsc/Cs2Jsc.csproj
+++ b/Sources/Compiler/Cs2Jsc/Cs2Jsc.csproj
@@ -27,8 +27,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
   </ItemGroup>
 </Project>

--- a/Sources/Compiler/JsCsc.Lib/JsCsc.Lib.csproj
+++ b/Sources/Compiler/JsCsc.Lib/JsCsc.Lib.csproj
@@ -30,9 +30,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NetSerializer" Version="4.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
+    <PackageReference Include="NetSerializer" Version="4.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Sources/Compiler/NScript.Converter/NScript.Converter.csproj
+++ b/Sources/Compiler/NScript.Converter/NScript.Converter.csproj
@@ -28,8 +28,8 @@
     <ProjectReference Include="..\JsCsc.Lib\JsCsc.Lib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="DependencyBuilder\TypeDependencyInfo.cs" />

--- a/Sources/Compiler/NScript.Csc.Lib/NScript.csc.lib.csproj
+++ b/Sources/Compiler/NScript.Csc.Lib/NScript.csc.lib.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="10.0.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.7" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
   </ItemGroup>
 </Project>

--- a/Sources/Compiler/NScript.Utils/NScript.Utils.csproj
+++ b/Sources/Compiler/NScript.Utils/NScript.Utils.csproj
@@ -10,7 +10,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/Sources/Compiler/XwmlParser/XwmlParser.csproj
+++ b/Sources/Compiler/XwmlParser/XwmlParser.csproj
@@ -41,9 +41,9 @@
     <Content Include="SampleTemplate.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="SampleTemplate.cs" />

--- a/Test/Compiler/NScript.CLR.Test/NScript.CLR.Test.csproj
+++ b/Test/Compiler/NScript.CLR.Test/NScript.CLR.Test.csproj
@@ -137,11 +137,11 @@
     <EmbeddedResource Include="CstTests\ForLoopBlocks\ForLoopContinue.csast" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Reflection.Metadata" Version="10.0.1" />

--- a/Test/Compiler/NScript.Converter.Test/NScript.Converter.Test.csproj
+++ b/Test/Compiler/NScript.Converter.Test/NScript.Converter.Test.csproj
@@ -502,8 +502,8 @@
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.1.4" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.1.4" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.1.4" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Reflection.Metadata" Version="10.0.1" />

--- a/Test/Compiler/NScript.Csc.Lib.Test/NScript.Csc.Lib.Test.csproj
+++ b/Test/Compiler/NScript.Csc.Lib.Test/NScript.Csc.Lib.Test.csproj
@@ -25,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="protobuf-net" Version="3.1.25" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
+    <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Reflection.Metadata" Version="10.0.1" />

--- a/Test/Compiler/XwmlParser.Test/XwmlParser.Test.csproj
+++ b/Test/Compiler/XwmlParser.Test/XwmlParser.Test.csproj
@@ -222,8 +222,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Collections.Immutable" Version="10.0.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />


### PR DESCRIPTION
Fixes #49.

## Summary

- **Security:** `Microsoft.Build.Framework` / `Microsoft.Build.Tasks.Core` / `Microsoft.Build.Utilities.Core` `16.10.0` → `18.4.0` in `Cs2Jsc`. Clears [GHSA-h4j7-5rxr-p4wc](https://github.com/advisories/GHSA-h4j7-5rxr-p4wc) (HIGH) on `Microsoft.Build.Tasks.Core` 16.10.0.
- **Patch/minor refresh:** `Newtonsoft.Json` 13.0.1 → 13.0.4, `protobuf-net` 3.1.25 → 3.2.56, `NetSerializer` 4.1.1 → 4.1.2, `HtmlAgilityPack` 1.11.34 → 1.12.4, `System.Text.Encoding.CodePages` 8.0.0 → 10.0.7, `System.Buffers` 4.5.1 → 4.6.1.
- 11 csproj files only — no source code touched (+23/-23 lines).

## Explicitly deferred (follow-up PRs)

- **`Microsoft.ClearScript` 7.5.0** — breaks V8 null-deref error format used by `NullableTests` snapshots. Needs a dedicated PR + snapshot refresh.
- **`MSTest` 3.x + `Microsoft.NET.Test.Sdk` 17.x/18.x** — coupled upgrade, deserves its own test-infra PR.

## Test plan

- [x] `dotnet build NScript_Full.sln -c Release` green
- [x] `dotnet build NScript_Full.sln -c Debug` green
- [x] All compiler tests pass (942/942) when run sequentially per-project. Sequential is required because of a pre-existing race (out of scope here) between `NScript.CLR.Test` and `NScript.Converter.Test` over `%TEMP%\mscorlib.dll`.
- [x] Pre-commit hook on this branch: 807/807 passing (incl. 50 Playwright e2e tests).
