### PR TITLE
Add secondary repo source root support to RepoLinkedSourceMaps

### DIFF
--- a/Sources/Compiler/NScript.Converter/Builder.cs
+++ b/Sources/Compiler/NScript.Converter/Builder.cs
@@ -69,6 +69,22 @@ namespace NScript.Converter
         private readonly string repoRoot;
 
         /// <summary>
+        /// Optional raw-file base URL for a second repository (e.g. a deployed framework or
+        /// shared library) whose sources should resolve from a different remote than
+        /// <see cref="sourceMapRoot"/>. Files under <see cref="secondaryRepoRoot"/> are
+        /// emitted into <c>sources[]</c> as absolute <c>https://</c> URLs prefixed by this
+        /// value — V3 spec says DevTools uses such absolute entries directly, bypassing the
+        /// primary <see cref="sourceMapRoot"/>.
+        /// </summary>
+        private readonly string secondarySourceRoot;
+
+        /// <summary>
+        /// Optional absolute path to the secondary repository's worktree. Paired with
+        /// <see cref="secondarySourceRoot"/> to enable the multi-repo source map emission.
+        /// </summary>
+        private readonly string secondaryRepoRoot;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="jsScript">               The js script. </param>
@@ -84,6 +100,12 @@ namespace NScript.Converter
         ///     When supplied alongside <paramref name="sourceMapRoot"/>, <c>sources[i]</c> entries
         ///     are emitted as forward-slash, repo-relative paths so they combine with a remote
         ///     repo URL. Files outside the repo root keep the legacy absolutized form. </param>
+        /// <param name="secondarySourceRoot">     Optional raw-file base URL for a second
+        ///     repository. Sources living under <paramref name="secondaryRepoRoot"/> are emitted
+        ///     as absolute <c>https://</c> URLs prefixed by this value so DevTools bypasses the
+        ///     primary <paramref name="sourceMapRoot"/> for them. </param>
+        /// <param name="secondaryRepoRoot">       Optional absolute path to the worktree of a
+        ///     second repository whose files should be served from the secondary remote. </param>
         public Builder(
             string jsScript,
             int jsParts,
@@ -92,7 +114,9 @@ namespace NScript.Converter
             IConverterPlugin[] plugins,
             (bool minify, bool uglify, bool optimize) scriptGenerateSettings,
             string sourceMapRoot = null,
-            string repoRoot = null)
+            string repoRoot = null,
+            string secondarySourceRoot = null,
+            string secondaryRepoRoot = null)
         {
             this.mainAssembly = mainAssembly;
             this.jsScript = jsScript;
@@ -107,6 +131,8 @@ namespace NScript.Converter
             this.scriptGenerateSettings = scriptGenerateSettings;
             this.sourceMapRoot = sourceMapRoot;
             this.repoRoot = repoRoot;
+            this.secondarySourceRoot = secondarySourceRoot;
+            this.secondaryRepoRoot = secondaryRepoRoot;
         }
 
         /// <summary>
@@ -305,7 +331,13 @@ namespace NScript.Converter
                         Path.GetFileName(this.jsScript))
                     : this.sourceMapRoot;
 
-                writer.Write(this.jsScript, effectiveSourceRoot, emitLegacyAshxHandler: isLegacySourceRoot, repoRoot: this.repoRoot);
+                writer.Write(
+                    this.jsScript,
+                    effectiveSourceRoot,
+                    emitLegacyAshxHandler: isLegacySourceRoot,
+                    repoRoot: this.repoRoot,
+                    secondaryRepoRoot: this.secondaryRepoRoot,
+                    secondarySourceRoot: this.secondarySourceRoot);
                 log.Information("JSWriter.End {JsScript}", this.jsScript);
             }
             catch(ConverterLocationException ex)

--- a/Sources/Compiler/NScript.JST/JSWriter.cs
+++ b/Sources/Compiler/NScript.JST/JSWriter.cs
@@ -349,7 +349,14 @@ namespace NScript.JST
         /// <param name="emitLegacyAshxHandler"> When true, the emitted <c>.map</c> file also gets
         ///     the legacy <c>SrcMapper.ashx</c> sidecar dropped alongside it. Callers that configure
         ///     a non-legacy source root (ASP.NET Core endpoint, repo URL, etc.) should pass false. </param>
-        public void Write(string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null)
+        /// <param name="repoRoot">              Optional absolute path to the primary repo root for
+        ///     repo-relative source path emission. </param>
+        /// <param name="secondaryRepoRoot">     Optional absolute path to a second repository whose
+        ///     sources should resolve from <paramref name="secondarySourceRoot"/> instead of the
+        ///     primary <paramref name="sourceRoot"/>. </param>
+        /// <param name="secondarySourceRoot">   Optional raw-file base URL paired with
+        ///     <paramref name="secondaryRepoRoot"/>. Must be an absolute <c>https://</c> URL. </param>
+        public void Write(string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null, string secondaryRepoRoot = null, string secondarySourceRoot = null)
         {
             using var streamWriter = new StreamWriter(jsFileName, false, System.Text.Encoding.UTF8);
             this.Write(
@@ -359,7 +366,9 @@ namespace NScript.JST
                 true,
                 sourceRoot,
                 emitLegacyAshxHandler,
-                repoRoot);
+                repoRoot,
+                secondaryRepoRoot,
+                secondarySourceRoot);
         }
 
         /// <summary>
@@ -368,7 +377,7 @@ namespace NScript.JST
         /// <param name="writer"> The TextWriter to write. </param>
         public void Write(TextWriter writer)
         {
-            this.Write(writer, null, null, false, null, emitLegacyAshxHandler: true, repoRoot: null);
+            this.Write(writer, null, null, false, null, emitLegacyAshxHandler: true, repoRoot: null, secondaryRepoRoot: null, secondarySourceRoot: null);
         }
 
         /// <summary>
