### PR TITLE
Fix static-field cctor crash: emit all _tri_b() before concrete cctors

### DIFF
--- a/Sources/Compiler/NScript.Converter/TypeSystemConverter/RuntimeScopeManager.cs
+++ b/Sources/Compiler/NScript.Converter/TypeSystemConverter/RuntimeScopeManager.cs
@@ -530,7 +530,11 @@ namespace NScript.Converter.TypeSystemConverter
                     if (!converter.HasTypeRefInit)
                     { continue; }
 
-                    returnValue.Add(converter.InitializeTypeStatement(typeReference));
+                    var triB = converter.InitializeTypeStatement(typeReference);
+                    if (triB != null)
+                    {
+                        returnValue.Add(triB);
+                    }
                 }
 
                 // Pass 2: run static constructors for concrete (non-generic) types.

--- a/Sources/Compiler/NScript.Converter/TypeSystemConverter/RuntimeScopeManager.cs
+++ b/Sources/Compiler/NScript.Converter/TypeSystemConverter/RuntimeScopeManager.cs
@@ -518,20 +518,35 @@ namespace NScript.Converter.TypeSystemConverter
                                 Scope)));
                 }
 
-                // here we need to initialize all the static constructor for
-                // all these classes.
+                // Pass 1: call _tri_b() on all generic types before any concrete cctor runs.
+                // A concrete cctor may call new ObservableCollection<T>() which requires T's
+                // _tri_b() to have already set the closure variable for List<T>.
                 foreach (var typeReference in typesInitializedInOrder)
                 {
                     if (!typesDefinitionsUsed.ContainsKey(typeReference.Resolve()))
                     { continue; }
 
-                    var staticConstructor =
-                        typesDefinitionsUsed[typeReference.Resolve()]
-                            .InitializeTypeStatement(typeReference);
+                    var converter = typesDefinitionsUsed[typeReference.Resolve()];
+                    if (!converter.HasTypeRefInit)
+                    { continue; }
 
-                    if (staticConstructor != null)
+                    returnValue.Add(converter.InitializeTypeStatement(typeReference));
+                }
+
+                // Pass 2: run static constructors for concrete (non-generic) types.
+                foreach (var typeReference in typesInitializedInOrder)
+                {
+                    if (!typesDefinitionsUsed.ContainsKey(typeReference.Resolve()))
+                    { continue; }
+
+                    var converter = typesDefinitionsUsed[typeReference.Resolve()];
+                    if (converter.HasTypeRefInit)
+                    { continue; }
+
+                    var cctorCall = converter.InitializeTypeStatement(typeReference);
+                    if (cctorCall != null)
                     {
-                        returnValue.Add(staticConstructor);
+                        returnValue.Add(cctorCall);
                     }
                 }
 

--- a/Sources/Compiler/NScript.Converter/TypeSystemConverter/TypeConverter.cs
+++ b/Sources/Compiler/NScript.Converter/TypeSystemConverter/TypeConverter.cs
@@ -136,6 +136,12 @@ namespace NScript.Converter.TypeSystemConverter
         private bool hasTypeRefInit = false;
 
         /// <summary>
+        /// Gets a value indicating whether this type has a type-ref init function (_tri_b).
+        /// Used to order _tri_b() calls before concrete cctors at module init time.
+        /// </summary>
+        public bool HasTypeRefInit => this.hasTypeRefInit;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TypeConverter"/> class.
         /// </summary>
         /// <param name="scopeManager">The scope manager.</param>

--- a/Test/Framework/Sunlight.Framework.Test/ObservableCollectionTests.cs
+++ b/Test/Framework/Sunlight.Framework.Test/ObservableCollectionTests.cs
@@ -115,6 +115,17 @@ namespace Sunlight.Framework.Test
 
         }
 
+        [Test]
+        public static void TestStaticReadonlyObservableCollectionOfUserType(Assert assert)
+        {
+            // Regression test for issue #83: static readonly ObservableCollection<UserType>
+            // triggered a crash because _tri_b() for ObservableCollection<UserType> was called
+            // after the cctor that constructs it.
+            var collection = StaticCollectionHolder.EmptyItems;
+            assert.NotEqual(null, collection, "static readonly ObservableCollection<StaticCollectionItem> should be initialized");
+            assert.Equal(0, collection.Count, "static collection should be empty");
+        }
+
         public static void CheckGetAsserts(Assert assert, ObservableCollection<int> observableCollection, int index, int count) {
             try
             {
@@ -128,7 +139,7 @@ namespace Sunlight.Framework.Test
             catch (Exception)
             {
                 assert.IsTrue(
-                    index < 0 
+                    index < 0
                     || index > observableCollection.Count - 1
                     || count <= 0
                     || count > observableCollection.Count
@@ -137,5 +148,16 @@ namespace Sunlight.Framework.Test
                     "Improper value of parameters for index : " + index + " ,count : " + count);
             }
         }
+    }
+
+    public class StaticCollectionItem
+    {
+        public int Value { get; set; }
+    }
+
+    public class StaticCollectionHolder
+    {
+        internal static readonly ObservableCollection<StaticCollectionItem> EmptyItems =
+            new ObservableCollection<StaticCollectionItem>();
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #83: `static readonly ObservableCollection<UserType>` crash at startup
- Splits the module-init loop in `RuntimeScopeManager.Convert()` into two passes: all `_tri_b()` calls first, then all cctors
- Adds a `HasTypeRefInit` property to `TypeConverter` to distinguish generic types (with `_tri_b`) from concrete types

## Root Cause

Generic closure variables (e.g. `List$1_$T$__f` inside `ObservableCollection<T>`) are only initialized when `_tri_b()` runs. The old single-loop ordering placed `WorkspaceListViewModel.cctor()` before `ObservableCollection<TagChip>._tri_b()` whenever the generic type was added to `typesInitializedInOrder` by the third loop (not by the dependency callback), causing a crash on `List$1_$T$__f.defaultConstructor_c()`.

## Fix

Pass 1: for every type in `typesInitializedInOrder` where `HasTypeRefInit == true`, emit the `_tri_b()` call.  
Pass 2: for every type where `HasTypeRefInit == false`, emit the static constructor call.

## Test

Added `StaticCollectionHolder` + `StaticCollectionItem` classes and a regression test `TestStaticReadonlyObservableCollectionOfUserType` in `ObservableCollectionTests`. The test accesses a `static readonly ObservableCollection<StaticCollectionItem>` field — if the ordering bug is present, the module crashes before any test runs.