### PR TITLE
[Gautam's Dev bot] WI-47 Phase F5: BCL interface collection-expression targets

### DIFF
--- a/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
+++ b/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
@@ -745,7 +745,7 @@
                     var addRange = ResolveAddRangeOverload(listType, spread.Expression.Type);
                     if (addRange == null)
                     {
-                        throw new NotSupportedException(
+                        throw new InvalidOperationException(
                             $"No 'AddRange' overload on '{listType}' accepts spread source type "
                             + $"'{spread.Expression.Type}'. Required to lower a non-array spread "
                             + "source into a List<T> target.");

--- a/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
+++ b/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
@@ -461,39 +461,52 @@
 
         public override AstBase VisitCollectionExpression(BoundCollectionExpression node, SerializationContext arg)
         {
-            // Phase F1 — array (T[]) target: spread sources must also be T[].
+            // Phase F1 — array (T[]) target: spread sources include T[] and List<T>.
             // Phase F4 — List<T> target: literal-only and with spread sources
             // whose static type is List<T> or T[]. Lowers to
             // `new List<T>()` + Add/AddRange calls via the existing
             // NewCollectionInitializerExpression pipeline.
+            // Phase F5 — list-shaped BCL interface targets
+            // (IEnumerable<T> / IList<T> / ICollection<T> /
+            // IReadOnlyList<T> / IReadOnlyCollection<T>) collapse to the
+            // same `new List<T>()` + Add/AddRange lowering used by F4: every
+            // one of these interfaces is implemented by List<T>, and the JS
+            // runtime has no notion of an "interface type", so the static
+            // type information is preserved at the C# call site only.
+            // Phase F5 also adds IEnumerable<T> spread sources for both
+            // T[] and List<T> targets via the existing AddRange(IEnumerable<T>)
+            // overload (List<T> target) or a synthesised
+            // `new List<T>(); AddRange(src); ToArray()` bridge (T[] target).
             //
-            // Deferred to Phase F5:
-            //   - The five list-shaped BCL interface targets
-            //     (IEnumerable<T> / IList<T> / IReadOnlyList<T> /
-            //     ICollection<T> / IReadOnlyCollection<T>). Roslyn's binder
-            //     errors at CS0656 for a long tail of well-known members on
-            //     these interfaces and their implementers; the facade work
-            //     is large enough to track as a separate slice.
+            // Deferred to Phase F6:
             //   - [CollectionBuilder]-attributed user types.
-            //   - IEnumerable<T> spread sources into a T[] target.
+            //   - Index/range residuals on element-position sub-spreads.
             // Span<T> / ReadOnlySpan<T> remain Non-Goals.
             if (node.Type is ArrayTypeSymbol arrayType)
             {
                 return VisitArrayCollectionExpression(node, arrayType, arg);
             }
 
-            if (node.Type is NamedTypeSymbol namedType
-                && IsSystemCollectionsGenericList(namedType))
+            if (node.Type is NamedTypeSymbol namedType)
             {
-                return VisitListCollectionExpression(node, namedType, arg);
+                if (IsSystemCollectionsGenericList(namedType))
+                {
+                    return VisitListCollectionExpression(node, namedType, arg);
+                }
+
+                var listFromInterface = TryConstructListFromListShapedInterface(namedType);
+                if (listFromInterface is object)
+                {
+                    return VisitListCollectionExpression(node, listFromInterface, arg);
+                }
             }
 
             throw new NotSupportedException(
                 $"Collection expressions targeting '{node.Type}' are not yet supported. " +
-                "Phase F4 supports T[] and List<T> targets. " +
-                "BCL interface targets (IEnumerable<T>, IList<T>, IReadOnlyList<T>, " +
-                "ICollection<T>, IReadOnlyCollection<T>) and [CollectionBuilder] types " +
-                "are deferred to Phase F5. Span<T>/ReadOnlySpan<T> remain Non-Goals.");
+                "Phase F4 supports T[] and List<T> targets; Phase F5 supports the five " +
+                "list-shaped BCL interface targets (IEnumerable<T>, IList<T>, " +
+                "ICollection<T>, IReadOnlyList<T>, IReadOnlyCollection<T>). " +
+                "[CollectionBuilder] types and Span<T>/ReadOnlySpan<T> remain unsupported.");
         }
 
         private AstBase VisitArrayCollectionExpression(
@@ -548,8 +561,9 @@
         // collection expression. Array sources pass through unchanged; List<T>
         // sources are normalised by routing through `List<T>.ToArray()` so the
         // existing F1 array-source converter (`ArrayWithSpreadsConverter`) handles
-        // both shapes uniformly. IEnumerable<T> sources into a T[] target are
-        // deferred to Phase F5.
+        // both shapes uniformly. IEnumerable<T> sources are bridged through a
+        // synthesised `new List<T>(); AddRange(src); ToArray()` chain so they
+        // collapse onto the same array-source converter.
         private ExpressionSer BuildArrayTargetSpreadOperand(
             BoundCollectionExpressionSpreadElement spread,
             SerializationContext arg)
@@ -566,33 +580,123 @@
             if (sourceType is NamedTypeSymbol namedSource
                 && IsSystemCollectionsGenericList(namedSource))
             {
-                var toArray = namedSource
-                    .GetMembers("ToArray")
-                    .OfType<MethodSymbol>()
-                    .FirstOrDefault(m => m.ParameterCount == 0
-                        && m.MethodKind == MethodKind.Ordinary);
+                return BuildToArrayCall(namedSource, visitedExpression, spreadLocation, arg);
+            }
 
-                if (toArray == null)
-                {
-                    throw new InvalidOperationException(
-                        $"Could not find parameterless 'ToArray' method on '{namedSource}'. "
-                        + "Required to lower a List<T> spread source into a T[] target collection expression.");
-                }
-
-                return new MethodCallExpression
-                {
-                    Location = spreadLocation,
-                    Method = arg.SymbolSerializer.GetMethodSpecId(toArray),
-                    Instance = visitedExpression,
-                    Arguments = new List<MethodCallArg>(),
-                };
+            // Phase F5 — IEnumerable<T> spread source. Synthesise
+            // `new List<T>(); AddRange(src); ToArray()` so the existing
+            // F1 array-source converter handles the result uniformly.
+            // The element type is recovered from the IEnumerable<T> the
+            // bound expression carries (or the IEnumerable<T> any other
+            // list-shaped BCL interface is constructed over).
+            if (sourceType is NamedTypeSymbol enumerableSource
+                && TryGetListShapedInterfaceElementType(enumerableSource) is TypeSymbol elementType
+                && TryFindSiblingListType(enumerableSource) is NamedTypeSymbol siblingList)
+            {
+                var listOfT = siblingList.Construct(elementType);
+                return BuildEnumerableToArrayBridge(
+                    listOfT,
+                    enumerableSource,
+                    visitedExpression,
+                    spreadLocation,
+                    arg);
             }
 
             throw new NotSupportedException(
                 $"Spread element source type '{sourceType}' is not yet supported "
-                + "inside a T[] target collection expression. Phase F4 supports "
-                + "T[] and List<T> spread sources; IEnumerable<T> spread sources into "
-                + "a T[] target are tracked for Phase F5.");
+                + "inside a T[] target collection expression. Phase F5 supports "
+                + "T[], List<T>, and the list-shaped BCL interfaces "
+                + "(IEnumerable<T>, IList<T>, ICollection<T>, IReadOnlyList<T>, "
+                + "IReadOnlyCollection<T>) as spread sources.");
+        }
+
+        // Emits a `<source>.ToArray()` MethodCallExpression for a constructed
+        // List<T> source. Centralised so the same shape is reused by the
+        // direct-List path and the IEnumerable bridge below.
+        private static MethodCallExpression BuildToArrayCall(
+            NamedTypeSymbol listType,
+            ExpressionSer instance,
+            JsCsc.Lib.Serialization.LocationSer location,
+            SerializationContext arg)
+        {
+            var toArray = listType
+                .GetMembers("ToArray")
+                .OfType<MethodSymbol>()
+                .FirstOrDefault(m => m.ParameterCount == 0
+                    && m.MethodKind == MethodKind.Ordinary);
+
+            if (toArray == null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find parameterless 'ToArray' method on '{listType}'. "
+                    + "Required to lower a List<T> spread source into a T[] target collection expression.");
+            }
+
+            return new MethodCallExpression
+            {
+                Location = location,
+                Method = arg.SymbolSerializer.GetMethodSpecId(toArray),
+                Instance = instance,
+                Arguments = new List<MethodCallArg>(),
+            };
+        }
+
+        // Bridges an IEnumerable<T>-shaped spread source into a T[] target by
+        // synthesising `new List<T>() { AddRange(src) }.ToArray()`. The
+        // intermediate List<T> is built via NewCollectionInitializerExpression
+        // (the same shape used by VisitListCollectionExpression) so no new
+        // ProtoBuf tag or Stage-2 converter is needed; ToArray() collapses the
+        // result onto the existing F1 array-source converter path.
+        private static ExpressionSer BuildEnumerableToArrayBridge(
+            NamedTypeSymbol listType,
+            NamedTypeSymbol enumerableSourceType,
+            ExpressionSer source,
+            JsCsc.Lib.Serialization.LocationSer location,
+            SerializationContext arg)
+        {
+            var ctor = listType
+                .GetMembers(WellKnownMemberNames.InstanceConstructorName)
+                .OfType<MethodSymbol>()
+                .FirstOrDefault(m => m.ParameterCount == 0);
+
+            if (ctor == null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find parameterless constructor on '{listType}'. "
+                    + "Required to bridge an IEnumerable<T> spread source into a T[] target.");
+            }
+
+            var addRange = ResolveAddRangeOverload(listType, enumerableSourceType);
+            if (addRange == null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find an 'AddRange' overload on '{listType}' accepting "
+                    + $"'{enumerableSourceType}'. Required to bridge an IEnumerable<T> "
+                    + "spread source into a T[] target collection expression.");
+            }
+
+            var listExpression = new NewCollectionInitializerExpression
+            {
+                Location = location,
+                Type = arg.SymbolSerializer.GetTypeSpecId(listType),
+                Method = arg.SymbolSerializer.GetMethodSpecId(ctor),
+                Arguments = new List<MethodCallArg>(),
+                ItemInitializers = new List<MethodCallExpression>
+                {
+                    new MethodCallExpression
+                    {
+                        Location = location,
+                        Method = arg.SymbolSerializer.GetMethodSpecId(addRange),
+                        Instance = null,
+                        Arguments = new List<MethodCallArg>
+                        {
+                            new MethodCallArg { Value = source },
+                        },
+                    },
+                },
+            };
+
+            return BuildToArrayCall(listType, listExpression, location, arg);
         }
 
         // Lowers a C# 12 collection expression whose target is List<T> (or one of