@@ -381,7 +390,7 @@ namespace NScript.JST
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. Never null. </returns>
         public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName)
         {
-            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: null, emitLegacyAshxHandler: true, repoRoot: null);
+            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: null, emitLegacyAshxHandler: true, repoRoot: null, secondaryRepoRoot: null, secondarySourceRoot: null);
         }
 
         /// <summary>
@@ -394,9 +403,9 @@ namespace NScript.JST
         /// <param name="sourceRoot"> Source-root override; pass null to use the legacy fallback. </param>
         /// <param name="emitLegacyAshxHandler"> Whether the sidecar <c>.ashx</c> should still drop. </param>
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. </returns>
-        public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null)
+        public OwaSourceMapper.SourceMap WriteWithMap(TextWriter writer, string jsFileName, string sourceRoot, bool emitLegacyAshxHandler = true, string repoRoot = null, string secondaryRepoRoot = null, string secondarySourceRoot = null)
         {
-            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: sourceRoot, emitLegacyAshxHandler: emitLegacyAshxHandler, repoRoot: repoRoot);
+            return this.Write(writer, jsFileName, null, outputMap: false, sourceRoot: sourceRoot, emitLegacyAshxHandler: emitLegacyAshxHandler, repoRoot: repoRoot, secondaryRepoRoot: secondaryRepoRoot, secondarySourceRoot: secondarySourceRoot);
         }
 
         /// <summary>
@@ -418,7 +427,7 @@ namespace NScript.JST
         ///     Callers that know they are using a non-legacy <paramref name="sourceRoot"/> should pass
         ///     false; the default of true preserves the legacy IIS deployment behaviour. </param>
         /// <returns> The populated <see cref="OwaSourceMapper.SourceMap"/>. Never null. </returns>
-        private OwaSourceMapper.SourceMap Write(TextWriter writer, string jsFileName, string outputDirectory, bool outputMap, string sourceRoot, bool emitLegacyAshxHandler, string repoRoot)
+        private OwaSourceMapper.SourceMap Write(TextWriter writer, string jsFileName, string outputDirectory, bool outputMap, string sourceRoot, bool emitLegacyAshxHandler, string repoRoot, string secondaryRepoRoot, string secondarySourceRoot)
         {
             this.ArrangeSpaces();
 
@@ -439,6 +448,8 @@ namespace NScript.JST
 
             sourceMapping.EmitLegacyAshxHandler = emitLegacyAshxHandler;
             sourceMapping.RepoRoot = repoRoot;
+            sourceMapping.SecondaryRepoRoot = secondaryRepoRoot;
+            sourceMapping.SecondarySourceRoot = secondarySourceRoot;
 
             sourceMapping.AddMapping(
                 curLine,

--- a/Sources/Compiler/NScript.Lib/CommandLine.cs
+++ b/Sources/Compiler/NScript.Lib/CommandLine.cs
@@ -45,7 +45,9 @@ namespace NScript.Lib
                     plugins.ToArray(),
                     (parseOptions.Minify, parseOptions.Uglify, parseOptions.Optimize),
                     parseOptions.SourceMapRoot,
-                    parseOptions.RepoRoot);
+                    parseOptions.RepoRoot,
+                    parseOptions.SecondarySourceRoot,
+                    parseOptions.SecondaryRepoRoot);
 
                 var stopWatch = new System.Diagnostics.Stopwatch();
                 stopWatch.Start();

--- a/Sources/Compiler/NScript.Lib/ParseOptions.cs
+++ b/Sources/Compiler/NScript.Lib/ParseOptions.cs
@@ -87,6 +87,21 @@ namespace NScript.Lib
         private string repoRoot;
 
         /// <summary>
+        /// Optional raw-file base URL for a SECOND repository (e.g. a deployed framework or
+        /// shared library) whose sources should resolve from a different remote than the
+        /// primary app's <c>sourceRoot</c>. Must be an <c>https://</c> URL. Per V3 spec, any
+        /// absolute URL in <c>sources[]</c> bypasses <c>sourceRoot</c> prepending — that is
+        /// the mechanism the secondary-repo emit exploits.
+        /// </summary>
+        private string secondarySourceRoot;
+
+        /// <summary>
+        /// Optional absolute path to the secondary repository's worktree. Source files under
+        /// this path are emitted as absolute URLs prefixed with <see cref="SecondarySourceRoot"/>.
+        /// </summary>
+        private string secondaryRepoRoot;
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="ParseOptions"/> class from being created.
         /// </summary>
         private ParseOptions()
@@ -167,6 +182,18 @@ namespace NScript.Lib
         /// the flag was not supplied.
         /// </summary>
         public string RepoRoot => this.repoRoot;
+
+        /// <summary>
+        /// Gets the secondary raw-file base URL supplied via <c>-secondarySourceRoot</c>, or
+        /// null when the flag was not supplied.
+        /// </summary>
+        public string SecondarySourceRoot => this.secondarySourceRoot;
+
+        /// <summary>
+        /// Gets the absolute path to the secondary repository's worktree supplied via
+        /// <c>-secondaryRepoRoot</c>, or null when the flag was not supplied.
+        /// </summary>
+        public string SecondaryRepoRoot => this.secondaryRepoRoot;
 
         /// <summary>
         /// Parses the args.
@@ -303,6 +330,38 @@ namespace NScript.Lib
                         }
 
                         options.repoRoot = args[iArg];
