### PR TITLE
Add SourceMap.Server support to test runner; add DevServer to solution (#91)

### DIFF
--- a/NScript_Full.sln
+++ b/NScript_Full.sln
@@ -146,6 +146,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sunlight.Framework.Data.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoApp.Test.Runner", "Test\Framework\TodoApp.Test.Runner\TodoApp.Test.Runner.csproj", "{C10084E9-1E62-4130-8C42-552BDC998E22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevServer", "Test\Framework\DevServer\DevServer.csproj", "{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -756,6 +758,18 @@ Global
 		{C10084E9-1E62-4130-8C42-552BDC998E22}.Release|x86.Build.0 = Release|Any CPU
 		{C10084E9-1E62-4130-8C42-552BDC998E22}.Release|x64.ActiveCfg = Release|Any CPU
 		{C10084E9-1E62-4130-8C42-552BDC998E22}.Release|x64.Build.0 = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|x86.Build.0 = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -818,6 +832,7 @@ Global
 		{39FD32BE-9BF5-4B6A-9D46-0DB079A0B3DD} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
 		{2FE77C74-2DC3-46BF-99B3-0F4E71DCFA7B} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
 		{C10084E9-1E62-4130-8C42-552BDC998E22} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
+		{1E5E2E8E-FE27-44BC-9D3F-27E93CEB42BA} = {83E63E0D-A2F7-6880-9B65-A58BDBC8FCDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {583A0EE8-123E-4527-835C-EF2149A86292}

--- a/Sources/Compiler/SunlightTestAdapter/Runner.cs
+++ b/Sources/Compiler/SunlightTestAdapter/Runner.cs
@@ -2,6 +2,7 @@ namespace SunlightTestAdapter;
 
 using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -12,13 +13,52 @@ public class TestRunner
     private const string QunitJsPath = "/qunit.js";
     private const string QunitCssPath = "/qunit.css";
     private const string IndexPath = "/index.html";
+    private const string SourceMapPrefix = "/sourcemap/";
 
     private readonly string _jsFilePath;
+    private Dictionary<string, string>? _sourceLongMap;
 
     public TestRunner(string jsFilePath)
     {
         _jsFilePath = jsFilePath;
     }
+
+    // Builds sources[i] -> sourcesLong[i] lookup from the companion .map file.
+    private Dictionary<string, string> GetSourceLongMap()
+    {
+        if (_sourceLongMap != null) return _sourceLongMap;
+        var mapPath = Path.ChangeExtension(_jsFilePath, ".map");
+        if (!File.Exists(mapPath)) return _sourceLongMap = new();
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(mapPath));
+            var root = doc.RootElement;
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (root.TryGetProperty("sources", out var srcProp) &&
+                root.TryGetProperty("sourcesLong", out var longProp))
+            {
+                var sources = srcProp.EnumerateArray().ToArray();
+                var longs = longProp.EnumerateArray().ToArray();
+                for (int i = 0; i < Math.Min(sources.Length, longs.Length); i++)
+                {
+                    var shortName = sources[i].GetString();
+                    var longPath = longs[i].GetString();
+                    if (shortName != null && longPath != null)
+                        map[shortName] = longPath;
+                }
+            }
+            return _sourceLongMap = map;
+        }
+        catch { return _sourceLongMap = new(); }
+    }
+
+    // Rewrites sourceRoot in the map JSON so DevTools fetches sources from our
+    // synthetic host instead of the baked-in SrcMapper.ashx / localhost URL.
+    private static string PatchSourceRoot(string mapJson) =>
+        Regex.Replace(
+            mapJson,
+            @"""sourceRoot""\s*:\s*""[^""]*""",
+            $@"""sourceRoot"":""{SyntheticHost}{SourceMapPrefix}""");
 
     public async Task<RootObject[]> RunTests(IMessageLogger logger)
     {
@@ -139,6 +179,47 @@ public class TestRunner
                 Status = 200,
                 ContentType = "application/javascript; charset=utf-8",
                 BodyBytes = bytes,
+            });
+        });
+
+        // Serve the companion .map file for the test bundle. Rewrite sourceRoot to
+        // point at our synthetic host so DevTools requests source files from us
+        // rather than the baked-in SrcMapper.ashx URL.
+        await page.RouteAsync(SyntheticHost + "/**/*.map", async route =>
+        {
+            var mapPath = Path.ChangeExtension(_jsFilePath, ".map");
+            if (!File.Exists(mapPath))
+            {
+                await route.FulfillAsync(new RouteFulfillOptions { Status = 404 });
+                return;
+            }
+            var mapJson = await File.ReadAllTextAsync(mapPath);
+            await route.FulfillAsync(new RouteFulfillOptions
+            {
+                Status = 200,
+                ContentType = "application/json; charset=utf-8",
+                Body = PatchSourceRoot(mapJson),
+            });
+        });
+
+        // Serve individual source files via the sourcesLong[] lookup table.
+        // DevTools requests https://nscript.test/sourcemap/{sources[i]} after
+        // reading the patched sourceRoot from the .map file above.
+        await page.RouteAsync(SyntheticHost + "/sourcemap/**", async route =>
+        {
+            var sourceName = Uri.UnescapeDataString(
+                route.Request.Url[(SyntheticHost + SourceMapPrefix).Length..]);
+            var sourceMap = GetSourceLongMap();
+            if (!sourceMap.TryGetValue(sourceName, out var filePath) || !File.Exists(filePath))
+            {
+                await route.FulfillAsync(new RouteFulfillOptions { Status = 404 });
+                return;
+            }
+            await route.FulfillAsync(new RouteFulfillOptions
+            {
+                Status = 200,
+                ContentType = "text/plain; charset=utf-8",
+                BodyBytes = await File.ReadAllBytesAsync(filePath),
             });
         });
     }