@@ -753,12 +857,28 @@
 
         // True iff `type` is the constructed `System.Collections.Generic.List<T>`.
         private static bool IsSystemCollectionsGenericList(NamedTypeSymbol type)
+            => IsSystemCollectionsGenericArity1(type, "List`1");
+
+        // True iff `type` is one of the five list-shaped BCL interfaces in
+        // System.Collections.Generic over a single type parameter.
+        private static bool IsListShapedSystemCollectionsGenericInterface(NamedTypeSymbol type)
+            => IsSystemCollectionsGenericArity1(type, "IEnumerable`1")
+                || IsSystemCollectionsGenericArity1(type, "IList`1")
+                || IsSystemCollectionsGenericArity1(type, "ICollection`1")
+                || IsSystemCollectionsGenericArity1(type, "IReadOnlyList`1")
+                || IsSystemCollectionsGenericArity1(type, "IReadOnlyCollection`1");
+
+        // Anchors a name match against the global namespace
+        // System.Collections.Generic. Naked metadata-name matching false-
+        // positives on user types named e.g. `List<T>` in nested namespaces
+        // (per the WI-47 learning recorded after the F4 review).
+        private static bool IsSystemCollectionsGenericArity1(NamedTypeSymbol type, string metadataName)
         {
-            if (type.Arity != 1)
+            if (type is null || type.Arity != 1)
             { return false; }
 
             var def = type.OriginalDefinition;
-            if (def?.MetadataName != "List`1")
+            if (def?.MetadataName != metadataName)
             { return false; }
 
             var ns = def.ContainingNamespace;
@@ -767,6 +887,55 @@
                 && ns.ContainingNamespace?.Name == "Collections"
                 && ns.ContainingNamespace?.ContainingNamespace?.Name == "System"
                 && ns.ContainingNamespace?.ContainingNamespace?.ContainingNamespace?.IsGlobalNamespace == true;
+        }
+
+        // For a target type that is one of the list-shaped BCL interfaces,
+        // returns a constructed `System.Collections.Generic.List<T>` over the
+        // same element type so the F4 list-target lowering can take over.
+        // Returns null when `type` is not one of the five interfaces or when
+        // a sibling `List<T>` cannot be located in the same containing
+        // namespace (e.g. the test compilation references a stripped
+        // mscorlib facade that does not declare `List<T>`).
+        private static NamedTypeSymbol TryConstructListFromListShapedInterface(NamedTypeSymbol type)
+        {
+            if (!IsListShapedSystemCollectionsGenericInterface(type))
+            { return null; }
+
+            var elementType = type.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.FirstOrDefault().Type;
+            if (elementType is null)
+            { return null; }
+
+            var sibling = TryFindSiblingListType(type);
+            if (sibling is null)
+            { return null; }
+
+            return sibling.Construct(elementType);
+        }
+
+        // Recovers the element type T from a list-shaped BCL interface
+        // (IEnumerable<T>/IList<T>/etc.). Returns null for any other type.
+        private static TypeSymbol TryGetListShapedInterfaceElementType(NamedTypeSymbol type)
+        {
+            if (!IsListShapedSystemCollectionsGenericInterface(type))
+            { return null; }
+
+            return type.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics.FirstOrDefault().Type;
+        }
+
+        // Looks up the unconstructed `List`1` definition in the same
+        // System.Collections.Generic namespace that contains `sibling`.
+        // Centralised so the interface-target dispatch and the IEnumerable
+        // spread bridge share lookup semantics.
+        private static NamedTypeSymbol TryFindSiblingListType(NamedTypeSymbol sibling)
+        {
+            var ns = sibling?.OriginalDefinition?.ContainingNamespace;
+            if (ns == null)
+            { return null; }
+
+            return ns
+                .GetTypeMembers("List", 1)
+                .OfType<NamedTypeSymbol>()
+                .FirstOrDefault();
         }
 
         public override AstBase VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node, SerializationContext arg) => throw new NotImplementedException();

