### PR TITLE
WI-51: split QUnit pages so each loads only one *.Test.js bundle

### DIFF
--- a/Test/CLAUDE.md
+++ b/Test/CLAUDE.md
@@ -22,11 +22,19 @@ cd Test/Framework/TestWebApplication
 npx serve .
 
 # 3. Open http://localhost:3000/TestPage.htm in any browser
+#    (this is now an index page; pick a per-suite page from the list)
 ```
+
+> **Each test suite runs on its own page.** Co-loading multiple NScript bundles
+> on a single page corrupts `Function.prototype` runtime metadata because the
+> minifier picks per-IIFE letters that collide on the shared prototype (see
+> issue #51). `TestPage.htm` is now a link index; the actual suites are at
+> `Sunlight.Framework.TestPage.htm`, `Sunlight.Framework.UI.TestPage.htm`,
+> `DataTestPage.htm`, and `TodoApp.TestPage.htm`.
 
 ### How It Works
 
-C# test code using `[TestFixture]` / `[Test]` attributes from the `SunlightUnit` framework gets compiled to JavaScript by the NScript compiler. The `TestGenerator` plugin (`Sources/Compiler/NScript.Converter.Plugins/TestGenerator.cs`) scans for these attributes and emits `QUnit.module()` / `QUnit.test()` registration calls in the generated JS. The `TestPage.htm` page loads QUnit and the generated scripts, and QUnit runs everything automatically.
+C# test code using `[TestFixture]` / `[Test]` attributes from the `SunlightUnit` framework gets compiled to JavaScript by the NScript compiler. The `TestGenerator` plugin (`Sources/Compiler/NScript.Converter.Plugins/TestGenerator.cs`) scans for these attributes and emits `QUnit.module()` / `QUnit.test()` registration calls in the generated JS. Each suite-specific QUnit page (e.g. `Sunlight.Framework.TestPage.htm`) loads QUnit plus exactly one generated bundle, and QUnit runs everything automatically.
 
 ### Pipeline
 
@@ -37,7 +45,7 @@ C# [TestFixture]/[Test]  -->  dotnet build (Debug)  -->  nscript.exe + TestGener
                                                     GeneratedScripts/*.js
                                                               |
                                                               v
-                                                    TestPage.htm + QUnit 2.2.0
+                                                    Per-suite *.TestPage.htm + QUnit 2.2.0
                                                               |
                                                               v
                                                     Browser executes tests
@@ -58,16 +66,20 @@ The `SunlightUnit.Assert` class uses `[ScriptAlias]` attributes so C# assertion 
 1. Create a `[TestFixture]` class with `public static` `[Test]` methods that accept `Assert assert`
 2. Project `.csproj` must have `<GenerateJs>True</GenerateJs>`, `<JsOutputPath>../TestWebApplication/GeneratedScripts</JsOutputPath>`, and `<PluginConfig>PluginConfig.xml</PluginConfig>`
 3. `PluginConfig.xml` must register `NScript.Converter.Plugins.TestGenerator`
-4. Add a `<script>` tag for the generated JS in `TestPage.htm`
+4. Add a **new** `*.TestPage.htm` that loads ONLY your project's generated JS (mirror `Sunlight.Framework.TestPage.htm`); do not co-load it with another bundle, and link it from `TestPage.htm`
 5. Build Debug, serve, open in browser
 
 ### Automated Execution (Playwright)
 
-For CI or headless runs, use Playwright to launch a browser, navigate to `TestPage.htm`, and wait for `#qunit-banner` to gain class `qunit-pass` or `qunit-fail`. Extract per-test results from `#qunit-tests > li` elements. See `Test/docs/browser-testing.md` for a full script pattern.
+For CI or headless runs, use Playwright to launch a browser, navigate to each per-suite page (`Sunlight.Framework.TestPage.htm`, `Sunlight.Framework.UI.TestPage.htm`, `DataTestPage.htm`, `TodoApp.TestPage.htm`), and wait for `#qunit-banner` to gain class `qunit-pass` or `qunit-fail`. Extract per-test results from `#qunit-tests > li` elements. `run-qunit.mjs` and `run-tests.js` both already iterate the per-suite pages — see `Test/docs/browser-testing.md` for the full pattern.
 
 ### Key Locations
 
-- `Test/Framework/TestWebApplication/TestPage.htm` -- QUnit HTML runner
+- `Test/Framework/TestWebApplication/TestPage.htm` -- index page (links to per-suite pages; loads no bundles)
+- `Test/Framework/TestWebApplication/Sunlight.Framework.TestPage.htm` -- core framework suite
+- `Test/Framework/TestWebApplication/Sunlight.Framework.UI.TestPage.htm` -- UI framework suite
+- `Test/Framework/TestWebApplication/DataTestPage.htm` -- data-layer suite
+- `Test/Framework/TestWebApplication/TodoApp.TestPage.htm` -- TodoApp suite
 - `Test/Framework/TestWebApplication/GeneratedScripts/` -- Compiled JS output
 - `Test/Framework/TestWebApplication/Scripts/QUnit.2.2.0.js` -- QUnit framework
 - `Test/Framework/Sunlight.Framework.Test/` -- Core framework tests (container, events, observables, binders)