+                        continue;
+                    case "-secondarysourceroot":
+                        option = CurrentOption.None;
+                        if (options.secondarySourceRoot != null)
+                        {
+                            Logger.Instance.LogError("-secondarySourceRoot specified at least twice");
+                            return null;
+                        }
+
+                        if (++iArg >= args.Length)
+                        {
+                            Logger.Instance.LogError("-secondarySourceRoot requires a value");
+                            return null;
+                        }
+
+                        options.secondarySourceRoot = args[iArg];
+                        continue;
+                    case "-secondaryreporoot":
+                        option = CurrentOption.None;
+                        if (options.secondaryRepoRoot != null)
+                        {
+                            Logger.Instance.LogError("-secondaryRepoRoot specified at least twice");
+                            return null;
+                        }
+
+                        if (++iArg >= args.Length)
+                        {
+                            Logger.Instance.LogError("-secondaryRepoRoot requires a value");
+                            return null;
+                        }
+
+                        options.secondaryRepoRoot = args[iArg];
                         continue;
                     case "-log":
                     case "--log":
@@ -442,6 +501,37 @@ namespace NScript.Lib
                     "-repoRoot requires -sourceMapRoot to also be specified");
             }
 
+            // -secondaryRepoRoot requires -secondarySourceRoot — without the remote URL the
+            // secondary rebase has nothing to absolutize against and would silently fall back
+            // to the legacy form; that's almost certainly not what the user meant.
+            if (!string.IsNullOrEmpty(options.secondaryRepoRoot)
+                && string.IsNullOrEmpty(options.secondarySourceRoot))
+            {
+                Logger.Instance.LogError(
+                    "-secondaryRepoRoot requires -secondarySourceRoot to also be specified");
+            }
+
+            // -secondarySourceRoot only makes sense alongside the primary -sourceMapRoot: the
+            // secondary URL exists to side-step the primary sourceRoot for files in a second
+            // repo, so a primary sourceRoot is a prerequisite.
+            if (!string.IsNullOrEmpty(options.secondarySourceRoot)
+                && string.IsNullOrEmpty(options.sourceMapRoot))
+            {
+                Logger.Instance.LogError(
+                    "-secondarySourceRoot requires -sourceMapRoot to also be specified");
+            }
+
+            // -secondarySourceRoot must be an https:// URL — the whole point is to embed an
+            // absolute URL in sources[] so DevTools fetches it directly. Any other scheme
+            // (file://, http://, repo-relative path) would either fail to load in the browser
+            // or defeat the bypass-sourceRoot mechanism.
+            if (!string.IsNullOrEmpty(options.secondarySourceRoot)
+                && !options.secondarySourceRoot.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.Instance.LogError(
+                    "-secondarySourceRoot must be an https:// URL");
+            }
+
             return Logger.Instance.HasErrors ? null : options;
         }
 
@@ -450,7 +540,7 @@ namespace NScript.Lib
         /// </summary>
         public static void PrintUsage()
         {
-            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-sourceMapRoot <url>] [-repoRoot <absolute-path>] [-log <jsonl path>] [-runid <id>]");
+            Console.WriteLine("NScript -outJs <JSFileName> -references <references (dll paths)... > -entryAssembly <assembly with entrypoint> [-pluginConfig <plugin for JsGenerator>] [-pluginHintPath <; seperated directories to find plugin dlls in>] [-referenceHintPath <;seperated directories to find reference dlls in>] [-sourceMapRoot <url>] [-repoRoot <absolute-path>] [-secondarySourceRoot <url>] [-secondaryRepoRoot <absolute-path>] [-log <jsonl path>] [-runid <id>]");
             Environment.Exit(1);
         }
 

--- a/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
+++ b/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
@@ -146,11 +146,89 @@
 		         Condition="'$(SourceMapRoot)' != ''" />
 	</Target>
 