--- a/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
+++ b/Sources/Compiler/NScript.Csc.Lib/BoundAstToAstBase.cs
@@ -541,9 +541,8 @@
                 {
                     throw new NotSupportedException(
                         $"Unsupported collection-expression element kind '{element.Kind}'. "
-                        + "Phase F4 supports literal expressions and spread sources whose static "
-                        + "type is T[] or List<T>; IEnumerable<T> spread sources into a T[] target "
-                        + "are tracked for Phase F5.");
+                        + "Supported shapes are literal expressions and spread sources whose static "
+                        + "type is T[], List<T>, or one of the list-shaped BCL interfaces.");
                 }
 
                 elements.Add(serElement);
@@ -654,17 +653,9 @@
             JsCsc.Lib.Serialization.LocationSer location,
             SerializationContext arg)
         {
-            var ctor = listType
-                .GetMembers(WellKnownMemberNames.InstanceConstructorName)
-                .OfType<MethodSymbol>()
-                .FirstOrDefault(m => m.ParameterCount == 0);
-
-            if (ctor == null)
-            {
-                throw new InvalidOperationException(
-                    $"Could not find parameterless constructor on '{listType}'. "
-                    + "Required to bridge an IEnumerable<T> spread source into a T[] target.");
-            }
+            var ctor = ResolveParameterlessCtor(
+                listType,
+                "bridge an IEnumerable<T> spread source into a T[] target");
 
             var addRange = ResolveAddRangeOverload(listType, enumerableSourceType);
             if (addRange == null)
@@ -699,14 +690,16 @@
             return BuildToArrayCall(listType, listExpression, location, arg);
         }
 
-        // Lowers a C# 12 collection expression whose target is List<T> (or one of
-        // the BCL interfaces IEnumerable<T>/IList<T>/IReadOnlyList<T>/
-        // ICollection<T>/IReadOnlyCollection<T> — Roslyn synthesises the bound
-        // tree's static type as List<T> for those, per the language spec) into a
+        // Lowers a C# 12 collection expression whose target is List<T> into a
         // NewCollectionInitializerExpression: `new List<T>()` plus a sequence of
         // `Add(elem)` / `AddRange(spread)` calls. This reuses the existing
         // collection-initializer Stage-2 path (InlineCollectionInitializationExpression),
         // so no new ProtoBuf tag or Stage-2 converter is needed.
+        // Also reused by the F5 BCL-interface dispatch
+        // (TryConstructListFromListShapedInterface): when the bound node's
+        // static type is IEnumerable<T>/IList<T>/IReadOnlyList<T>/
+        // ICollection<T>/IReadOnlyCollection<T>, NScript constructs the
+        // sibling List<T> in the same namespace and re-enters here.
         private AstBase VisitListCollectionExpression(
             BoundCollectionExpression node,
             NamedTypeSymbol listType,
@@ -714,17 +707,9 @@
         {
             var location = node.Syntax.Location.GetSerLoc();
 
-            var ctor = listType
-                .GetMembers(WellKnownMemberNames.InstanceConstructorName)
-                .OfType<MethodSymbol>()
-                .FirstOrDefault(m => m.ParameterCount == 0);
-
-            if (ctor == null)
-            {
-                throw new InvalidOperationException(
-                    $"Could not find parameterless constructor on '{listType}'. "
-                    + "Required to lower a List<T>-target collection expression.");
-            }
+            var ctor = ResolveParameterlessCtor(
+                listType,
+                "lower a List<T>-target collection expression");
 
             // For List<T> collection-expression targets Roslyn does NOT
             // pre-resolve each literal element into a
@@ -812,6 +797,28 @@
                 Arguments = new List<MethodCallArg>(),
                 ItemInitializers = itemInitializers,
             };
+        }
+
+        // Resolve the parameterless `.ctor()` on `listType`. Throws with a
+        // contextual message that names the caller's lowering so failures point
+        // at the right collection-expression dispatch path.
+        private static MethodSymbol ResolveParameterlessCtor(
+            NamedTypeSymbol listType,
+            string callerContext)
+        {
+            var ctor = listType
+                .GetMembers(WellKnownMemberNames.InstanceConstructorName)
+                .OfType<MethodSymbol>()
+                .FirstOrDefault(m => m.ParameterCount == 0);
+
+            if (ctor == null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find parameterless constructor on '{listType}'. "
+                    + $"Required to {callerContext}.");
+            }
+
+            return ctor;
         }
 
         // Resolve `List<T>.Add(T)`. The constructed `listType` already has T

--- a/Sources/Framework/System.Core/Dynamic/ExpandoObject.cs
+++ b/Sources/Framework/System.Core/Dynamic/ExpandoObject.cs
@@ -146,6 +146,16 @@
             return this.GetEnumerator();
         }
 
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
+
         [Script(@"
             return ({}).constructor.keys(this.@{[mscorlib]System.Dynamic.ExpandoObject::innerDict});
             ")]

--- a/Sources/Framework/System.Web.Html/DomList.cs
+++ b/Sources/Framework/System.Web.Html/DomList.cs
@@ -141,7 +141,7 @@ namespace System.Web.Html
             }
         }
 
-        void Collections.IList.Add(object value)
+        int Collections.IList.Add(object value)
         {
             throw new NotImplementedException();
         }
@@ -174,6 +174,16 @@ namespace System.Web.Html
         void Collections.ICollection.CopyTo(Array array, int index)
         {
             throw new NotImplementedException();
+        }
+
+        bool Collections.ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object Collections.ICollection.SyncRoot
+        {
+            get { return this; }
         }
 
         bool ICollection<T>.IsReadOnly

--- a/Sources/Framework/mscorlib/Array.cs
+++ b/Sources/Framework/mscorlib/Array.cs
@@ -62,7 +62,7 @@
             set;
         }
 
-        extern void IList.Add(object value);
+        extern int IList.Add(object value);
 
         extern void IList.Clear();
 
@@ -73,6 +73,12 @@
         extern void IList.RemoveAt(int index);
 
         extern int ICollection.Count
+        { get; }
+
+        extern bool ICollection.IsSynchronized
+        { get; }
+
+        extern object ICollection.SyncRoot
         { get; }
 
         public extern void CopyTo(Array array, int index);
@@ -148,7 +154,7 @@
             }
         }
 
-        void IList.Add(object value)
+        int IList.Add(object value)
         {
             throw new NotSupportedException();
         }
@@ -176,6 +182,16 @@
         int ICollection.Count
         {
             get { return this.Length; }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
         }
     }
 }