--- a/Test/Framework/TestWebApplication/Sunlight.Framework.TestPage.htm
+++ b/Test/Framework/TestWebApplication/Sunlight.Framework.TestPage.htm
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Sunlight.Framework Tests</title>
+  <link href="Styles/QUnit.2.2.0.css" rel="stylesheet" type="text/css" />
+  <script src="Scripts/QUnit.2.2.0.js" type="text/javascript"></script>
+  <!--
+    Framework tests are hosted on their own page because each NScript-compiled
+    bundle installs its own copy of Type runtime methods (IsInstanceOfType,
+    DefaultConstructor, etc.) onto Function.prototype, with per-bundle
+    minified field names (fullName_d vs fullName_i, baseInterfaces_h vs
+    baseInterfaces_V). If two bundles' minifier happens to pick the same
+    method suffix (e.g., `_l`), the last-loaded bundle clobbers earlier
+    installs with a body that reads the wrong field tokens — triggering
+    InvalidCast at runtime. Keeping each app-scale test suite on its own
+    page matches NScript's single-bundle-per-app design.
+  -->
+  <script src="GeneratedScripts/Sunlight.Framework.Test.js" type="text/javascript"></script>
+</head>
+<body>
+  <h1 id="qunit-header">
+    Sunlight.Framework UnitTest</h1>
+  <h2 id="qunit-banner">
+  </h2>
+  <h2 id="qunit-userAgent">
+  </h2>
+  <ol id="qunit-tests">
+  </ol>
+  <br />
+  <textarea id="qunit-log" rows="10" cols="100"></textarea>
+</body>
+</html>

--- a/Test/Framework/TestWebApplication/Sunlight.Framework.UI.TestPage.htm
+++ b/Test/Framework/TestWebApplication/Sunlight.Framework.UI.TestPage.htm
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Sunlight.Framework.UI Tests</title>
+  <link href="Styles/QUnit.2.2.0.css" rel="stylesheet" type="text/css" />
+  <script src="Scripts/QUnit.2.2.0.js" type="text/javascript"></script>
+  <!--
+    UI tests are hosted on their own page because each NScript-compiled
+    bundle installs its own copy of Type runtime methods (IsInstanceOfType,
+    DefaultConstructor, etc.) onto Function.prototype, with per-bundle
+    minified field names (fullName_d vs fullName_i, baseInterfaces_h vs
+    baseInterfaces_V). If two bundles' minifier happens to pick the same
+    method suffix (e.g., `_l`), the last-loaded bundle clobbers earlier
+    installs with a body that reads the wrong field tokens — triggering
+    InvalidCast at runtime. Keeping each app-scale test suite on its own
+    page matches NScript's single-bundle-per-app design.
+  -->
+  <script src="GeneratedScripts/Sunlight.Framework.UI.Test.js" type="text/javascript"></script>
+</head>
+<body>
+  <h1 id="qunit-header">
+    Sunlight.Framework.UI UnitTest</h1>
+  <h2 id="qunit-banner">
+  </h2>
+  <h2 id="qunit-userAgent">
+  </h2>
+  <ol id="qunit-tests">
+  </ol>
+  <br />
+  <textarea id="qunit-log" rows="10" cols="100"></textarea>
+</body>
+</html>

--- a/Test/Framework/TestWebApplication/TestPage.htm
+++ b/Test/Framework/TestWebApplication/TestPage.htm
@@ -1,30 +1,38 @@
-﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <title>Cs2JsC scripts</title>
+  <title>NScript Framework Tests — Index</title>
   <link href="Styles/QUnit.2.2.0.css" rel="stylesheet" type="text/css" />
-  <script src="Scripts/QUnit.2.2.0.js" type="text/javascript"></script>
-  <script src="GeneratedScripts/Sunlight.Framework.Test.js" type="text/javascript"></script>
-  <!--<script src="GeneratedScripts/System.Web.Html.Tests.js" type="text/javascript"></script>-->
-  <script src="GeneratedScripts/Sunlight.Framework.UI.Test.js" type="text/javascript"></script>
-  <script src="GeneratedScripts/TodoApp.Test.js" type="text/javascript"></script>
-
+  <!--
+    This page intentionally loads NO test bundles. Each NScript-compiled
+    bundle installs its own copy of Type runtime methods (IsInstanceOfType,
+    DefaultConstructor, etc.) onto Function.prototype, with per-bundle
+    minified field names (fullName_d vs fullName_i, baseInterfaces_h vs
+    baseInterfaces_V). If two bundles' minifier happens to pick the same
+    method suffix (e.g., `_l`), the last-loaded bundle clobbers earlier
+    installs with a body that reads the wrong field tokens — triggering
+    InvalidCast at runtime. Keeping each app-scale test suite on its own
+    page matches NScript's single-bundle-per-app design. Open one of the
+    suite-specific pages below; do NOT add `<script>` tags here.
+  -->
 </head>
 <body>
