### PR TITLE
Fix: Razor skin templates write short name instead of absolute path in sourcesLong[] (#87)

### DIFF
--- a/Sources/Compiler/RazorSkinParser/RazorSkinCompiler.cs
+++ b/Sources/Compiler/RazorSkinParser/RazorSkinCompiler.cs
@@ -23,7 +23,8 @@ namespace NScript.RazorSkin
         public static SkinTemplateNode CompileToIR(
             string templateName,
             string templateSource,
-            string[] additionalCSharpSources = null)
+            string[] additionalCSharpSources = null,
+            string sourceFile = null)
         {
             var log = Logger;
             var totalSw = Stopwatch.StartNew();
@@ -44,7 +45,7 @@ namespace NScript.RazorSkin
             // Phase 3: Build IR
             phaseSw.Restart();
             log.Debug("Phase {Phase} started for template {TemplateName}", "BuildIR", templateName);
-            var ir = TemplateIRBuilder.Build(templateName, preprocessed, parsed);
+            var ir = TemplateIRBuilder.Build(templateName, preprocessed, parsed, sourceFile);
             log.Debug("Phase {Phase} completed in {ElapsedMs}ms for template {TemplateName}", "BuildIR", phaseSw.ElapsedMilliseconds, templateName);
 
             // Phase 4: Roslyn analysis (refine classifications)

--- a/Sources/Compiler/RazorSkinParser/RazorTemplatingPlugin.cs
+++ b/Sources/Compiler/RazorSkinParser/RazorTemplatingPlugin.cs
@@ -191,7 +191,7 @@ namespace Sunlight.Framework.Observables
 
                             var ir = RazorSkinCompiler.CompileToIR(
                                 templateName, templateSource,
-                                additionalSources);
+                                additionalSources, fileName);
                             // Store under both short name and full resource name
                             // so [Skin("full.resource.name.skin.cshtml")] matches
                             _compiledIRs[templateName] = ir;