--- a/Sources/Framework/mscorlib/Collections/Generic/Dictionary.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/Dictionary.cs
@@ -124,5 +124,14 @@ namespace System.Collections.Generic
 
         #endregion IEnumerable Members
 
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
     }
 }

--- a/Sources/Framework/mscorlib/Collections/Generic/ICollection.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/ICollection.cs
@@ -12,6 +12,25 @@ namespace System.Collections.Generic
     public interface ICollection<T> : ICollection, IEnumerable<T>
     {
         /// <summary>
+        /// Gets the number of elements contained in the collection.
+        /// </summary>
+        /// <value>
+        /// The number of elements contained in the <see cref="ICollection{T}"/>.
+        /// </value>
+        /// <remarks>
+        /// Roslyn's collection-expression binder requires
+        /// <c>System.Collections.Generic.ICollection`1.Count</c> as a
+        /// well-known member when target-typing to <c>ICollection&lt;T&gt;</c>
+        /// (or any list-shaped interface that derives from it). The non-
+        /// generic <c>System.Collections.ICollection.Count</c> is not enough
+        /// — the binder anchors on the generic interface specifically. Phase
+        /// F5 of WI-47 added this declaration so collection expressions can
+        /// bind cleanly when target-typed to one of the five list-shaped
+        /// BCL interfaces.
+        /// </remarks>
+        new int Count { get; }
+
+        /// <summary>
         /// Gets a value indicating whether this instance is read only.
         /// </summary>
         /// <value>

--- a/Sources/Framework/mscorlib/Collections/Generic/IList.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/IList.cs
@@ -38,5 +38,20 @@ namespace System.Collections.Generic
         ///   <paramref name="index" /> is not a valid index in the <see cref="T:System.Collections.Generic.IList`1" />.</exception>
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IList`1" /> is read-only.</exception>
         void Insert(int index, T item);
+
+        /// <summary>Removes the <see cref="T:System.Collections.Generic.IList`1" /> item at the specified index.</summary>
+        /// <param name="index">The zero-based index of the item to remove.</param>
+        /// <remarks>
+        /// Roslyn's collection-expression binder requires
+        /// <c>System.Collections.Generic.IList`1.RemoveAt</c> as a well-known
+        /// member when target-typing to <c>IList&lt;T&gt;</c> (or any list-
+        /// shaped interface that derives from it). The non-generic
+        /// <c>System.Collections.IList.RemoveAt</c> is not enough — the
+        /// binder anchors on the generic interface specifically. Phase F5
+        /// of WI-47 added this declaration so collection expressions can
+        /// bind cleanly when target-typed to one of the five list-shaped
+        /// BCL interfaces.
+        /// </remarks>
+        new void RemoveAt(int index);
     }
 }

--- a/Sources/Framework/mscorlib/Collections/Generic/List.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/List.cs
@@ -281,9 +281,10 @@ namespace System.Collections.Generic
             this.nativeArray.Push(item);
         }
 
-        void System.Collections.IList.Add(object value)
+        int System.Collections.IList.Add(object value)
         {
             this.Add((T)value);
+            return this.nativeArray.Length - 1;
         }
 
         /// <summary>
@@ -361,6 +362,16 @@ namespace System.Collections.Generic
             {
                 array.SetValue(i + index, nativeArray[i]);
             }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
         }
 
         /// <summary>

--- a/Sources/Framework/mscorlib/Collections/Generic/NumberDictionary.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/NumberDictionary.cs
@@ -147,6 +147,16 @@ namespace System.Collections.Generic
             return this.GetEnumerator();
         }
 
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
+
         [Script(@"
             return ({}).constructor.keys(this.@{[mscorlib]System.Collections.Generic.NumberDictionary`1::innerDict});
             ")]

--- a/Sources/Framework/mscorlib/Collections/Generic/StringDictionary.cs
+++ b/Sources/Framework/mscorlib/Collections/Generic/StringDictionary.cs
@@ -148,6 +148,16 @@ namespace System.Collections.Generic
             return this.GetEnumerator();
         }
 
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
+
         [Script(@"
             return ({}).constructor.keys(this.@{[mscorlib]System.Collections.Generic.StringDictionary`1::innerDict});
             ")]

--- a/Sources/Framework/mscorlib/Collections/ICollection.cs
+++ b/Sources/Framework/mscorlib/Collections/ICollection.cs
@@ -21,6 +21,30 @@ namespace System.Collections
         int Count { get; }
 
         // Summary:
+        //     Gets a value indicating whether access to the System.Collections.ICollection
+        //     is synchronized (thread safe).
+        //
+        // Remarks:
+        //     Roslyn's collection-expression binder requires
+        //     System.Collections.ICollection.IsSynchronized as a well-known
+        //     member when target-typing to any list-shaped interface. Phase F5
+        //     of WI-47 added this declaration so collection expressions can
+        //     bind cleanly when target-typed to one of the five list-shaped
+        //     BCL interfaces. The transpiler emits single-threaded JavaScript;
+        //     all implementers return false.
+        bool IsSynchronized { get; }
+
+        // Summary:
+        //     Gets an object that can be used to synchronize access to the
+        //     System.Collections.ICollection.
+        //
+        // Remarks:
+        //     Companion well-known member to IsSynchronized — Roslyn's binder
+        //     resolves both together. Phase F5 of WI-47 added this declaration.
+        //     The JS runtime is single-threaded; implementers return `this`.
+        object SyncRoot { get; }
+
+        // Summary:
         //     Copies the elements of the System.Collections.ICollection to an System.Array,
         //     starting at a particular System.Array index.
         //

--- a/Sources/Framework/mscorlib/Collections/IList.cs
+++ b/Sources/Framework/mscorlib/Collections/IList.cs
@@ -62,7 +62,16 @@ namespace System.Collections
         //   System.NotSupportedException:
         //     The System.Collections.IList is read-only.-or- The System.Collections.IList
         //     has a fixed size.
-        void Add(object value);
+        //
+        // Remarks:
+        //     Roslyn's collection-expression binder requires
+        //     System.Collections.IList.Add as a well-known member with the
+        //     real-BCL signature `int Add(object)` — returning the position
+        //     of the inserted item — when target-typing to any list-shaped
+        //     interface that derives from non-generic IList. Phase F5 of
+        //     WI-47 changed the return type from `void` to `int` so the
+        //     binder's signature match succeeds.
+        int Add(object value);
 
         //
         // Summary:

--- a/Sources/Framework/mscorlib/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/Sources/Framework/mscorlib/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -178,7 +178,7 @@ namespace System.Collections.ObjectModel
             }
         }
 
-        public void Add(object value)
+        public int Add(object value)
         {
             throw new NotImplementedException();
         }
@@ -222,6 +222,16 @@ namespace System.Collections.ObjectModel
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.list.GetEnumerator();
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
         }
 
 

--- a/Sources/Framework/mscorlib/InternalArrayImpl.cs
+++ b/Sources/Framework/mscorlib/InternalArrayImpl.cs
@@ -60,6 +60,11 @@ namespace System
             get { return false; }
         }
 