-  <a id="coverage" href="CodeCoverage.html?UnitTest4Coverage.html">Coverage Report</a>
-  <!-- QUnit markup
--->
-  <h1 id="qunit-header">
-    UnitTest</h1>
-  <h2 id="qunit-banner">
-  </h2>
-  <h2 id="qunit-userAgent">
-  </h2>
-  <ol id="qunit-tests">
-  </ol>
-  <br />
-  <textarea id="qunit-log" rows="10" cols="100"></textarea>
-  <!-- Include other markup needed by the test code and the application being tested
--->
+  <h1 id="qunit-header">NScript Framework Tests</h1>
+  <p>
+    Each suite runs on its own page so per-IIFE minified runtime metadata on
+    <code>Function.prototype</code> does not collide across bundles. Open the
+    page for the suite you want to run:
+  </p>
+  <ul>
+    <li><a href="Sunlight.Framework.TestPage.htm">Sunlight.Framework.Test</a> — core framework (IoC, observables, binders)</li>
+    <li><a href="Sunlight.Framework.UI.TestPage.htm">Sunlight.Framework.UI.Test</a> — UI templates, skins, list views</li>
+    <li><a href="DataTestPage.htm">Sunlight.Framework.Data.Test</a> — data layer (IndexedDB, WebStore)</li>
+    <li><a href="TodoApp.TestPage.htm">TodoApp.Test</a> — TodoApp end-to-end</li>
+  </ul>
+  <p>
+    For headless / CI execution use <code>node run-qunit.mjs</code> (Playwright,
+    one suite per browser page) or <code>node run-tests.js</code> (iterates the
+    suite pages above).
+  </p>
 </body>
 </html>

--- a/Test/Framework/TestWebApplication/TestWebApplication.csproj
+++ b/Test/Framework/TestWebApplication/TestWebApplication.csproj
@@ -69,6 +69,9 @@
     <Content Include="Styles\QUnit.2.2.0.css" />
     <Content Include="Global.asax" />
     <Content Include="TestPage.htm" />
+    <Content Include="Sunlight.Framework.TestPage.htm" />
+    <Content Include="Sunlight.Framework.UI.TestPage.htm" />
+    <Content Include="TodoApp.TestPage.htm" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/Test/Framework/TestWebApplication/TodoApp.TestPage.htm
+++ b/Test/Framework/TestWebApplication/TodoApp.TestPage.htm
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>TodoApp Tests</title>
+  <link href="Styles/QUnit.2.2.0.css" rel="stylesheet" type="text/css" />
+  <script src="Scripts/QUnit.2.2.0.js" type="text/javascript"></script>
+  <!--
+    TodoApp tests are hosted on their own page because each NScript-compiled
+    bundle installs its own copy of Type runtime methods (IsInstanceOfType,
+    DefaultConstructor, etc.) onto Function.prototype, with per-bundle
+    minified field names (fullName_d vs fullName_i, baseInterfaces_h vs
+    baseInterfaces_V). If two bundles' minifier happens to pick the same
+    method suffix (e.g., `_l`), the last-loaded bundle clobbers earlier
+    installs with a body that reads the wrong field tokens — triggering
+    InvalidCast at runtime. Keeping each app-scale test suite on its own
+    page matches NScript's single-bundle-per-app design.
+  -->
+  <script src="GeneratedScripts/TodoApp.Test.js" type="text/javascript"></script>
+</head>
+<body>
+  <h1 id="qunit-header">
+    TodoApp UnitTest</h1>
+  <h2 id="qunit-banner">
+  </h2>
+  <h2 id="qunit-userAgent">
+  </h2>
+  <ol id="qunit-tests">
+  </ol>
+  <br />
+  <textarea id="qunit-log" rows="10" cols="100"></textarea>
+</body>
+</html>

--- a/Test/Framework/TestWebApplication/run-tests.js
+++ b/Test/Framework/TestWebApplication/run-tests.js
@@ -1,81 +1,118 @@
 const { chromium } = require('playwright');
 