--- a/Sources/Compiler/RazorSkinParser/TemplateIR/TemplateIRBuilder.cs
+++ b/Sources/Compiler/RazorSkinParser/TemplateIR/TemplateIRBuilder.cs
@@ -105,8 +105,13 @@ namespace NScript.RazorSkin.TemplateIR
         public static SkinTemplateNode Build(
             string templateName,
             PreprocessorResult preprocessed,
-            RazorParseResult parsed)
+            RazorParseResult parsed,
+            string sourceFile = null)
         {
+            // Use the full source path for Location.FileName so source-map entries resolve
+            // to the .skin.cshtml file on disk rather than the short template name.
+            string locationFileName = sourceFile ?? templateName;
+
             var root = new SkinTemplateNode
             {
                 TemplateName = templateName,
@@ -148,12 +153,12 @@ namespace NScript.RazorSkin.TemplateIR
             // Anchor the root SkinTemplateNode at the first attributable span in the
             // method body so the final source map has a non-null fallback Location for
             // template-level JST (skin factory / getter).
-            root.Location = TryGetLocation(methodNode, templateName)
-                ?? FindFirstAttributableLocation(methodNode, templateName)
-                ?? new Location(templateName, 1, 0);
+            root.Location = TryGetLocation(methodNode, locationFileName)
+                ?? FindFirstAttributableLocation(methodNode, locationFileName)
+                ?? new Location(locationFileName, 1, 0);
 
             // Walk the flat sequence of children in the method body
-            WalkMethodBody(methodNode.Children, root, preprocessed.ModelTypeName, templateName);
+            WalkMethodBody(methodNode.Children, root, preprocessed.ModelTypeName, locationFileName);
 
             // Count IR nodes by type
             var htmlCount = CountNodes<HtmlNode>(root.Children);

--- a/Test/Compiler/RazorSkinParser.Test/TemplateSourceMapTests.cs
+++ b/Test/Compiler/RazorSkinParser.Test/TemplateSourceMapTests.cs
@@ -187,11 +187,108 @@ namespace RazorSkinParser.Test
             field.FieldType.Should().Be(typeof(Location));
         }
 
-        private static SkinTemplateNode BuildIR(string template)
+        // -----------------------------------------------------------------------
+        // sourceFile parameter regression tests (Phase 3c fix)
+        //
+        // Before this fix every Location.FileName in Razor-template IR contained
+        // the short template name (e.g. "TestSkin") instead of the absolute path
+        // to the .skin.cshtml file. This caused SourceMap.Server to return 404
+        // because sourcesLong[] held the short name rather than a disk path.
+        // The tests below guard all node types against a regression.
+        // -----------------------------------------------------------------------
+
+        private const string AbsoluteSourceFile = @"B:\project\Views\TestSkin.skin.cshtml";
+
+        [TestMethod]
+        public void SourceFile_Root_UsesAbsolutePath()
+        {
+            var ir = BuildIR("@model TestVM\n\n<div>Hello</div>", AbsoluteSourceFile);
+
+            ir.Location.Should().NotBeNull();
+            ir.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "sourceFile must override templateName as Location.FileName so " +
+                "sourcesLong[] in the source map resolves to the .skin.cshtml on disk");
+        }
+
+        [TestMethod]
+        public void SourceFile_HtmlNode_UsesAbsolutePath()
+        {
+            var ir = BuildIR("@model TestVM\n\n<div>Hello</div>", AbsoluteSourceFile);
+
+            var html = ir.Children.OfType<HtmlNode>().First();
+            html.Location.Should().NotBeNull();
+            html.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "WalkMethodBody must propagate locationFileName (not templateName) into HtmlNode");
+        }
+
+        [TestMethod]
+        public void SourceFile_ExpressionBindingNode_UsesAbsolutePath()
+        {
+            var ir = BuildIR("@model TestVM\n\n<span>@Model.Name</span>", AbsoluteSourceFile);
+
+            var binding = ir.Children.OfType<ExpressionBindingNode>().First();
+            binding.Location.Should().NotBeNull();
+            binding.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "CreateExpressionBinding must propagate locationFileName into ExpressionBindingNode");
+        }
+
+        [TestMethod]
+        public void SourceFile_EventNode_UsesAbsolutePath()
+        {
+            var ir = BuildIR(
+                "@model TestVM\n\n<button onclick=\"@Model.HandleClick\">Click</button>",
+                AbsoluteSourceFile);
+
+            var evt = ir.Children.OfType<EventNode>().FirstOrDefault();
+            evt.Should().NotBeNull();
+            evt.Location.Should().NotBeNull();
+            evt.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "CreateEventNode must propagate locationFileName into EventNode");
+        }
+
+        [TestMethod]
+        public void SourceFile_ConditionalNode_UsesAbsolutePath()
+        {
+            var ir = BuildIR(
+                "@model TestVM\n\n@if (Model.IsActive)\n{\n    <div>Active</div>\n}",
+                AbsoluteSourceFile);
+
+            var cond = ir.Children.OfType<ConditionalNode>().First();
+            cond.Location.Should().NotBeNull();
+            cond.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "ParseIfBlock must propagate locationFileName into ConditionalNode");
+        }
+
+        [TestMethod]
+        public void SourceFile_LoopNode_UsesAbsolutePath()
+        {
+            var ir = BuildIR(
+                "@model TestVM\n\n@foreach (var item in Model.Items)\n{\n    <li>@item.Name</li>\n}",
+                AbsoluteSourceFile);
+
+            var loop = ir.Children.OfType<LoopNode>().First();
+            loop.Location.Should().NotBeNull();
+            loop.Location.FileName.Should().Be(AbsoluteSourceFile,
+                "ParseForeachBlock must propagate locationFileName into LoopNode");
+        }
+
+        [TestMethod]
+        public void SourceFile_Null_FallsBackToTemplateName()
+        {
+            // When sourceFile is omitted the short template name must remain the
+            // fallback — this is the path used by tests and any caller without a
+            // disk path available.
+            var ir = BuildIR("@model TestVM\n\n<div>Hello</div>");
+
+            ir.Location.FileName.Should().Be(TestTemplateName,
+                "omitting sourceFile must fall back to templateName, not null");
+        }
+
+        private static SkinTemplateNode BuildIR(string template, string sourceFile = null)
         {
             var preprocessed = RazorSkinPreprocessor.Process(template);
             var parsed = RazorParserPhase.Parse(TestTemplateName, preprocessed.CleanedTemplate);
-            return TemplateIRBuilder.Build(TestTemplateName, preprocessed, parsed);
+            return TemplateIRBuilder.Build(TestTemplateName, preprocessed, parsed, sourceFile);
         }
     }
 }


### PR DESCRIPTION
Closes #87

## Summary

- Razor `.skin.cshtml` templates were writing the short template name (e.g. `"AppShell"`) into `sourcesLong[]` of the generated source map instead of the absolute disk path, causing `SourceMap.Server` to return 404 for every Razor template source file
- Root cause: `TemplateIRBuilder.Build` used `templateName` as `Location.FileName` for all IR nodes; the full `.skin.cshtml` path was available in `RazorTemplatingPlugin` but dropped before reaching the builder
- Fix: thread `sourceFile` (full path) through `CompileToIR` → `Build`; compute `locationFileName = sourceFile ?? templateName`; use for all `Location` constructions while keeping `templateName` as IR identity

## Changes

| File | Change |
|------|--------|
| `TemplateIRBuilder.cs` | Add `sourceFile` param; compute `locationFileName`; use for all `new Location(...)` |
| `RazorSkinCompiler.cs` | Add `sourceFile` param; pass through to `Build` |
| `RazorTemplatingPlugin.cs` | Pass `fileName` from `GetResourceFileName` as `sourceFile` |
| `TemplateSourceMapTests.cs` | 7 new regression tests covering `sourceFile` override through every IR node type |

## Test plan

- [x] All 830 tests pass (780 compiler + 50 E2E browser) — pre-commit hook verified
- [x] `TemplateSourceMapTests` — 7 new tests: root, HtmlNode, ExpressionBindingNode, EventNode, ConditionalNode, LoopNode, null fallback
- [x] Manual verification: `http://localhost:5005/sourcemap/TodoApp/Test/Framework/TodoApp/RazorTemplates/AppShell.skin.cshtml` returns 200 (was 404 before fix)
- [x] `sourcesLong[61]` in `TodoApp.map` is now `B:\sources\NScript\Test\Framework\TodoApp\RazorTemplates\AppShell.skin.cshtml` (was `"AppShell"`)