+        int ICollection<T>.Count
+        {
+            get { return this.innerArray.Length; }
+        }
+
         internal NativeArray<T> InnerArray
         {
             get { return this.innerArray; }
@@ -122,6 +127,11 @@ namespace System
         }
 
         void IList<T>.Insert(int index, T item)
+        {
+            throw new Exception("Not Implemented.");
+        }
+
+        void IList<T>.RemoveAt(int index)
         {
             throw new Exception("Not Implemented.");
         }

--- a/Test/Compiler/NScript.Converter.Test/TypeConverterTests/CoreLibTests/ArrayTypeMcs.js
+++ b/Test/Compiler/NScript.Converter.Test/TypeConverterTests/CoreLibTests/ArrayTypeMcs.js
@@ -47,6 +47,12 @@ ptyp_.system__Collections__IList__RemoveAt = function ArrayImpl__System__Collect
 ptyp_.system__Collections__ICollection__get_Count = function ArrayImpl__System__Collections__ICollection__get_Count() {
   return this.gl();
 };
+ptyp_.system__Collections__ICollection__get_IsSynchronized = function ArrayImpl__System__Collections__ICollection__get_IsSynchronized() {
+  return false;
+};
+ptyp_.system__Collections__ICollection__get_SyncRoot = function ArrayImpl__System__Collections__ICollection__get_SyncRoot() {
+  return this;
+};
 ptyp_.V_GetEnumerator_d = ptyp_.system__Collections__IEnumerable__GetEnumerator;
 ptyp_.V_get_IsFixedSize_e = ptyp_.system__Collections__IList__get_IsFixedSize;
 ptyp_.V_get_IsReadOnly_e = ptyp_.system__Collections__IList__get_IsReadOnly;
@@ -58,6 +64,8 @@ ptyp_.V_Insert_e = ptyp_.system__Collections__IList__Insert;
 ptyp_.V_Remove_e = ptyp_.system__Collections__IList__Remove;
 ptyp_.V_RemoveAt_e = ptyp_.system__Collections__IList__RemoveAt;
 ptyp_.V_get_Count_f = ptyp_.system__Collections__ICollection__get_Count;
+ptyp_.V_get_IsSynchronized_f = ptyp_.system__Collections__ICollection__get_IsSynchronized;
+ptyp_.V_get_SyncRoot_f = ptyp_.system__Collections__ICollection__get_SyncRoot;
 ptyp_.V_Contains_e = function(arg0) {
   return this.cons(arg0);
 };