--- a/Test/Framework/DevServer/DevServer.csproj
+++ b/Test/Framework/DevServer/DevServer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>DevServer</AssemblyName>
+    <RootNamespace>DevServer</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../Sources/Compiler/SourceMap.Server/SourceMap.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Test/Framework/DevServer/Directory.Build.props
+++ b/Test/Framework/DevServer/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Stop NScript Framework Directory.Build.props inheritance — DevServer uses the standard .NET SDK -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+</Project>

--- a/Test/Framework/DevServer/Program.cs
+++ b/Test/Framework/DevServer/Program.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.FileProviders;
+using OwaSourceMapper.Server;
+
+// Resolve the TestWebApplication directory relative to this project.
+// When run from the project dir (dotnet run) the base is the project source dir;
+// when run from the bin dir the base is the output dir, so we walk up from either.
+string devServerDir = AppContext.BaseDirectory;
+string webAppDir = ResolveWebAppDir(devServerDir);
+string mapsDir = Path.Combine(webAppDir, "GeneratedScripts");
+string repoRoot = Path.GetFullPath(Path.Combine(webAppDir, "../../.."));
+
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://localhost:5005");
+
+var app = builder.Build();
+
+// Serve static files from TestWebApplication/.
+var fp = new PhysicalFileProvider(webAppDir);
+app.UseDefaultFiles(new DefaultFilesOptions
+{
+    FileProvider = fp,
+    DefaultFileNames = ["TodoApp.htm"],
+});
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = fp,
+    ServeUnknownFileTypes = true,
+});
+
+// SourceMap.Server — resolves sourcesLong paths for DevTools source requests.
+app.MapSourceMapFiles("/sourcemap", new SourceMapFileHandlerOptions
+{
+    MapsDirectory = mapsDir,
+    AllowedSourceRoots = [repoRoot],
+});
+
+Console.WriteLine($"Web root : {webAppDir}");
+Console.WriteLine($"Maps dir : {mapsDir}");
+Console.WriteLine($"Repo root: {repoRoot}");
+Console.WriteLine("Open     : http://localhost:5005/TodoApp.htm");
+
+app.Run();
+
+static string ResolveWebAppDir(string startDir)
+{
+    // Walk up from startDir looking for the TestWebApplication sibling.
+    // Handles both `dotnet run` (project dir) and bin/Debug/net8.0 (bin dir).
+    var current = new DirectoryInfo(startDir);
+    while (current != null)
+    {
+        string candidate = Path.Combine(current.FullName, "TestWebApplication");
+        if (Directory.Exists(candidate))
+            return Path.GetFullPath(candidate);
+
+        // Also check sibling of current dir name == "DevServer"
+        if (current.Name == "DevServer")
+        {
+            string sibling = Path.Combine(current.Parent!.FullName, "TestWebApplication");
+            if (Directory.Exists(sibling))
+                return Path.GetFullPath(sibling);
+        }
+
+        current = current.Parent;
+    }
+
+    throw new DirectoryNotFoundException(
+        "Could not locate TestWebApplication relative to " + startDir +
+        ". Run from the DevServer project directory or a parent.");
+}


### PR DESCRIPTION
Closes #91

## Summary

- `Runner.cs` now serves `.map` files and source files via Playwright routes so DevTools can resolve source maps during headless test runs
- `DevServer` project added to `NScript_Full.sln` — the ASP.NET Core dev server for manual browser testing is now a first-class solution member

## Changes

| File | Change |
|------|--------|
| `SunlightTestAdapter/Runner.cs` | Two new Playwright routes: `/**/*.map` (map file with patched `sourceRoot`) and `/sourcemap/**` (source files via `sourcesLong[]` lookup) |
| `NScript_Full.sln` | Add `Test/Framework/DevServer/DevServer.csproj` |
| `Test/Framework/DevServer/*` | New: Program.cs, DevServer.csproj, Directory.Build.props |

## How source map serving works in the runner

1. Test bundle loaded at `https://nscript.test/test-bundle.js` with `//# sourceMappingURL=TodoApp.Test.map`
2. Browser requests `https://nscript.test/TodoApp.Test.map` → new `/**/*.map` route serves the companion `.map` file, rewriting `sourceRoot` from the baked-in `SrcMapper.ashx` URL to `https://nscript.test/sourcemap/`
3. DevTools requests `https://nscript.test/sourcemap/{sources[i]}` for each source file → new `/sourcemap/**` route looks up `sources[i]` in the `sourcesLong[]` dictionary and serves the file from disk

## Test plan

- [x] 830 tests pass (780 compiler + 50 E2E) — pre-commit hook verified
- [x] `dotnet build NScript_Full.sln` builds DevServer without errors