+	<!--
+	  Resolves the secondary/dependency repo's raw-file base URL for multi-repo source map
+	  support. Runs only when RepoLinkedSourceMaps=true, the primary SourceMapRoot is already
+	  resolved, AND NScriptSecondaryRepoRoot is provided. Tolerates missing git metadata the
+	  same way ComputeNScriptRepoMetadata does — emits a warning and skips rather than failing.
+	-->
+	<Target Name="ComputeNScriptSecondaryRepoMetadata"
+	        Condition="'$(RepoLinkedSourceMaps)' == 'true'
+	                   and '$(SourceMapRoot)' != ''
+	                   and '$(NScriptSecondaryRepoRoot)' != ''
+	                   and '$(NScriptSecondarySourceMapRoot)' == ''"
+	        BeforeTargets="ScriptGenerate"
+	        DependsOnTargets="ComputeNScriptRepoMetadata">
+
+		<Exec Command="git -C &quot;$(NScriptSecondaryRepoRoot)&quot; remote get-url origin"
+		      Condition="'$(NScriptSecondarySourceRepoOriginUrl)' == ''"
+		      ConsoleToMSBuild="true"
+		      EchoOff="true"
+		      IgnoreExitCode="true"
+		      ContinueOnError="WarnAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_NScriptSecGitRemoteRaw" />
+			<Output TaskParameter="ExitCode"      PropertyName="_NScriptSecGitRemoteExit" />
+		</Exec>
+
+		<Exec Command="git -C &quot;$(NScriptSecondaryRepoRoot)&quot; rev-parse HEAD"
+		      Condition="'$(NScriptSecondaryCommitSha)' == ''"
+		      ConsoleToMSBuild="true"
+		      EchoOff="true"
+		      IgnoreExitCode="true"
+		      ContinueOnError="WarnAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_NScriptSecGitShaRaw" />
+		</Exec>
+
+		<PropertyGroup>
+			<NScriptSecondarySourceRepoOriginUrl Condition="'$(NScriptSecondarySourceRepoOriginUrl)' == '' and '$(_NScriptSecGitRemoteRaw)' != ''">$(_NScriptSecGitRemoteRaw.Trim())</NScriptSecondarySourceRepoOriginUrl>
+			<NScriptSecondaryCommitSha Condition="'$(NScriptSecondaryCommitSha)' == '' and '$(_NScriptSecGitShaRaw)' != ''">$(_NScriptSecGitShaRaw.Trim())</NScriptSecondaryCommitSha>
+			<_NScriptSecOriginUrlRedacted Condition="'$(NScriptSecondarySourceRepoOriginUrl)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(NScriptSecondarySourceRepoOriginUrl)', '://[^/@]+@', '://***@'))</_NScriptSecOriginUrlRedacted>
+		</PropertyGroup>
+
+		<Warning Text="NScriptSecondaryRepoRoot set but secondary repo git metadata could not be captured (origin='$(_NScriptSecOriginUrlRedacted)' sha='$(NScriptSecondaryCommitSha)'). Set NScriptSecondarySourceMapRoot manually."
+		         Condition="('$(NScriptSecondarySourceRepoOriginUrl)' == '' or '$(NScriptSecondaryCommitSha)' == '')" />
+
+		<!-- GitHub HTTPS / SSH — same patterns as ComputeNScriptRepoMetadata -->
+		<PropertyGroup Condition="'$(NScriptSecondarySourceRepoOriginUrl)' != '' and '$(NScriptSecondaryCommitSha)' != '' and ('$(NScriptSecondaryRepoProvider)' == '' or '$(NScriptSecondaryRepoProvider)' == 'auto' or '$(NScriptSecondaryRepoProvider)' == 'GitHub')">
+			<_NScriptSecGitHubHttpsPattern>^https?://(?:[^/@]+@)?github\.com/(?&lt;owner&gt;[^/]+)/(?&lt;repo&gt;[^/]+?)(?:\.git)?/?$</_NScriptSecGitHubHttpsPattern>
+			<_NScriptSecGitHubSshPattern>^(?:ssh://)?git@github\.com[:/](?&lt;owner&gt;[^/]+)/(?&lt;repo&gt;[^/]+?)(?:\.git)?/?$</_NScriptSecGitHubSshPattern>
+			<_NScriptSecGitHubOwner>$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecGitHubHttpsPattern)').Groups[1].Value)</_NScriptSecGitHubOwner>
+			<_NScriptSecGitHubRepo>$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecGitHubHttpsPattern)').Groups[2].Value)</_NScriptSecGitHubRepo>
+			<_NScriptSecGitHubOwner Condition="'$(_NScriptSecGitHubOwner)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecGitHubSshPattern)').Groups[1].Value)</_NScriptSecGitHubOwner>
+			<_NScriptSecGitHubRepo Condition="'$(_NScriptSecGitHubRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecGitHubSshPattern)').Groups[2].Value)</_NScriptSecGitHubRepo>
+			<NScriptSecondarySourceMapRoot Condition="'$(_NScriptSecGitHubOwner)' != '' and '$(_NScriptSecGitHubRepo)' != ''">https://raw.githubusercontent.com/$(_NScriptSecGitHubOwner)/$(_NScriptSecGitHubRepo)/$(NScriptSecondaryCommitSha)/</NScriptSecondarySourceMapRoot>
+		</PropertyGroup>
+
+		<!-- Azure DevOps — same patterns as ComputeNScriptRepoMetadata -->
+		<PropertyGroup Condition="'$(NScriptSecondarySourceMapRoot)' == '' and '$(NScriptSecondarySourceRepoOriginUrl)' != '' and '$(NScriptSecondaryCommitSha)' != '' and ('$(NScriptSecondaryRepoProvider)' == '' or '$(NScriptSecondaryRepoProvider)' == 'auto' or '$(NScriptSecondaryRepoProvider)' == 'AzureDevOps')">
+			<_NScriptSecAdoModernHttpsPattern>^https?://(?:[^/@]+@)?dev\.azure\.com/(?&lt;org&gt;[^/]+)/(?&lt;project&gt;[^/]+)/_git/(?&lt;repo&gt;[^/]+?)(?:\.git)?/?$</_NScriptSecAdoModernHttpsPattern>
+			<_NScriptSecAdoModernSshPattern>^git@ssh\.dev\.azure\.com:v3/(?&lt;org&gt;[^/]+)/(?&lt;project&gt;[^/]+)/(?&lt;repo&gt;[^/]+?)(?:\.git)?/?$</_NScriptSecAdoModernSshPattern>
+			<_NScriptSecAdoLegacyHttpsPattern>^https?://(?:[^/@]+@)?(?&lt;org&gt;[^/.]+)\.visualstudio\.com/(?&lt;project&gt;[^/]+)/_git/(?&lt;repo&gt;[^/]+?)(?:\.git)?/?$</_NScriptSecAdoLegacyHttpsPattern>
+			<_NScriptSecAdoOrg>$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernHttpsPattern)').Groups[1].Value)</_NScriptSecAdoOrg>
+			<_NScriptSecAdoProject>$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernHttpsPattern)').Groups[2].Value)</_NScriptSecAdoProject>
+			<_NScriptSecAdoRepo>$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernHttpsPattern)').Groups[3].Value)</_NScriptSecAdoRepo>
+			<_NScriptSecAdoOrg Condition="'$(_NScriptSecAdoOrg)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernSshPattern)').Groups[1].Value)</_NScriptSecAdoOrg>
+			<_NScriptSecAdoProject Condition="'$(_NScriptSecAdoProject)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernSshPattern)').Groups[2].Value)</_NScriptSecAdoProject>
+			<_NScriptSecAdoRepo Condition="'$(_NScriptSecAdoRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoModernSshPattern)').Groups[3].Value)</_NScriptSecAdoRepo>
+			<_NScriptSecAdoOrg Condition="'$(_NScriptSecAdoOrg)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoLegacyHttpsPattern)').Groups[1].Value)</_NScriptSecAdoOrg>
+			<_NScriptSecAdoProject Condition="'$(_NScriptSecAdoProject)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoLegacyHttpsPattern)').Groups[2].Value)</_NScriptSecAdoProject>
+			<_NScriptSecAdoRepo Condition="'$(_NScriptSecAdoRepo)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(NScriptSecondarySourceRepoOriginUrl)', '$(_NScriptSecAdoLegacyHttpsPattern)').Groups[3].Value)</_NScriptSecAdoRepo>
+			<NScriptSecondarySourceMapRoot Condition="'$(_NScriptSecAdoOrg)' != '' and '$(_NScriptSecAdoProject)' != '' and '$(_NScriptSecAdoRepo)' != ''">https://dev.azure.com/$(_NScriptSecAdoOrg)/$(_NScriptSecAdoProject)/_apis/git/repositories/$(_NScriptSecAdoRepo)/items?api-version=7.1&amp;versionDescriptor.version=$(NScriptSecondaryCommitSha)&amp;versionDescriptor.versionType=commit&amp;path=/</NScriptSecondarySourceMapRoot>
+		</PropertyGroup>
+
+		<Warning Text="NScriptSecondaryRepoRoot set but origin URL '$(_NScriptSecOriginUrlRedacted)' did not match GitHub or Azure DevOps. Set NScriptSecondarySourceMapRoot manually for other providers."
+		         Condition="'$(NScriptSecondarySourceMapRoot)' == '' and '$(NScriptSecondarySourceRepoOriginUrl)' != '' and '$(NScriptSecondaryCommitSha)' != ''" />
+
+		<Message Importance="high"
+		         Text="NScript secondary repo source maps: sourceRoot='$(NScriptSecondarySourceMapRoot)' repoRoot='$(NScriptSecondaryRepoRoot)'"
+		         Condition="'$(NScriptSecondarySourceMapRoot)' != ''" />
+	</Target>
+
 	<Target
 		Name="ScriptGenerate"
 		Inputs="$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)\$(AssemblyName).$(Ext);@(ReferencePath)"
 		Outputs="$(JsOutputPath)\$(AssemblyName).js"