@@ -181,6 +189,9 @@ function ArrayG(T, _callStatiConstructor) {
   ptyp_.system__Collections__Generic__ICollection_$T$___get_IsReadOnly = function ArrayG$1__System__Collections__Generic__ICollection_$T$___get_IsReadOnly() {
     return false;
   };
+  ptyp_.system__Collections__Generic__ICollection_$T$___get_Count = function ArrayG$1__System__Collections__Generic__ICollection_$T$___get_Count() {
+    return this.innerArray.length;
+  };
   ptyp_.get_innerArray = function ArrayG$1__get_InnerArray() {
     return this.innerArray;
   };
@@ -218,6 +229,9 @@ function ArrayG(T, _callStatiConstructor) {
   ptyp_.system__Collections__Generic__IList_$T$___Insert = function ArrayG$1__System__Collections__Generic__IList_$T$___Insert(index, item) {
     throw new Error("Not Implemented.");
   };
+  ptyp_.system__Collections__Generic__IList_$T$___RemoveAt = function ArrayG$1__System__Collections__Generic__IList_$T$___RemoveAt(index) {
+    throw new Error("Not Implemented.");
+  };
   ptyp_.system__Collections__Generic__ICollection_$T$___Add = function ArrayG$1__System__Collections__Generic__ICollection_$T$___Add(item) {
     throw new Error("Not Implemented.");
   };
@@ -252,7 +266,9 @@ function ArrayG(T, _callStatiConstructor) {
     return Enumerator_$T$_.__ctor(this);
   };
   ptyp_["V_get_IsReadOnly_" + ICollection$1_$T$_.typeId] = ptyp_.system__Collections__Generic__ICollection_$T$___get_IsReadOnly;
+  ptyp_["V_get_Count_" + ICollection$1_$T$_.typeId] = ptyp_.system__Collections__Generic__ICollection_$T$___get_Count;
   ptyp_["V_Insert_" + IList$1_$T$_.typeId] = ptyp_.system__Collections__Generic__IList_$T$___Insert;
+  ptyp_["V_RemoveAt_" + IList$1_$T$_.typeId] = ptyp_.system__Collections__Generic__IList_$T$___RemoveAt;
   ptyp_["V_Add_" + ICollection$1_$T$_.typeId] = ptyp_.system__Collections__Generic__ICollection_$T$___Add;
   ptyp_["V_Clear_" + ICollection$1_$T$_.typeId] = ptyp_.system__Collections__Generic__ICollection_$T$___Clear;
   ptyp_["V_Remove_" + ICollection$1_$T$_.typeId] = ptyp_.system__Collections__Generic__ICollection_$T$___Remove;

--- a/Test/Compiler/NScript.Converter.Test/TypeConverterTests/CoreLibTests/ListType.js
+++ b/Test/Compiler/NScript.Converter.Test/TypeConverterTests/CoreLibTests/ListType.js
@@ -196,6 +196,7 @@ function List(T, _callStatiConstructor) {
   };
   ptyp_.system__Collections__IList__Add = function List$1__System__Collections__IList__Add(value) {
     this.add(Type__UnBoxTypeInstance(T, value));
+    return this.nativeArray.length - 1;
   };
   ptyp_.addRange = function List$1__AddRange(items) {
     this.nativeArray = NativeArray$1__Concata(this.nativeArray, NativeArray$1__GetNativeArray(items));
@@ -229,6 +230,12 @@ function List(T, _callStatiConstructor) {
     length = nativeArray.length;
     for (i = 0; i < length; i++)
       array.sv(i + index, Type__BoxTypeInstance(T, nativeArray[i]));
+  };
+  ptyp_.system__Collections__ICollection__get_IsSynchronized = function List$1__System__Collections__ICollection__get_IsSynchronized() {
+    return false;
+  };
+  ptyp_.system__Collections__ICollection__get_SyncRoot = function List$1__System__Collections__ICollection__get_SyncRoot() {
+    return this;
   };
   ptyp_.toArray = function List$1__ToArray() {
     return ArrayG$1_$T$_.__ctor(this.nativeArray.slice(0, this.nativeArray.length));
@@ -271,6 +278,8 @@ function List(T, _callStatiConstructor) {
   ptyp_.V_get_IsReadOnly_e = ptyp_.system__Collections__IList__get_IsReadOnly;
   ptyp_.V_Add_e = ptyp_.system__Collections__IList__Add;
   ptyp_.V_CopyTo_g = ptyp_.system__Collections__ICollection__CopyTo;
+  ptyp_.V_get_IsSynchronized_g = ptyp_.system__Collections__ICollection__get_IsSynchronized;
+  ptyp_.V_get_SyncRoot_g = ptyp_.system__Collections__ICollection__get_SyncRoot;
   ptyp_.V_Remove_e = ptyp_.system__Collections__IList__Remove;
   ptyp_.V_GetEnumerator_c = ptyp_.system__Collections__IEnumerable__GetEnumerator;
   ptyp_.V_get_IsFixedSize_e = ptyp_.system__Collections__IList__get_IsFixedSize;
@@ -281,9 +290,11 @@ function List(T, _callStatiConstructor) {
   ptyp_["V_set_Item_" + IList$1_$T$_.typeId] = ptyp_.set_item;
   ptyp_["V_IndexOf_" + IList$1_$T$_.typeId] = ptyp_.indexOf;
   ptyp_["V_Insert_" + IList$1_$T$_.typeId] = ptyp_.insert;
+  ptyp_["V_RemoveAt_" + IList$1_$T$_.typeId] = ptyp_.removeAt;
   ptyp_.V_Clear_e = ptyp_.clear;
   ptyp_.V_RemoveAt_e = ptyp_.removeAt;
   ptyp_.V_get_Count_g = ptyp_.get_count;
+  ptyp_["V_get_Count_" + ICollection$1_$T$_.typeId] = ptyp_.get_count;
   ptyp_["V_Add_" + ICollection$1_$T$_.typeId] = ptyp_.add;
   ptyp_["V_Clear_" + ICollection$1_$T$_.typeId] = ptyp_.clear;
   ptyp_["V_Contains_" + ICollection$1_$T$_.typeId] = ptyp_.contains;

--- a/Test/Compiler/NScript.Converter.Test/TypeConverterTests/SimpleTypeConverter/SystemGenericListType.js
+++ b/Test/Compiler/NScript.Converter.Test/TypeConverterTests/SimpleTypeConverter/SystemGenericListType.js
@@ -135,6 +135,7 @@ function List(T, _callStatiConstructor) {
   };
   ptyp_.system__Collections__IList__Add = function List$1__System__Collections__IList__Add(value) {
     this.add(Type__UnBoxTypeInstance(T, value));
+    return this.nativeArray.length - 1;
   };
   ptyp_.addRange = function List$1__AddRange(items) {
     this.nativeArray = NativeArray$1__Concat(this.nativeArray, NativeArray$1__GetNativeArray(items));
@@ -168,6 +169,12 @@ function List(T, _callStatiConstructor) {
     length = nativeArray.length;
     for (i = 0; i < length; i++)
       array.sv(i + index, Type__BoxTypeInstance(T, nativeArray[i]));
+  };
+  ptyp_.system__Collections__ICollection__get_IsSynchronized = function List$1__System__Collections__ICollection__get_IsSynchronized() {
+    return false;
+  };
+  ptyp_.system__Collections__ICollection__get_SyncRoot = function List$1__System__Collections__ICollection__get_SyncRoot() {
+    return this;
   };
   ptyp_.toArray = function List$1__ToArray() {
     return ArrayG$1_$T$_.__ctor(this.nativeArray.slice(0, this.nativeArray.length));
@@ -210,6 +217,8 @@ function List(T, _callStatiConstructor) {
   ptyp_.V_get_IsReadOnly_d = ptyp_.system__Collections__IList__get_IsReadOnly;
   ptyp_.V_Add_d = ptyp_.system__Collections__IList__Add;
   ptyp_.V_CopyTo_f = ptyp_.system__Collections__ICollection__CopyTo;
+  ptyp_.V_get_IsSynchronized_f = ptyp_.system__Collections__ICollection__get_IsSynchronized;
+  ptyp_.V_get_SyncRoot_f = ptyp_.system__Collections__ICollection__get_SyncRoot;
   ptyp_.V_Remove_d = ptyp_.system__Collections__IList__Remove;
   ptyp_.V_GetEnumerator_b = ptyp_.system__Collections__IEnumerable__GetEnumerator;
   ptyp_.V_get_IsFixedSize_d = ptyp_.system__Collections__IList__get_IsFixedSize;
@@ -220,9 +229,11 @@ function List(T, _callStatiConstructor) {
   ptyp_["V_set_Item_" + IList$1_$T$_.typeId] = ptyp_.set_item;
   ptyp_["V_IndexOf_" + IList$1_$T$_.typeId] = ptyp_.indexOf;
   ptyp_["V_Insert_" + IList$1_$T$_.typeId] = ptyp_.insert;
+  ptyp_["V_RemoveAt_" + IList$1_$T$_.typeId] = ptyp_.removeAt;
   ptyp_.V_Clear_d = ptyp_.clear;
   ptyp_.V_RemoveAt_d = ptyp_.removeAt;
   ptyp_.V_get_Count_f = ptyp_.get_count;
+  ptyp_["V_get_Count_" + ICollection$1_$T$_.typeId] = ptyp_.get_count;
   ptyp_["V_Add_" + ICollection$1_$T$_.typeId] = ptyp_.add;
   ptyp_["V_Clear_" + ICollection$1_$T$_.typeId] = ptyp_.clear;
   ptyp_["V_Contains_" + ICollection$1_$T$_.typeId] = ptyp_.contains;

--- a/Test/Compiler/NScript.Converter.Test/TypeConverterTests/SimpleTypeConverter/SystemGenericListType.static.js
+++ b/Test/Compiler/NScript.Converter.Test/TypeConverterTests/SimpleTypeConverter/SystemGenericListType.static.js
@@ -135,6 +135,7 @@ function List(T, _callStatiConstructor) {
   };
   ptyp_.system__Collections__IList__Add = function List$1__System__Collections__IList__Add(value) {
     this.add(Type__UnBoxTypeInstance(T, value));
+    return this.nativeArray.length - 1;
   };
   ptyp_.addRange = function List$1__AddRange(items) {
     this.nativeArray = NativeArray$1__Concat(this.nativeArray, NativeArray$1__GetNativeArray(items));
@@ -168,6 +169,12 @@ function List(T, _callStatiConstructor) {
     length = nativeArray.length;
     for (i = 0; i < length; i++)
       array.sv(i + index, Type__BoxTypeInstance(T, nativeArray[i]));
+  };
+  ptyp_.system__Collections__ICollection__get_IsSynchronized = function List$1__System__Collections__ICollection__get_IsSynchronized() {
+    return false;
+  };
+  ptyp_.system__Collections__ICollection__get_SyncRoot = function List$1__System__Collections__ICollection__get_SyncRoot() {
+    return this;
   };
   ptyp_.toArray = function List$1__ToArray() {
     return ArrayG$1_$T$_.__ctor(this.nativeArray.slice(0, this.nativeArray.length));
@@ -210,6 +217,8 @@ function List(T, _callStatiConstructor) {
   ptyp_.V_get_IsReadOnly_d = ptyp_.system__Collections__IList__get_IsReadOnly;
   ptyp_.V_Add_d = ptyp_.system__Collections__IList__Add;
   ptyp_.V_CopyTo_f = ptyp_.system__Collections__ICollection__CopyTo;
+  ptyp_.V_get_IsSynchronized_f = ptyp_.system__Collections__ICollection__get_IsSynchronized;
+  ptyp_.V_get_SyncRoot_f = ptyp_.system__Collections__ICollection__get_SyncRoot;
   ptyp_.V_Remove_d = ptyp_.system__Collections__IList__Remove;
   ptyp_.V_GetEnumerator_b = ptyp_.system__Collections__IEnumerable__GetEnumerator;
   ptyp_.V_get_IsFixedSize_d = ptyp_.system__Collections__IList__get_IsFixedSize;
@@ -220,9 +229,11 @@ function List(T, _callStatiConstructor) {
   ptyp_["V_set_Item_" + IList$1_$T$_.typeId] = ptyp_.set_item;
   ptyp_["V_IndexOf_" + IList$1_$T$_.typeId] = ptyp_.indexOf;
   ptyp_["V_Insert_" + IList$1_$T$_.typeId] = ptyp_.insert;
+  ptyp_["V_RemoveAt_" + IList$1_$T$_.typeId] = ptyp_.removeAt;
   ptyp_.V_Clear_d = ptyp_.clear;
   ptyp_.V_RemoveAt_d = ptyp_.removeAt;
   ptyp_.V_get_Count_f = ptyp_.get_count;
+  ptyp_["V_get_Count_" + ICollection$1_$T$_.typeId] = ptyp_.get_count;
   ptyp_["V_Add_" + ICollection$1_$T$_.typeId] = ptyp_.add;
   ptyp_["V_Clear_" + ICollection$1_$T$_.typeId] = ptyp_.clear;
   ptyp_["V_Contains_" + ICollection$1_$T$_.typeId] = ptyp_.contains;

--- a/Test/Framework/RealScript/Lang12CollectionExpressionTests.cs
+++ b/Test/Framework/RealScript/Lang12CollectionExpressionTests.cs
@@ -44,21 +44,22 @@ namespace RealScript
     /// file via the MSBuild Framework build; no separate Csc.Lib unit-test
     /// file targets the round-trip directly.
     ///
-    /// Out of scope for this slice (deferred to Phase F5):
-    /// - The five BCL interface targets — <c>IEnumerable&lt;T&gt;</c>,
-    ///   <c>IList&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
-    ///   <c>ICollection&lt;T&gt;</c>, <c>IReadOnlyCollection&lt;T&gt;</c>.
-    ///   Roslyn's binder requires a long tail of well-known-member
-    ///   signatures on these interfaces (<c>RemoveAt</c>, <c>Count</c>,
-    ///   <c>IsSynchronized</c>, <c>SyncRoot</c>, etc.) before it will produce
-    ///   a <c>BoundCollectionExpression</c>; supplying those facade members
-    ///   ripples through every implementer (List, Dictionary, ArrayG,
-    ///   ReadOnlyCollection, NumberDictionary, StringDictionary, ExpandoObject)
-    ///   and is large enough to track separately.
+    /// Phase F5 extends coverage to the five list-shaped BCL interface
+    /// targets (<c>IEnumerable&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>,
+    /// <c>ICollection&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+    /// <c>IReadOnlyCollection&lt;T&gt;</c>) and to <c>IEnumerable&lt;T&gt;</c>
+    /// spread sources for both <c>T[]</c> and <c>List&lt;T&gt;</c> targets.
+    /// All five interfaces collapse to the same Phase F4 lowering — the
+    /// element type is recovered from the interface's single type argument
+    /// and a constructed <c>List&lt;T&gt;</c> is materialised. The
+    /// <c>IEnumerable&lt;T&gt;</c> spread bridge for <c>T[]</c> targets
+    /// synthesises <c>new List&lt;T&gt;(); AddRange(src); ToArray()</c> so
+    /// the F1 array-source converter handles the result uniformly.
+    ///
+    /// Out of scope for this slice (deferred to Phase F6):
     /// - <c>[CollectionBuilder]</c>-attributed user types.
-    /// - <c>IEnumerable&lt;T&gt;</c> spread sources into a <c>T[]</c> target
-    ///   (needs an iterator-based emit path; non-trivial without a
-    ///   <c>System.Linq.Enumerable.ToArray</c> helper in NScript's mscorlib facade).
+    /// - Index/range residuals on element-position sub-spreads
+    ///   (<c>[..src[1..3]]</c>).
     /// - <c>Span&lt;T&gt;</c> / <c>ReadOnlySpan&lt;T&gt;</c> (Non-Goal — see
     ///   <c>docs/language/limitations.md</c>).
     /// </summary>
@@ -177,6 +178,102 @@ namespace RealScript
             Console.WriteLine(dst.Count);
             Console.WriteLine(dst[0]);
             Console.WriteLine(dst[3]);
+        }
+
+        // -----------------------------------------------------------------
+        // Phase F5 — list-shaped BCL interface targets and IEnumerable<T>
+        // spread sources. All five interfaces collapse to the same Phase F4
+        // List<T> lowering; the JS runtime carries no "interface type", so
+        // the static-type information is preserved at the C# call site only.
+        // -----------------------------------------------------------------
+
+        // IEnumerable<T> target — collapses to `new List<int>()` + Add chain.
+        public static void IEnumerableTarget()
+        {
+            System.Collections.Generic.IEnumerable<int> xs = [1, 2, 3];
+            int sum = 0;
+            foreach (int v in xs)
+            {
+                sum += v;
+            }
+
+            Console.WriteLine(sum);
+        }
+
+        // IList<T> target — same lowering as List<T> directly.
+        public static void IListTarget()
+        {
+            System.Collections.Generic.IList<int> xs = [1, 2, 3];
+            Console.WriteLine(xs.Count);
+            Console.WriteLine(xs[2]);
+        }
+
+        // ICollection<T> target — exercises Count via the ICollection<T>
+        // interface dispatch.
+        public static void ICollectionTarget()
+        {
+            System.Collections.Generic.ICollection<int> xs = [10, 20, 30];
+            Console.WriteLine(xs.Count);
+        }
+
+        // IReadOnlyList<T> target — exercises indexer dispatch through
+        // the read-only interface.
+        public static void IReadOnlyListTarget()
+        {
+            System.Collections.Generic.IReadOnlyList<int> xs = [7, 8, 9];
+            Console.WriteLine(xs.Count);
+            Console.WriteLine(xs[1]);
+        }
+
+        // IReadOnlyCollection<T> target — exercises Count via the
+        // read-only collection interface.
+        public static void IReadOnlyCollectionTarget()
+        {
+            System.Collections.Generic.IReadOnlyCollection<int> xs = [4, 5, 6];
+            Console.WriteLine(xs.Count);
+        }
+
+        // Interface target with mixed literal + array spread — exercises
+        // the same Add(literal) → AddRange(spread) ordering as the
+        // direct-List target path.
+        public static void IListTargetWithSpread()
+        {
+            int[] src = [10, 20];
+            System.Collections.Generic.IList<int> dst = [1, ..src, 99];
+            Console.WriteLine(dst.Count);
+            Console.WriteLine(dst[3]);
+        }
+
+        // IEnumerable<T> spread source into a T[] target — bridged via
+        // `new List<int>(); AddRange(src); ToArray()` so the F1
+        // array-source converter handles the result uniformly.
+        public static void SpreadFromEnumerableIntoArray()
+        {
+            System.Collections.Generic.IEnumerable<int> src = ProduceEnumerable();
+            int[] dst = [0, ..src, 99];
+            Console.WriteLine(dst.Length);
+            Console.WriteLine(dst[1]);
+            Console.WriteLine(dst[dst.Length - 1]);
+        }
+
+        // IEnumerable<T> spread source into a List<T> target — exercises
+        // the AddRange(IEnumerable<T>) overload resolution path.
+        public static void SpreadFromEnumerableIntoList()
+        {
+            System.Collections.Generic.IEnumerable<int> src = ProduceEnumerable();
+            System.Collections.Generic.List<int> dst = [..src, 42];
+            Console.WriteLine(dst.Count);
+            Console.WriteLine(dst[dst.Count - 1]);
+        }
+
+        // Helper that returns an IEnumerable<int> backed by a List<int>.
+        // Inlined into the spread-source fixtures so the static type at the
+        // spread element is `IEnumerable<int>` (not `List<int>` / `int[]`),
+        // forcing the Phase F5 dispatch arm.
+        private static System.Collections.Generic.IEnumerable<int> ProduceEnumerable()
+        {
+            System.Collections.Generic.List<int> backing = [1, 2, 3];
+            return backing;
         }
     }
 }

--- a/Test/Framework/RealScript/Lang13Features.cs
+++ b/Test/Framework/RealScript/Lang13Features.cs
@@ -58,13 +58,23 @@ public class Lang13Features
     // C# 13 — params collections with a `List<T>` parameter. Roslyn synthesises
     // a List<T>-shaped collection expression at the call site, which routes
     // through the same Phase F4 lowering that handles explicit
-    // `List<T> xs = [...]` target-typing. (Interface params shapes such as
-    // `params IEnumerable<int>` are deferred to Phase F5 along with their
-    // collection-expression interface targets.)
+    // `List<T> xs = [...]` target-typing.
+    //
+    // Phase F5 extends coverage to the five list-shaped BCL interfaces
+    // (IEnumerable<T>, IList<T>, ICollection<T>, IReadOnlyList<T>,
+    // IReadOnlyCollection<T>) as `params` shapes — Roslyn target-types the
+    // synthesised call-site collection expression to the interface, which
+    // the F5 dispatch arm collapses to `new List<int>()` + Add chain.
     public static void ParamsCollections()
     {
         Sum(1, 2, 3);
         Sum(10, 20);
+
+        SumEnumerable(1, 2, 3, 4);
+        CountIList(10, 20, 30);
+        CountICollection(7, 8);
+        CountIReadOnlyList(11, 12, 13, 14);
+        CountIReadOnlyCollection(100, 200);
     }
 
     private static void Sum(params System.Collections.Generic.List<int> xs)
@@ -76,5 +86,37 @@ public class Lang13Features
         }
 
         Console.WriteLine(total);
+    }
+
+    private static void SumEnumerable(params System.Collections.Generic.IEnumerable<int> xs)
+    {
+        int total = 0;
+        foreach (int v in xs)
+        {
+            total += v;
+        }
+
+        Console.WriteLine(total);
+    }
+
+    private static void CountIList(params System.Collections.Generic.IList<int> xs)
+    {
+        Console.WriteLine(xs.Count);
+    }
+
+    private static void CountICollection(params System.Collections.Generic.ICollection<int> xs)
+    {
+        Console.WriteLine(xs.Count);
+    }
+
+    private static void CountIReadOnlyList(params System.Collections.Generic.IReadOnlyList<int> xs)
+    {
+        Console.WriteLine(xs.Count);
+    }
+
+    private static void CountIReadOnlyCollection(
+        params System.Collections.Generic.IReadOnlyCollection<int> xs)
+    {
+        Console.WriteLine(xs.Count);
     }
 }


### PR DESCRIPTION
[Gautam's Dev bot]

## Summary

Phase F5 of WI-47 closes the C# 12 collection-expression coverage gap on the five list-shaped BCL interface targets and on `IEnumerable<T>` spread sources, plus the C# 13 `params <interface>` shapes that bind through the same dispatch.

- **Stage-1 dispatch widening** in `BoundAstToAstBase.VisitCollectionExpression`: target types of `IEnumerable<T>`, `IList<T>`, `ICollection<T>`, `IReadOnlyList<T>`, and `IReadOnlyCollection<T>` now collapse to the existing F4 `List<T>` lowering by recovering the element type from the interface's single type argument and constructing a sibling `List<T>` in the same containing namespace. The JS runtime carries no notion of an "interface type", so the static-type information is preserved at the C# call site only.
- **`IEnumerable<T>` spread bridge** for `T[]` targets in `BuildArrayTargetSpreadOperand`: synthesised `new List<T>() { AddRange(src) }.ToArray()` so the F1 array-source converter handles the result uniformly. `IEnumerable<T>` into a `List<T>` target picks the existing `AddRange(IEnumerable<T>)` overload via the F4 spread path.
- **mscorlib facade widening** for the well-known members Roslyn's collection-expression binder requires when binding to list-shaped interfaces:
  - `System.Collections.Generic.ICollection<T>.Count` and `System.Collections.Generic.IList<T>.RemoveAt` on the generic interfaces.
  - `System.Collections.ICollection.IsSynchronized` and `SyncRoot`, plus a return-type fix on `System.Collections.IList.Add` (`void` → `int`, matching the real-BCL signature).
  - Implementers (`ArrayG<T>`, `ArrayImpl`, `Array`, `List<T>`, `Dictionary<K,V>`, `NumberDictionary<TValue>`, `StringDictionary<TValue>`, `ReadOnlyCollection<T>`, `DomList<T>`, `ExpandoObject`) declare the corresponding explicit interface members. JS is single-threaded, so `IsSynchronized` returns `false` and `SyncRoot` returns `this`.
- **Test fixtures**: 8 new methods in `Lang12CollectionExpressionTests.cs` covering all five interface targets, an interface target with mixed literal + array spread, and `IEnumerable<T>` spread into both `T[]` and `List<T>` targets. `Lang13Features.ParamsCollections` extended with five `params <interface>` methods (`IEnumerable<int>`, `IList<int>`, `ICollection<int>`, `IReadOnlyList<int>`, `IReadOnlyCollection<int>`).

Out of scope for F5 (deferred to F6): `[CollectionBuilder]`-attributed user types, index/range residuals on element-position sub-spreads. `Span<T>`/`ReadOnlySpan<T>` remain Non-Goals.

Closes #47

## Test plan

- [x] `dotnet build NScript_Full.sln -c Release` — 0 errors locally on Linux.
- [ ] Windows CI: full `Test/Compiler/NScript.CLR.Test` and downstream integration tests pass (Linux sandbox cannot run these per WI-47 learning).
- [ ] CoreLib JS snapshot diff: monitor for snapshot churn from the mscorlib facade additions; rely on Windows CI extraction if a refresh is needed (per the F4 procedure).