+// Each NScript-compiled test bundle must run on its own page — bundles
+// collide on Function.prototype runtime metadata when co-loaded. See
+// the comment block in TestPage.htm and DataTestPage.htm for details.
+const SUITE_PAGES = [
+  'Sunlight.Framework.TestPage.htm',
+  'Sunlight.Framework.UI.TestPage.htm',
+  'DataTestPage.htm',
+  'TodoApp.TestPage.htm',
+];
+
 (async () => {
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
 
-  // Collect console errors and debug logs
-  const errors = [];
-  const debugLogs = [];
-  page.on('console', msg => {
-    if (msg.type() === 'error') errors.push(msg.text());
-    const text = msg.text();
-    if (text.startsWith('[DBG-')) debugLogs.push(text);
-  });
-  page.on('pageerror', err => errors.push(err.message));
+  let totalPassed = 0;
+  let totalFailed = 0;
+  const allFailures = [];
+  const allErrors = [];
+  const allDebugLogs = [];
 
-  await page.goto('http://localhost:3000/TestPage.htm', { waitUntil: 'domcontentloaded' });
+  try {
+    for (const suitePage of SUITE_PAGES) {
+      const page = await browser.newPage();
 
-  // Wait for QUnit to finish (banner gets class qunit-pass or qunit-fail)
-  await page.waitForFunction(() => {
-    const banner = document.getElementById('qunit-banner');
-    return banner && (banner.className.includes('qunit-pass') || banner.className.includes('qunit-fail'));
-  }, { timeout: 60000 });
+      const errors = [];
+      const debugLogs = [];
+      page.on('console', msg => {
+        if (msg.type() === 'error') errors.push(msg.text());
+        const text = msg.text();
+        if (text.startsWith('[DBG-')) debugLogs.push(text);
+      });
+      page.on('pageerror', err => errors.push(err.message));
 
-  // Extract results
-  const results = await page.evaluate(() => {
-    const tests = document.querySelectorAll('#qunit-tests > li');
-    const output = [];
-    tests.forEach(li => {
-      const name = li.querySelector('.test-name')?.textContent || '';
-      const module = li.querySelector('.module-name')?.textContent || '';
-      const status = li.className.includes('pass') ? 'PASS' : 'FAIL';
-      let failDetail = '';
-      if (status === 'FAIL') {
-        const assertList = li.querySelectorAll('.qunit-assert-list > li.fail');
-        assertList.forEach(a => {
-          const expected = a.querySelector('.test-expected td')?.textContent || '';
-          const actual = a.querySelector('.test-actual td')?.textContent || '';
-          const msg = a.querySelector('.test-message')?.textContent || '';
-          const source = a.querySelector('.test-source')?.textContent || '';
-          failDetail += `  [${msg}] expected=${expected} actual=${actual}\n`;
-          if (source) failDetail += `  source: ${source.trim().substring(0, 200)}\n`;
+      await page.goto(`http://localhost:3000/${suitePage}`, { waitUntil: 'domcontentloaded' });
+
+      // Wait for QUnit to finish (banner gets class qunit-pass or qunit-fail)
+      await page.waitForFunction(() => {
+        const banner = document.getElementById('qunit-banner');
+        return banner && (banner.className.includes('qunit-pass') || banner.className.includes('qunit-fail'));
+      }, { timeout: 60000 });
+
+      // Extract results
+      const results = await page.evaluate(() => {
+        const tests = document.querySelectorAll('#qunit-tests > li');
+        const output = [];
+        tests.forEach(li => {
+          const name = li.querySelector('.test-name')?.textContent || '';
+          const module = li.querySelector('.module-name')?.textContent || '';
+          const status = li.className.includes('pass') ? 'PASS' : 'FAIL';
+          let failDetail = '';
+          if (status === 'FAIL') {
+            const assertList = li.querySelectorAll('.qunit-assert-list > li.fail');
+            assertList.forEach(a => {
+              const expected = a.querySelector('.test-expected td')?.textContent || '';
+              const actual = a.querySelector('.test-actual td')?.textContent || '';
+              const msg = a.querySelector('.test-message')?.textContent || '';
+              const source = a.querySelector('.test-source')?.textContent || '';
+              failDetail += `  [${msg}] expected=${expected} actual=${actual}\n`;
+              if (source) failDetail += `  source: ${source.trim().substring(0, 200)}\n`;
+            });
+            // Check for runtime errors (died on test)
+            const diedMsg = li.querySelector('.qunit-assert-list .test-message');
+            if (diedMsg && diedMsg.textContent.includes('Died on test')) {
+              failDetail += `  DIED: ${diedMsg.textContent}\n`;
+              const actual = li.querySelector('.qunit-assert-list .test-actual td');
+              if (actual) failDetail += `  Error: ${actual.textContent.substring(0, 300)}\n`;
+            }
+          }
+          output.push({ module, name, status, failDetail: failDetail.trim() });
         });
-        // Check for runtime errors (died on test)
-        const diedMsg = li.querySelector('.qunit-assert-list .test-message');
-        if (diedMsg && diedMsg.textContent.includes('Died on test')) {
-          failDetail += `  DIED: ${diedMsg.textContent}\n`;
-          const actual = li.querySelector('.qunit-assert-list .test-actual td');
-          if (actual) failDetail += `  Error: ${actual.textContent.substring(0, 300)}\n`;
-        }
+
+        const passed = document.querySelectorAll('#qunit-tests > li.pass').length;
+        const failed = document.querySelectorAll('#qunit-tests > li.fail').length;
+        return { tests: output, passed, failed, total: passed + failed };
+      });
+
+      console.log(`\n=== [${suitePage}] QUnit Results: ${results.passed} passed, ${results.failed} failed, ${results.total} total ===\n`);
+
+      const failures = results.tests.filter(t => t.status === 'FAIL');
+      failures.forEach(f => {
+        console.log(`FAIL: [${suitePage}] [${f.module}] ${f.name}`);
+        if (f.failDetail) console.log(f.failDetail);
+        console.log('');
+        allFailures.push({ suitePage, ...f });
+      });
+
+      if (debugLogs.length > 0) {
+        debugLogs.slice(0, 50).forEach(e => allDebugLogs.push(`[${suitePage}] ${e}`));
       }
-      output.push({ module, name, status, failDetail: failDetail.trim() });
-    });
 
-    const passed = document.querySelectorAll('#qunit-tests > li.pass').length;
-    const failed = document.querySelectorAll('#qunit-tests > li.fail').length;
-    return { tests: output, passed, failed, total: passed + failed };
-  });
+      if (errors.length > 0) {
+        errors.slice(0, 20).forEach(e => allErrors.push(`[${suitePage}] ${e}`));
+      }
 
-  console.log(`\n=== QUnit Results: ${results.passed} passed, ${results.failed} failed, ${results.total} total ===\n`);
+      totalPassed += results.passed;
+      totalFailed += results.failed;
 
-  // Show failures
-  const failures = results.tests.filter(t => t.status === 'FAIL');
-  failures.forEach(f => {
-    console.log(`FAIL: [${f.module}] ${f.name}`);
-    if (f.failDetail) console.log(f.failDetail);
-    console.log('');
-  });
+      await page.close();
+    }
 
-  if (debugLogs.length > 0) {
-    console.log(`\n=== Debug Logs (${debugLogs.length}) ===`);
-    debugLogs.slice(0, 50).forEach(e => console.log(e));
+    console.log(`\n=== TOTAL: ${totalPassed} passed, ${totalFailed} failed across ${SUITE_PAGES.length} suite pages ===\n`);
+
+    if (allDebugLogs.length > 0) {
+      console.log(`\n=== Debug Logs (${allDebugLogs.length}) ===`);
+      allDebugLogs.slice(0, 50).forEach(e => console.log(e));
+    }
+
+    if (allErrors.length > 0) {
+      console.log(`\n=== Console Errors (${allErrors.length}) ===`);
+      allErrors.slice(0, 20).forEach(e => console.log(e));
+    }
+
+    process.exitCode = totalFailed > 0 ? 1 : 0;
+  } finally {
+    await browser.close();
   }
-
-  if (errors.length > 0) {
-    console.log(`\n=== Console Errors (${errors.length}) ===`);
-    errors.slice(0, 20).forEach(e => console.log(e));
-  }
-
-  await browser.close();
 })();

--- a/Test/docs/browser-testing.md
+++ b/Test/docs/browser-testing.md
@@ -4,16 +4,26 @@ This document describes how NScript's framework tests run in a browser and how t
 
 ## Overview
 
-Framework tests are written in C# using the `SunlightUnit` test framework, compiled to JavaScript by the NScript compiler pipeline, and executed in a browser via QUnit 2.2.0. The generated JavaScript is served by a static web page (`TestPage.htm`) inside the `TestWebApplication` project.
+Framework tests are written in C# using the `SunlightUnit` test framework, compiled to JavaScript by the NScript compiler pipeline, and executed in a browser via QUnit 2.2.0. Each compiled bundle is served from its **own** static page inside the `TestWebApplication` project — `Sunlight.Framework.TestPage.htm`, `Sunlight.Framework.UI.TestPage.htm`, `DataTestPage.htm`, and `TodoApp.TestPage.htm`. The legacy `TestPage.htm` is now a no-bundle index that links to those pages.
+
+> **Why one bundle per page?** Each NScript-compiled bundle is its own IIFE
+> minified independently and writes runtime metadata (type-check method,
+> is-class flag, FQN, interface map, …) to slots on `Function.prototype`. The
+> minifier picks DIFFERENT short letters per bundle, so co-loading two bundles
+> on one page silently clobbers earlier metadata with the next bundle's
+> letter mapping — producing wrong-looking `TypeError`s such as
+> `b.m is not a function` or `InvalidCast`. See issue #51 for the full
+> reproduction. Until a runtime-metadata fix lands, every test suite has its
+> own page.
 
 ## Architecture
 
 ```
 C# Test Source                NScript Compiler                   Browser
 --------------                ----------------                   -------
-[TestFixture]          dotnet build (Debug)              TestPage.htm loads:
+[TestFixture]          dotnet build (Debug)              *.TestPage.htm loads:
 [Test] methods    -->  Stage 1: Roslyn --> DLL      -->    QUnit 2.2.0
-Assert.Equal()         Stage 2: DLL --> JavaScript         Generated .js files
+Assert.Equal()         Stage 2: DLL --> JavaScript         ONE generated .js file
                        + TestGenerator plugin                    |
                        (emits QUnit.module/test)                 v
                                                           QUnit discovers and
@@ -26,7 +36,7 @@ Assert.Equal()         Stage 2: DLL --> JavaScript         Generated .js files
 2. **JavaScript generation** -- The `AfterCompile` MSBuild target in `Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets` invokes `nscript.exe` to convert the compiled DLL into JavaScript.
 3. **TestGenerator plugin** -- Registered via `PluginConfig.xml` in each test project. Scans the assembly for `[TestFixture]` classes and `[Test]` methods, then emits `QUnit.module()` and `QUnit.test()` registration calls at the end of the generated JS file.
 4. **Output** -- Generated `.js` and `.map` (source map) files land in `Test/Framework/TestWebApplication/GeneratedScripts/`.
-5. **Execution** -- `TestPage.htm` includes QUnit and the generated scripts. Opening it in a browser runs all tests automatically.
+5. **Execution** -- Each `*.TestPage.htm` includes QUnit and exactly one generated script. Open the page for the suite you want; QUnit runs its tests automatically. `TestPage.htm` is an index page listing the four suites — open it first if you don't know which page you want.
 
 ## Key Components
 
@@ -72,7 +82,11 @@ Both projects have:
 ### TestWebApplication (`Test/Framework/TestWebApplication/`)
 
 Static web host containing:
-- `TestPage.htm` -- QUnit test runner HTML page
+- `TestPage.htm` -- index page linking to the four per-suite pages (loads no bundles)
+- `Sunlight.Framework.TestPage.htm` -- core framework suite (one bundle)
+- `Sunlight.Framework.UI.TestPage.htm` -- UI framework suite (one bundle)
+- `DataTestPage.htm` -- data-layer suite (one bundle)
+- `TodoApp.TestPage.htm` -- TodoApp suite (one bundle)
 - `Scripts/QUnit.2.2.0.js` -- QUnit framework
 - `Styles/QUnit.2.2.0.css` -- QUnit styling
 - `GeneratedScripts/` -- Build output directory for compiled JS test files
@@ -111,7 +125,7 @@ python -m http.server 8080
 
 ### Step 3: Open in browser
 
-Navigate to `http://localhost:<port>/TestPage.htm`. QUnit automatically discovers and runs all registered tests. Results appear inline with pass/fail counts and expandable details for each assertion.
+Navigate to `http://localhost:<port>/TestPage.htm` and click through to the per-suite page you want (or jump directly to e.g. `Sunlight.Framework.TestPage.htm`). QUnit automatically discovers and runs all registered tests on the suite-specific page. Results appear inline with pass/fail counts and expandable details for each assertion. Run each suite as a separate page load — never paste multiple `<script>` tags onto one page.
 
 ### Step 4 (Optional): Automated with Playwright
 
@@ -127,11 +141,12 @@ npx playwright install chromium
 Then run a script that:
 1. Starts a local HTTP server
 2. Launches Chromium via Playwright
-3. Navigates to `TestPage.htm`
+3. Iterates each per-suite page (`Sunlight.Framework.TestPage.htm`, `Sunlight.Framework.UI.TestPage.htm`, `DataTestPage.htm`, `TodoApp.TestPage.htm`), opening a fresh page per suite
 4. Waits for `#qunit-banner` to get class `qunit-pass` or `qunit-fail`
-5. Extracts results from `#qunit-tests > li` elements
+5. Extracts results from `#qunit-tests > li` elements and aggregates pass/fail counts
 
-See the example script pattern:
+The repo already ships two such runners — `run-qunit.mjs` (synthesises a one-bundle page per suite) and `run-tests.js` (iterates the static `*.TestPage.htm` files). Use either; do not roll your own that loads multiple bundles on a single page.
+
 ```javascript
 import http from 'node:http';
 import fs from 'node:fs';
@@ -140,12 +155,13 @@ import { chromium } from 'playwright';
 
 // 1. Create static file server on auto-assigned port
 // 2. browser = await chromium.launch({ headless: true });
-// 3. page.goto(`http://localhost:${port}/TestPage.htm`);
-// 4. page.waitForFunction(() => {
-//      const b = document.getElementById('qunit-banner');
-//      return b && (b.className.includes('qunit-pass') || b.className.includes('qunit-fail'));
-//    });
-// 5. Extract results from #qunit-tests > li elements
+// 3. for (const suite of ['Sunlight.Framework.TestPage.htm', ...]) {
+//      const page = await browser.newPage();
+//      await page.goto(`http://localhost:${port}/${suite}`);
+//      // 4. Wait for #qunit-banner.qunit-pass | .qunit-fail
+//      // 5. Extract results from #qunit-tests > li elements
+//      await page.close();
+//    }
 ```
 
 ## Writing New Framework Tests
@@ -195,12 +211,16 @@ In `PluginConfig.xml`:
 </Plugins>
 ```
 
-### 3. Include the generated JS in TestPage.htm
+### 3. Add a per-suite page that loads only your project's JS
 
-Add a `<script>` tag in `TestPage.htm`:
-```html
-<script src="GeneratedScripts/YourProject.js" type="text/javascript"></script>
-```
+Create a new `YourProject.TestPage.htm` next to the existing `*.TestPage.htm` pages, mirroring `Sunlight.Framework.TestPage.htm` (including the comment block that explains why bundles are not co-loaded). Then:
+
+- add a single `<script src="GeneratedScripts/YourProject.js"></script>` line for *only* your project's bundle,
+- add the new page to `TestWebApplication.csproj` under `<ItemGroup>` (`<Content Include="YourProject.TestPage.htm" />`),
+- link it from `TestPage.htm` (the index),
+- add it to the `SUITE_PAGES` array in `run-tests.js` and the `QUNIT_SUITES` array in `run-qunit.mjs`.
+
+Do NOT add a `<script>` tag for your bundle to any existing page — co-loading two bundles on one page corrupts `Function.prototype` runtime metadata (issue #51).
 
 ### 4. Build and run
 
@@ -208,7 +228,8 @@ Add a `<script>` tag in `TestPage.htm`:
 dotnet build NScript_Full.sln -c Debug
 cd Test/Framework/TestWebApplication
 npx serve .
-# Open http://localhost:3000/TestPage.htm
+# Open http://localhost:3000/TestPage.htm and click through to your suite,
+# or jump directly to http://localhost:3000/YourProject.TestPage.htm
 ```
 
 ## Assert API Reference
@@ -239,6 +260,7 @@ npx serve .
 ## Troubleshooting
 
 - **"GeneratedScripts/ is empty"** -- You need to build in Debug mode first: `dotnet build NScript_Full.sln -c Debug`. Framework tests require the Debug compiler.
-- **"Tests don't appear in QUnit"** -- Check that the `<script>` tag for your project's JS file is in `TestPage.htm`.
+- **"Tests don't appear in QUnit"** -- Check that the `<script>` tag for your project's JS file is on the right per-suite `*.TestPage.htm`.
 - **"QUnit shows 0 tests"** -- Verify `PluginConfig.xml` includes `TestGenerator`. Without it, `QUnit.module()`/`QUnit.test()` calls are not emitted.
-- **"CORS errors in browser"** -- You must serve via HTTP, not open `TestPage.htm` directly as a `file://` URL. Use any static HTTP server.
+- **"CORS errors in browser"** -- You must serve via HTTP, not open the page directly as a `file://` URL. Use any static HTTP server.
+- **"`b.m is not a function` / wrong-looking `InvalidCast` errors"** -- Almost always a sign that two bundles got loaded on the same page (issue #51). Check that the page you opened only has ONE `<script>` tag for a `GeneratedScripts/*.js` file.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -16,7 +16,7 @@ The `TestGenerator` plugin ([compiler/plugins.md](../compiler/plugins.md)) bridg
 | Category | Path | Stack | Runner | Target framework |
 |---|---|---|---|---|
 | Compiler | `Test/Compiler/*` | MSTest, .NET | `dotnet test` | `net6.0` |
-| Framework | `Test/Framework/*` | SunlightUnit + QUnit 2.2.0 | Browser via `TestPage.htm` (or Playwright for headless) | `netstandard2.1` (compiled to JS) |
+| Framework | `Test/Framework/*` | SunlightUnit + QUnit 2.2.0 | Browser via per-suite `*.TestPage.htm` pages, indexed from `TestPage.htm` (or Playwright for headless) | `netstandard2.1` (compiled to JS) |
 
 ## Reference — compiler test projects
 
@@ -42,8 +42,8 @@ flowchart LR
     B --> C["TestGenerator plugin<br/>scans for attributes"]
     C --> D["Emits QUnit.module() /<br/>QUnit.test() registrations"]
     D --> E["GeneratedScripts/*.js<br/>in TestWebApplication"]
-    E --> F["Browser opens<br/>TestPage.htm"]
-    F --> G["QUnit runs all tests"]
+    E --> F["Browser opens one<br/>*.TestPage.htm per suite"]
+    F --> G["QUnit runs the<br/>suite's tests"]
 ```
 
 ## Reference — `SunlightUnit.Assert` → QUnit mapping
@@ -85,8 +85,16 @@ cd Test/Framework/TestWebApplication
 npx serve .
 
 # 3. Open http://localhost:3000/TestPage.htm in any browser.
+#    TestPage.htm is now an index — pick one of the per-suite pages
+#    (Sunlight.Framework.TestPage.htm, Sunlight.Framework.UI.TestPage.htm,
+#    DataTestPage.htm, TodoApp.TestPage.htm). Each loads exactly one bundle.
 # QUnit runs automatically; status banner shows pass/fail.
 ```
+
+> **Why per-suite pages?** Each NScript-compiled bundle is its own IIFE
+> minified independently and writes runtime metadata to short letters on
+> `Function.prototype`. Co-loading two bundles silently corrupts that
+> metadata (issue #51). Always open ONE `*.TestPage.htm` per browser tab.
 
 ## Examples
 
@@ -134,7 +142,7 @@ And `PluginConfig.xml` registers the `TestGenerator`:
 </Plugins>
 ```
 
-Then add `<script src="GeneratedScripts/MyApp.Tests.js"></script>` to `TestPage.htm` and rebuild.
+Then add a new per-suite page `MyApp.Tests.TestPage.htm` (mirror `Sunlight.Framework.TestPage.htm` and load only `<script src="GeneratedScripts/MyApp.Tests.js"></script>`), register it in `TestWebApplication.csproj`, link it from the `TestPage.htm` index, add it to `SUITE_PAGES` in `run-tests.js` and `QUNIT_SUITES` in `run-qunit.mjs`, and rebuild. Do not paste a `<script>` tag into an existing per-suite page — co-loading bundles corrupts `Function.prototype` runtime metadata (issue #51).
 
 ### Writing a compiler test (snapshot regression)
 
@@ -155,7 +163,7 @@ The convention is one test per *snapshot pair*: `Inputs/GenericMethodWithConstra
 
 ### Headless framework test execution (CI)
 
-For CI runs you need Playwright to launch a real browser, navigate to `TestPage.htm`, and wait for QUnit's banner:
+For CI runs you need Playwright to launch a real browser, iterate the per-suite pages, and wait for QUnit's banner on each:
 
 ```javascript
 // Pseudocode — see Test/docs/browser-testing.md for full pattern
@@ -207,7 +215,8 @@ If a test uses `yield return`, `dynamic`, or other [unsupported features](../lan
 | QUnit reports `0 assertions, 0 tests run` | `TestGenerator` plugin not registered in `PluginConfig.xml`; or test method isn't `public static` |
 | Framework test passes locally, fails in CI | Browser version mismatch, or stale `GeneratedScripts/` checked in — rebuild before run |
 | Compiler test snapshot mismatch | Either a real regression or intentional output change — diff and update snapshot deliberately |
-| `TestPage.htm` 404s on a script | Generated file missing from `GeneratedScripts/` — check that the test project's `<JsOutputPath>` points there and `GenerateJs=True` |
+| `*.TestPage.htm` 404s on a script | Generated file missing from `GeneratedScripts/` — check that the test project's `<JsOutputPath>` points there and `GenerateJs=True` |
+| Wrong-looking `b.m is not a function` / `InvalidCast` in QUnit | Multiple bundles co-loaded on one page — issue #51. Open ONE `*.TestPage.htm` per tab; never combine `<script>` tags. |
 
 ## Cross-links
 


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Closes #51

Each NScript-compiled bundle is its own IIFE minified independently and writes runtime metadata (type-check, is-class flag, FQN, interface map, …) to short letters on `Function.prototype`. Co-loading two bundles on one page silently clobbers earlier metadata with the next bundle's letter mapping, producing `b.m is not a function` / `InvalidCast` errors in random downstream tests (issue #51).

`DataTestPage.htm` already isolates one bundle per page for exactly this reason. This PR extends the same pattern to the remaining three suites:

- Add `Sunlight.Framework.TestPage.htm` — loads only `Sunlight.Framework.Test.js`
- Add `Sunlight.Framework.UI.TestPage.htm` — loads only `Sunlight.Framework.UI.Test.js`
- Add `TodoApp.TestPage.htm` — loads only `TodoApp.Test.js`
- Convert `TestPage.htm` into a no-bundle **index page** linking to the four suites
- Update `run-tests.js` to iterate the four per-suite pages and aggregate pass/fail counts
- Register the new pages as `<Content Include>` in `TestWebApplication.csproj`
- Reword `Test/CLAUDE.md`, `Test/docs/browser-testing.md`, `docs/testing/README.md` to point at the per-suite pages and explain why bundles are not co-loaded

`run-qunit.mjs` already isolates one bundle per page (it synthesises a one-bundle page per suite via `/__qunit?name=`) and is unchanged. The pre-commit e2e flow (`TodoApp.htm` + `e2e-todo-tests.js`) is unaffected.

## Scope (and what this is NOT)

This is the **avoidance** fix from the plan approved on issue #51. It does **not** fix the root cause (per-IIFE letter collision on `Function.prototype`). The four candidate root-cause fixes listed in the issue (stable non-minified property names, `Symbol`-based keys, single shared bootstrap, or coordinating the minifier across bundles) all change the runtime ABI for `Function.prototype` slot access and are materially larger. **Recommendation:** open a follow-up issue tracking the root-cause fix (Option 2 from the bug report — stable `__nscript_*__` property names — is still the smallest viable patch). The avoidance fix here doesn't preclude the root-cause fix later.

## Test plan

- [ ] CI Phase 3 (`run-qunit.mjs`) passes on all four suites — this is the primary regression guard.
- [ ] CI Phase 3 (`e2e-todo-tests.js`) still passes — `TodoApp.htm` and the e2e bundle layout are untouched.
- [ ] `node run-tests.js` (after change) iterates the four per-suite pages and reports aggregate counts.
- [ ] Manual smoke (local): open each new `*.TestPage.htm`; QUnit banner reaches `qunit-pass`. Open the new index `TestPage.htm`; verify it loads no bundles and the four links resolve.
- [ ] Negative regression: confirm that on master before this change, opening the OLD multi-bundle `TestPage.htm` reproduces the 8 failures cited in the issue (`DataBinderTests.BasicBinderSimpleObjectTest`, etc.); then confirm those failures disappear on each per-suite page after the change.