-		DependsOnTargets="$(CoreCompile);ComputeNScriptRepoMetadata"
+		DependsOnTargets="$(CoreCompile);ComputeNScriptRepoMetadata;ComputeNScriptSecondaryRepoMetadata"
 		Condition="$(GenerateJs) == True">
 
 		<Message
@@ -170,6 +248,10 @@
 			<ScriptGenerateOption Include="-optimize" Condition="'$(JsOptimize)' == 'true'" />
 			<ScriptGenerateOption Include="-sourceMapRoot &quot;$(SourceMapRoot)&quot;" Condition="'$(SourceMapRoot)' != ''" />
 			<ScriptGenerateOption Include="-repoRoot &quot;$(NScriptRepoRoot)&quot;" Condition="'$(SourceMapRoot)' != '' and '$(NScriptRepoRoot)' != ''" />
+			<ScriptGenerateOption Include="-secondarySourceRoot &quot;$(NScriptSecondarySourceMapRoot)&quot;"
+				Condition="'$(NScriptSecondarySourceMapRoot)' != ''" />
+			<ScriptGenerateOption Include="-secondaryRepoRoot &quot;$(NScriptSecondaryRepoRoot)&quot;"
+				Condition="'$(NScriptSecondarySourceMapRoot)' != '' and '$(NScriptSecondaryRepoRoot)' != ''" />
 		</ItemGroup>
 
 		<MakeDir Directories="$(JsOutputPath)" Condition="!Exists('$(JsOutputPath)')" />

--- a/Sources/Compiler/SourceMap/SourceMap.cs
+++ b/Sources/Compiler/SourceMap/SourceMap.cs
@@ -200,6 +200,27 @@ namespace OwaSourceMapper
         public string RepoRoot { get; set; }
 
         /// <summary>
+        /// Optional absolute path to a secondary repository root (e.g. a deployed dependency
+        /// such as the NScript framework or a shared library). When set alongside
+        /// <see cref="SecondarySourceRoot"/>, files under this root are emitted into
+        /// <c>sources[i]</c> as absolute <c>https://</c> URLs (prefixed by
+        /// <see cref="SecondarySourceRoot"/>). Per the V3 source map spec DevTools uses such
+        /// absolute entries directly without prepending <see cref="SourceRoot"/>, so secondary-
+        /// repo sources resolve against the dependency's remote raw-file base while primary
+        /// sources keep using the app's <see cref="SourceRoot"/>.
+        /// </summary>
+        public string SecondaryRepoRoot { get; set; }
+
+        /// <summary>
+        /// Optional raw-file base URL for files under <see cref="SecondaryRepoRoot"/> (for
+        /// example <c>https://raw.githubusercontent.com/owner/repo/sha/</c>). Required for the
+        /// secondary-repo rebase to fire; if null or empty the secondary rebase is skipped and
+        /// the legacy absolutized form is used (matching the no-opt-in behaviour). Must be an
+        /// <c>https://</c> URL.
+        /// </summary>
+        public string SecondarySourceRoot { get; set; }
+
+        /// <summary>
         /// Mapping comparison.
         /// </summary>
         /// <param name="lineCol1"> The first line col. </param>
@@ -306,6 +327,50 @@ namespace OwaSourceMapper
 
             string relative = fullPath.Substring(normalizedRepoRoot.Length);
             return relative.Replace("\\", "/");
+        }
+
+        /// <summary>
+        /// Resolves the <c>sources[i]</c> entry for <paramref name="rawFile"/> using the
+        /// configured repo roots. Decision order:
+        /// <list type="number">
+        ///   <item><description>Primary repo: emit forward-slash, repo-relative path so DevTools
+        ///         combines it with <see cref="SourceRoot"/>.</description></item>
+        ///   <item><description>Secondary repo (only when <paramref name="secondarySourceRoot"/>
+        ///         is supplied): emit an absolute <c>https://</c> URL composed of the secondary
+        ///         source root plus the rebased path. Per V3 spec DevTools uses absolute URLs
+        ///         in <c>sources[]</c> directly, bypassing the <see cref="SourceRoot"/>
+        ///         prepend — this is the mechanism that lets a single map reference two
+        ///         repositories.</description></item>
+        ///   <item><description>Neither: fall back to the legacy absolutized form so existing
+        ///         consumers see no change.</description></item>
+        /// </list>
+        /// </summary>
+        /// <param name="rawFile">                   Source file path as stored by <see cref="AddMapping"/>
+        ///     (with backslashes escaped). </param>
+        /// <param name="normalizedPrimaryRoot">     Normalized primary repo root, or null. </param>
+        /// <param name="normalizedSecondaryRoot">   Normalized secondary repo root, or null. </param>
+        /// <param name="secondarySourceRoot">       Raw-file base URL for the secondary repo; null
+        ///     or empty disables the secondary rebase even if <paramref name="normalizedSecondaryRoot"/>
+        ///     is set, since without a URL we have nothing to absolutize against. </param>
+        private string GetSourceEntry(string rawFile,
+            string normalizedPrimaryRoot,
+            string normalizedSecondaryRoot,
+            string secondarySourceRoot)
+        {
+            // Primary repo → relative path (DevTools prepends app sourceRoot)
+            string rebased = TryRebaseToRepoRoot(rawFile, normalizedPrimaryRoot);
+            if (rebased != null) return rebased;
+
+            // Secondary repo → absolute URL (DevTools uses it directly, bypasses sourceRoot prepend)
+            if (normalizedSecondaryRoot != null && !string.IsNullOrEmpty(secondarySourceRoot))
+            {
+                rebased = TryRebaseToRepoRoot(rawFile, normalizedSecondaryRoot);
+                if (rebased != null)
+                    return secondarySourceRoot.TrimEnd('/') + "/" + rebased;
+            }
+
+            // Legacy fallback
+            return AbsolutizeForSources(rawFile);
         }
 
         /// <summary>
@@ -439,11 +504,15 @@ namespace OwaSourceMapper
             {
                 Dictionary<string, int> fileMap = new Dictionary<string, int>(this.files.Count);
                 string normalizedRepoRoot = NormalizeRepoRoot(this.RepoRoot);
+                string normalizedSecondaryRoot = NormalizeRepoRoot(this.SecondaryRepoRoot);
                 sb.Append("\t\"sources\": [");
                 for (int i = 0; i < this.files.Count; i++)
                 {
-                    var fileName = TryRebaseToRepoRoot(this.files[i], normalizedRepoRoot)
-                        ?? AbsolutizeForSources(this.files[i]);
+                    var fileName = GetSourceEntry(
+                        this.files[i],
+                        normalizedRepoRoot,
+                        normalizedSecondaryRoot,
+                        this.SecondarySourceRoot);
                     if (fileMap.TryGetValue(fileName, out var tmp))
                     { fileMap[fileName] = tmp + 1; fileName = fileName + tmp + 1; }
                     else

--- a/Sources/Compiler/SunlightTestAdapter/SunlightTestAdapter.csproj
+++ b/Sources/Compiler/SunlightTestAdapter/SunlightTestAdapter.csproj
@@ -42,7 +42,7 @@
          (they author the [TestFixture]/[Test] attributes). The adapter only
          reads attribute metadata via MetadataLoadContext, so we don't need
          to ship the SunlightUnit assembly transitively. -->
-    <PackageReference Include="Mcqdb.NScript.SunlightUnit" Version="$(NScriptPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Mcqdb.NScript.SunlightUnit" Version="[1.0.0,)" PrivateAssets="all" />
     <!-- Used for metadata-only inspection of the test DLL. The test DLL is
          NScript-compiled (custom mscorlib facade); Assembly.LoadFile + GetTypes
          fails to resolve those references at runtime. MetadataLoadContext reads

--- a/Test/Compiler/NScript.Utils.Test/ParseOptionsSecondaryRepoTests.cs
+++ b/Test/Compiler/NScript.Utils.Test/ParseOptionsSecondaryRepoTests.cs
@@ -1,0 +1,151 @@
+//-----------------------------------------------------------------------
+// <copyright file="ParseOptionsSecondaryRepoTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.Utils.Test
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NScript.Lib;
+    using NScript.Utils;
+
+    /// <summary>
+    /// Validation tests for the issue #85 secondary-repo command-line flags
+    /// (<c>-secondarySourceRoot</c>, <c>-secondaryRepoRoot</c>) parsed by
+    /// <see cref="ParseOptions.ParseArgs"/>. The shared <see cref="Logger"/> singleton is
+    /// reset in <see cref="Setup"/> so a previous test's error state cannot pollute
+    /// subsequent assertions (HasErrors is what determines ParseArgs' null return).
+    /// </summary>
+    [TestClass]
+    public class ParseOptionsSecondaryRepoTests
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            // ParseArgs returns null when Logger.Instance.HasErrors. The default Logger
+            // implementation accumulates errors across tests; swap in a fresh instance so
+            // each test starts from a clean state.
+            Logger.Instance = new Logger();
+        }
+
+        /// <summary>
+        /// Returns the path to a DLL that exists on disk so the <c>-references</c> argument
+        /// passes the file-existence check inside <see cref="ParseOptions.ParseArgs"/>.
+        /// Using the running test assembly's own location keeps the test self-contained and
+        /// works on every platform.
+        /// </summary>
+        private static string ExistingDllPath
+            => typeof(ParseOptionsSecondaryRepoTests).Assembly.Location;
+
+        /// <summary>
+        /// Sanity check: the four-arg "valid baseline" that the failure tests below extend
+        /// with bad secondary flags must, by itself, parse successfully. Without this
+        /// assertion the failure tests could pass for the wrong reason (e.g. missing
+        /// references file rather than the new validation).
+        /// </summary>
+        [TestMethod]
+        public void CommandLine_ValidBaseline_ParsesSuccessfully()
+        {
+            string dll = ExistingDllPath;
+            var result = ParseOptions.ParseArgs(new[]
+            {
+                "-outJs", "app.js",
+                "-entryAssembly", dll,
+                "-references", dll,
+                "-sourceMapRoot", "https://primary.example/",
+            });
+
+            Assert.IsNotNull(result, "Baseline args must parse successfully — failure tests rely on this.");
+        }
+
+        /// <summary>
+        /// -secondarySourceRoot is only meaningful when paired with the primary
+        /// -sourceMapRoot — without it, the secondary URL would side-step a sourceRoot that
+        /// doesn't exist, producing maps whose secondary sources resolve fine but whose
+        /// primary sources are stuck in the legacy <c>.ashx</c> fallback. ParseArgs must
+        /// reject the partial configuration loudly (return null).
+        /// </summary>
+        [TestMethod]
+        public void CommandLine_SecondarySourceRoot_RequiresPrimarySourceMapRoot()
+        {
+            string dll = ExistingDllPath;
+            var result = ParseOptions.ParseArgs(new[]
+            {
+                "-outJs", "app.js",
+                "-entryAssembly", dll,
+                "-references", dll,
+                "-secondarySourceRoot", "https://example.com/",
+            });
+
+            Assert.IsNull(result, "ParseArgs must return null when -secondarySourceRoot is supplied without -sourceMapRoot");
+        }
+
+        /// <summary>
+        /// -secondarySourceRoot must be an https:// URL — the whole point is to embed an
+        /// absolute URL in <c>sources[]</c> so DevTools fetches it directly. http://, file://
+        /// or any other scheme would either fail to load in the browser or defeat the
+        /// bypass-sourceRoot mechanism.
+        /// </summary>
+        [TestMethod]
+        public void CommandLine_SecondarySourceRoot_MustBeHttps()
+        {
+            string dll = ExistingDllPath;
+            var result = ParseOptions.ParseArgs(new[]
+            {
+                "-outJs", "app.js",
+                "-entryAssembly", dll,
+                "-references", dll,
+                "-sourceMapRoot", "https://example.com/",
+                "-secondarySourceRoot", "http://example.com/",
+            });
+
+            Assert.IsNull(result, "ParseArgs must return null when -secondarySourceRoot is not https://");
+        }
+
+        /// <summary>
+        /// Companion check to the partial-configuration validation: <c>-secondaryRepoRoot</c>
+        /// without <c>-secondarySourceRoot</c> has nothing to absolutize against, so the
+        /// command line is rejected.
+        /// </summary>
+        [TestMethod]
+        public void CommandLine_SecondaryRepoRoot_RequiresSecondarySourceRoot()
+        {
+            string dll = ExistingDllPath;
+            var result = ParseOptions.ParseArgs(new[]
+            {
+                "-outJs", "app.js",
+                "-entryAssembly", dll,
+                "-references", dll,
+                "-sourceMapRoot", "https://example.com/",
+                "-secondaryRepoRoot", System.IO.Path.GetTempPath(),
+            });
+
+            Assert.IsNull(result, "ParseArgs must return null when -secondaryRepoRoot is supplied without -secondarySourceRoot");
+        }
+
+        /// <summary>
+        /// Happy path: when all secondary flags are supplied alongside the primary
+        /// <c>-sourceMapRoot</c>, ParseArgs must succeed and surface both values on the
+        /// returned <see cref="ParseOptions"/> instance.
+        /// </summary>
+        [TestMethod]
+        public void CommandLine_SecondaryFlags_FullyConfigured_PropagatesValues()
+        {
+            string dll = ExistingDllPath;
+            var result = ParseOptions.ParseArgs(new[]
+            {
+                "-outJs", "app.js",
+                "-entryAssembly", dll,
+                "-references", dll,
+                "-sourceMapRoot", "https://primary.example/",
+                "-secondarySourceRoot", "https://secondary.example/lib/",
+                "-secondaryRepoRoot", System.IO.Path.GetTempPath(),
+            });
+
+            Assert.IsNotNull(result, "ParseArgs must succeed when secondary flags are fully configured");
+            Assert.AreEqual("https://secondary.example/lib/", result.SecondarySourceRoot);
+            Assert.AreEqual(System.IO.Path.GetTempPath(), result.SecondaryRepoRoot);
+        }
+    }
+}

--- a/Test/Compiler/SourceMap.Test/SourceMapTests.cs
+++ b/Test/Compiler/SourceMap.Test/SourceMapTests.cs
@@ -365,6 +365,61 @@ namespace OwaSourceMapper.Test
         }
 
         /// <summary>
+        /// Multi-repo support: when a file lives under <see cref="SourceMap.SecondaryRepoRoot"/>
+        /// and <see cref="SourceMap.SecondarySourceRoot"/> is configured, the corresponding
+        /// <c>sources[i]</c> entry must be emitted as a fully absolute <c>https://</c> URL
+        /// (secondary URL + repo-relative path). Per the V3 spec DevTools uses such absolute
+        /// entries directly and does NOT prepend <see cref="SourceMap.SourceRoot"/> — that is
+        /// the mechanism that lets one map reference two repositories.
+        /// </summary>
+        [TestMethod]
+        public void ToString_SecondaryRepoFile_EmitsAbsoluteUrl()
+        {
+            var map = new SourceMap { File = "app.js", SourceRoot = "/sourcemap/app/", RepoRoot = @"C:\app\", SecondaryRepoRoot = @"C:\lib\", SecondarySourceRoot = "https://raw.githubusercontent.com/org/lib/abc123/" };
+            map.AddMapping(1, 0, 1, 0, @"C:\lib\src\Foo.cs");
+            string json = map.ToString();
+            StringAssert.Contains(json, "\"https://raw.githubusercontent.com/org/lib/abc123/src/Foo.cs\"");
+        }
+
+        /// <summary>
+        /// Mixed-bundle integration: a single map containing files from BOTH repos must emit
+        /// the primary file as a repo-relative path (DevTools combines it with the app's
+        /// <see cref="SourceMap.SourceRoot"/>) and the secondary file as an absolute URL
+        /// (DevTools uses it verbatim). Crucially, the secondary file must NOT appear in its
+        /// would-be repo-relative form, since that would resolve against the wrong remote.
+        /// </summary>
+        [TestMethod]
+        public void ToString_MixedBundle_PrimaryRelativeSecondaryAbsolute()
+        {
+            var map = new SourceMap { File = "app.js", SourceRoot = "https://raw.githubusercontent.com/org/app/sha1/", RepoRoot = @"C:\app\", SecondaryRepoRoot = @"C:\lib\", SecondarySourceRoot = "https://raw.githubusercontent.com/org/lib/sha2/" };
+            map.AddMapping(1, 0, 1, 0, @"C:\app\src\App.cs");
+            map.AddMapping(2, 0, 2, 0, @"C:\lib\src\Lib.cs");
+            string json = map.ToString();
+            // App source → relative path
+            StringAssert.Contains(json, "\"src/App.cs\"");
+            // Library source → absolute URL
+            StringAssert.Contains(json, "\"https://raw.githubusercontent.com/org/lib/sha2/src/Lib.cs\"");
+            // Library source must NOT appear as relative
+            Assert.IsFalse(json.Contains("\"src/Lib.cs\""));
+        }
+
+        /// <summary>
+        /// Safety regression: <see cref="SourceMap.SecondaryRepoRoot"/> on its own (without a
+        /// <see cref="SourceMap.SecondarySourceRoot"/>) must NOT trigger the absolute-URL
+        /// rebase. Without a remote URL there is nothing to prefix, so we fall back to the
+        /// legacy absolutized form — same behaviour as a fully-unconfigured map.
+        /// </summary>
+        [TestMethod]
+        public void ToString_SecondaryRepoRoot_WithoutSecondarySourceRoot_FallsBackToLegacy()
+        {
+            var map = new SourceMap { File = "app.js", SourceRoot = "/sourcemap/app/", RepoRoot = @"C:\app\", SecondaryRepoRoot = @"C:\lib\" /* SecondarySourceRoot intentionally null */ };
+            map.AddMapping(1, 0, 1, 0, @"C:\lib\src\Foo.cs");
+            string json = map.ToString();
+            // Should fall back to AbsolutizeForSources, NOT an absolute https:// URL
+            Assert.IsFalse(json.Contains("https://"));
+        }
+
+        /// <summary>
         /// Repo-rebase preserves the long form unchanged in <c>sourcesLong</c>; only the
         /// browser-facing <c>sources[]</c> array is rebased. This keeps the local-disk
         /// resolution path (used by the ASP.NET Core handler when a file IS available


### PR DESCRIPTION
## Summary

Fixes #85

- Adds `SecondaryRepoRoot` / `SecondarySourceRoot` properties to `SourceMap` so files from a dependency repo are emitted as absolute `https://` URLs in `sources[]` rather than falling back to `AbsolutizeForSources()` (which produces `B$/sources/...` paths that combine nonsensically with the app's GitHub `sourceRoot`)
- Exploits the V3 source map spec: absolute URLs in `sources[]` are used verbatim by DevTools — `sourceRoot` is **not** prepended — so one `.map` can reference two distinct Git repos
- New compiler flags: `-secondarySourceRoot <url>` and `-secondaryRepoRoot <path>` wired through `ParseOptions` → `Builder` → `JSWriter` → `SourceMap`
- New MSBuild target `ComputeNScriptSecondaryRepoMetadata` auto-detects GitHub / ADO URL + commit SHA from the secondary repo using the same git exec + regex patterns as the primary `ComputeNScriptRepoMetadata`; exposes `NScriptSecondaryRepoRoot` / `NScriptSecondarySourceMapRoot` / `NScriptSecondaryCommitSha` / `NScriptSecondarySourceRepoOriginUrl` properties
- Feature generalised to any dependency repo (NScript framework, internal shared libraries, etc.) — not NScript-specific

## How to use

```xml
<!-- In your app's .csproj or Directory.Build.props -->
<PropertyGroup>
  <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
  <!-- Path to the secondary repo's local checkout — SHA + remote URL auto-detected -->
  <NScriptSecondaryRepoRoot>$(MSBuildThisFileDirectory)..\NScript\</NScriptSecondaryRepoRoot>
</PropertyGroup>
```

For non-GitHub/ADO remotes, set `NScriptSecondarySourceMapRoot` manually (skips auto-detection).

## Test plan

- [x] `ToString_SecondaryRepoFile_EmitsAbsoluteUrl` — secondary repo file → absolute `https://` URL
- [x] `ToString_MixedBundle_PrimaryRelativeSecondaryAbsolute` — primary relative, secondary absolute in same map
- [x] `ToString_SecondaryRepoRoot_WithoutSecondarySourceRoot_FallsBackToLegacy` — graceful fallback when only one half configured
- [x] `CommandLine_SecondarySourceRoot_RequiresPrimarySourceMapRoot` — validation rejects secondary without primary
- [x] `CommandLine_SecondarySourceRoot_MustBeHttps` — validation rejects non-https secondary source root
- [x] All 88 existing `SourceMap.Test` tests pass
- [x] All 33 existing `NScript.Utils.Test` tests pass
- [x] `dotnet build NScript_Full.sln -c Debug` — 0 errors