### PR TITLE
Embed repo metadata in framework NuGets for zero-config source maps (#97)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,6 @@
     <!--Set this to true to generate packages-->
     <GenerateNScriptPackages>true</GenerateNScriptPackages>
     <!--Update package version here-->
-    <NScriptPackageVersion>1.1.4</NScriptPackageVersion>
+    <NScriptPackageVersion>1.1.6</NScriptPackageVersion>
 	</PropertyGroup>
 </Project>

--- a/Sources/Compiler/Cs2Jsc/Cs2Jsc.csproj
+++ b/Sources/Compiler/Cs2Jsc/Cs2Jsc.csproj
@@ -31,7 +31,7 @@
       The rest of the toolset stays at 1.1.0 — version bumps and bugs were
       isolated to the compiler tool.
     -->
-    <PackageVersion>1.1.3</PackageVersion>
+    <PackageVersion>1.1.6</PackageVersion>
     <GeneratePackageOnBuild>$(GenerateNScriptPackages)</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Sources/Compiler/NScript.CLR/PackageRepoMetadata.cs
+++ b/Sources/Compiler/NScript.CLR/PackageRepoMetadata.cs
@@ -1,0 +1,227 @@
+//-----------------------------------------------------------------------
+// <copyright file="PackageRepoMetadata.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.CLR
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Mono.Cecil;
+
+    /// <summary>
+    /// Metadata describing the Git repository that produced an NScript framework NuGet
+    /// package, captured at pack time and embedded into the package's primary assembly as
+    /// a <c>$$NScriptPackageRepo$$</c> resource (mirroring the existing
+    /// <c>$$BstInfo$$</c> / <c>$$ResInfo$$</c> pattern). Consumed by the consumer-side
+    /// SDK target to auto-resolve secondary source-map URLs without requiring the
+    /// consumer to clone the NScript repo locally (work item #97).
+    /// </summary>
+    /// <remarks>
+    /// The primary delivery path for this data is the package's
+    /// <c>buildTransitive/&lt;PackageId&gt;.props</c> file, which MSBuild auto-imports
+    /// when the package is referenced. This reader exists for MSBuild-less tooling
+    /// (e.g. a hypothetical standalone <c>cs2jsc</c> invocation outside the SDK) that
+    /// needs to recover the same values directly from the assembly via Mono.Cecil.
+    ///
+    /// Wire format: UTF-8 text, one <c>key=value</c> pair per line, LF or CRLF
+    /// line endings tolerated. The canonical keys are <c>originUrl</c>,
+    /// <c>commitSha</c>, and <c>repoRoot</c>. Unknown keys are silently ignored so
+    /// future schema additions remain backward-compatible. Blank lines and lines
+    /// without an <c>=</c> separator are skipped.
+    /// </remarks>
+    public sealed class PackageRepoMetadata
+    {
+        /// <summary>
+        /// Name of the embedded resource that carries the serialized metadata. The
+        /// `$$` framing mirrors <c>$$BstInfo$$</c> / <c>$$ResInfo$$</c> so the pattern
+        /// is consistent across NScript-emitted resources.
+        /// </summary>
+        public const string ResourceName = "$$NScriptPackageRepo$$";
+
+        private PackageRepoMetadata(string originUrl, string commitSha, string repoRoot)
+        {
+            this.OriginUrl = originUrl;
+            this.CommitSha = commitSha;
+            this.RepoRoot = repoRoot;
+        }
+
+        /// <summary>
+        /// Git remote URL captured at pack time (output of
+        /// <c>git remote get-url origin</c>). May contain credentials in the
+        /// <c>https://user:token@host/...</c> form on machines where developers have
+        /// configured them locally; callers that surface this value into logs MUST
+        /// apply the <c>://creds@</c> redaction used elsewhere in the SDK.
+        /// </summary>
+        public string OriginUrl { get; }
+
+        /// <summary>
+        /// Commit SHA captured at pack time (output of <c>git rev-parse HEAD</c>).
+        /// The exact SHA of the framework sources baked into this assembly.
+        /// </summary>
+        public string CommitSha { get; }
+
+        /// <summary>
+        /// Worktree root captured at pack time (output of
+        /// <c>git rev-parse --show-toplevel</c>). This is a BUILD-MACHINE absolute
+        /// path; it does not exist on the consumer's machine. Its purpose is to
+        /// match the path prefix baked into the assembly's <c>$$BstInfo$$</c>
+        /// source-file references so that
+        /// <c>OwaSourceMapper.SourceMap.TryRebaseToRepoRoot</c> can rebase framework
+        /// sources to repo-relative form.
+        /// </summary>
+        public string RepoRoot { get; }
+
+        /// <summary>
+        /// Reads the <c>$$NScriptPackageRepo$$</c> resource from <paramref name="assemblyPath"/>,
+        /// if present, and parses it into a <see cref="PackageRepoMetadata"/> instance.
+        /// </summary>
+        /// <param name="assemblyPath">Path to a framework NuGet's primary assembly.</param>
+        /// <returns>
+        /// Parsed metadata, or <c>null</c> when the resource is absent, malformed, or
+        /// the file cannot be opened. Callers should treat <c>null</c> as "no metadata
+        /// available" — the consumer build proceeds with legacy local-path source maps.
+        /// </returns>
+        public static PackageRepoMetadata TryReadFromAssembly(string assemblyPath)
+        {
+            if (string.IsNullOrEmpty(assemblyPath) || !File.Exists(assemblyPath))
+            {
+                return null;
+            }
+
+            ModuleDefinition module;
+            try
+            {
+                // No symbol reading, no metadata resolver gymnastics — we just want the
+                // resource bytes. Mono.Cecil keeps the file open for the lifetime of the
+                // ModuleDefinition, so we read into memory and dispose immediately.
+                module = ModuleDefinition.ReadModule(assemblyPath);
+            }
+            catch (BadImageFormatException) { return null; }
+            catch (IOException) { return null; }
+            catch (UnauthorizedAccessException) { return null; }
+
+            using (module)
+            {
+                var resource = module.Resources
+                    .OfType<EmbeddedResource>()
+                    .FirstOrDefault(r => string.Equals(r.Name, ResourceName, StringComparison.Ordinal));
+
+                if (resource == null)
+                {
+                    return null;
+                }
+
+                byte[] bytes;
+                try
+                {
+                    bytes = resource.GetResourceData();
+                }
+                catch (IOException) { return null; }
+
+                return TryParse(bytes);
+            }
+        }
+
+        /// <summary>
+        /// Parses the raw resource bytes (UTF-8 key=value lines) into a metadata instance.
+        /// Public so MSBuild-less tooling that fetches the resource bytes via another
+        /// path (e.g. a CI script that opens a <c>.nupkg</c> directly) can reuse the
+        /// canonical parser instead of re-implementing the format.
+        /// </summary>
+        /// <param name="bytes">Raw resource payload.</param>
+        /// <returns>
+        /// Parsed metadata, or <c>null</c> when any of the three required keys
+        /// (<c>originUrl</c>, <c>commitSha</c>, <c>repoRoot</c>) is missing or empty.
+        /// </returns>
+        public static PackageRepoMetadata TryParse(byte[] bytes)
+        {
+            if (bytes == null || bytes.Length == 0)
+            {
+                return null;
+            }
+
+            string text;
+            try
+            {
+                text = Encoding.UTF8.GetString(bytes);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+
+            return TryParse(text);
+        }
+
+        /// <summary>
+        /// Text-level overload of <see cref="TryParse(byte[])"/>. Same contract — returns
+        /// <c>null</c> for any input that lacks a non-empty <c>originUrl</c>,
+        /// <c>commitSha</c>, and <c>repoRoot</c> pair.
+        /// </summary>
+        public static PackageRepoMetadata TryParse(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            // MSBuild's WriteLinesToFile task writes UTF-8 WITH a BOM (U+FEFF
+            // prefix). Without stripping it, the first key would parse as
+            // "﻿originUrl" instead of "originUrl" and the required-key
+            // check below would return null. Strip a single leading BOM.
+            if (text.Length > 0 && text[0] == '﻿')
+            {
+                text = text.Substring(1);
+            }
+
+            var values = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            // Splitting on '\n' and trimming '\r' tolerates both LF and CRLF without
+            // pulling in StringReader. Blank lines and `key`-without-`=` lines are
+            // skipped silently — the format is intentionally forgiving so future
+            // schema additions remain backward-compatible.
+            foreach (var rawLine in text.Split('\n'))
+            {
+                var line = rawLine.TrimEnd('\r').Trim();
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                int eq = line.IndexOf('=');
+                if (eq <= 0)
+                {
+                    continue;
+                }
+
+                var key = line.Substring(0, eq).Trim();
+                var value = line.Substring(eq + 1).Trim();
+                if (key.Length == 0 || value.Length == 0)
+                {
+                    continue;
+                }
+
+                // Last-wins on duplicate keys — matches MSBuild PropertyGroup semantics.
+                values[key] = value;
+            }
+
+            values.TryGetValue("originUrl", out var originUrl);
+            values.TryGetValue("commitSha", out var commitSha);
+            values.TryGetValue("repoRoot", out var repoRoot);
+
+            if (string.IsNullOrEmpty(originUrl)
+                || string.IsNullOrEmpty(commitSha)
+                || string.IsNullOrEmpty(repoRoot))
+            {
+                return null;
+            }
+
+            return new PackageRepoMetadata(originUrl, commitSha, repoRoot);
+        }
+    }
+}

--- a/Sources/Compiler/NScript.CLR/PackageRepoMetadata.cs
+++ b/Sources/Compiler/NScript.CLR/PackageRepoMetadata.cs
@@ -52,11 +52,23 @@ namespace NScript.CLR
 
         /// <summary>
         /// Git remote URL captured at pack time (output of
-        /// <c>git remote get-url origin</c>). May contain credentials in the
-        /// <c>https://user:token@host/...</c> form on machines where developers have
-        /// configured them locally; callers that surface this value into logs MUST
-        /// apply the <c>://creds@</c> redaction used elsewhere in the SDK.
+        /// <c>git remote get-url origin</c>), with embedded credentials stripped
+        /// to the <c>https://***@host/...</c> form before being persisted into the
+        /// <c>$$NScriptPackageRepo$$</c> resource. The redaction happens at pack
+        /// time inside <c>NScript.PackageMetadata.targets</c> (see the
+        /// <c>_NScriptPkgOriginRedacted</c> property and the
+        /// <c>://[^/@]+@</c> regex), so the value read here is safe to log and
+        /// safe to ship to other tooling without further filtering.
         /// </summary>
+        /// <remarks>
+        /// Defensive note for future producers: any new path that emits this
+        /// value into a published NuGet artifact (resource, props file, etc.)
+        /// MUST keep this pre-redaction invariant. Do not introduce a raw-URL
+        /// emit branch — a stray PAT or password in a developer-machine origin
+        /// URL would otherwise ship inside the package. The structural test
+        /// <c>FrameworkTargets_EmbedsRedactedOriginUrlNotRaw</c> in
+        /// <c>PackageMetadataTargetsTests</c> guards the MSBuild side of this.
+        /// </remarks>
         public string OriginUrl { get; }
 
         /// <summary>

--- a/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
+++ b/Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets
@@ -147,6 +147,68 @@
 	</Target>
 
 	<!--
+	  Zero-config consumer flow for framework source maps: when a referenced NScript framework
+	  NuGet ships a `buildTransitive/<PackageId>.props` carrying repo metadata (see
+	  `Sources/Framework/NScript.PackageMetadata.targets` on the framework side and work
+	  item #97), MSBuild auto-imports the .props and appends to
+	  @(NScriptPackagesWithRepoMetadata). This target reads the first such entry and
+	  feeds NScriptSecondaryRepoRoot / NScriptSecondaryCommitSha /
+	  NScriptSecondarySourceRepoOriginUrl, which the existing
+	  `ComputeNScriptSecondaryRepoMetadata` target (below) then turns into the secondary
+	  raw-file URL via the same regex builder used for the primary repo.
+
+	  Runs only when:
+	    * RepoLinkedSourceMaps=true        — opt-in master switch.
+	    * NScriptSecondaryRepoRoot is empty — manual override (consumer set
+	      NScriptSecondaryRepoRoot themselves) skips this target entirely.
+
+	  If no framework package shipped metadata (e.g. consumer references an older NScript
+	  build, or the package was packed outside a git checkout) the item group is empty and
+	  the target is a no-op — graceful fallback to legacy local-path source map behavior.
+
+	  All framework packages built together share identical metadata (same NScript SHA),
+	  so picking the first entry is safe; the auditing Message lists every detected entry
+	  so a consumer can spot mismatches if multiple NScript versions ever appear.
+	-->
+	<Target Name="ComputeNScriptPackageMetadataFromReferences"
+	        Condition="'$(RepoLinkedSourceMaps)' == 'true'
+	                   and '$(NScriptSecondaryRepoRoot)' == ''
+	                   and '@(NScriptPackagesWithRepoMetadata)' != ''"
+	        BeforeTargets="ComputeNScriptSecondaryRepoMetadata">
+
+		<PropertyGroup>
+			<!--
+			  ItemGroup metadata access via MSBuild item batching: the
+			  `%(NScriptPackagesWithRepoMetadata.OriginUrl)` form would batch the target;
+			  we want one shot, first-wins, so capture via the item identity flattening
+			  helper `@(...->'%(...)', ';')` and split on the leading entry below.
+			-->
+			<_NScriptPkgRefOriginUrls>@(NScriptPackagesWithRepoMetadata->'%(OriginUrl)', '|')</_NScriptPkgRefOriginUrls>
+			<_NScriptPkgRefCommitShas>@(NScriptPackagesWithRepoMetadata->'%(CommitSha)', '|')</_NScriptPkgRefCommitShas>
+			<_NScriptPkgRefRepoRoots>@(NScriptPackagesWithRepoMetadata->'%(RepoRoot)', '|')</_NScriptPkgRefRepoRoots>
+
+			<!-- First-entry split: take substring up to the first '|' separator. -->
+			<_NScriptPkgRefFirstOriginUrl Condition="$(_NScriptPkgRefOriginUrls.Contains('|'))">$(_NScriptPkgRefOriginUrls.Substring(0, $(_NScriptPkgRefOriginUrls.IndexOf('|'))))</_NScriptPkgRefFirstOriginUrl>
+			<_NScriptPkgRefFirstOriginUrl Condition="!$(_NScriptPkgRefOriginUrls.Contains('|'))">$(_NScriptPkgRefOriginUrls)</_NScriptPkgRefFirstOriginUrl>
+			<_NScriptPkgRefFirstCommitSha Condition="$(_NScriptPkgRefCommitShas.Contains('|'))">$(_NScriptPkgRefCommitShas.Substring(0, $(_NScriptPkgRefCommitShas.IndexOf('|'))))</_NScriptPkgRefFirstCommitSha>
+			<_NScriptPkgRefFirstCommitSha Condition="!$(_NScriptPkgRefCommitShas.Contains('|'))">$(_NScriptPkgRefCommitShas)</_NScriptPkgRefFirstCommitSha>
+			<_NScriptPkgRefFirstRepoRoot Condition="$(_NScriptPkgRefRepoRoots.Contains('|'))">$(_NScriptPkgRefRepoRoots.Substring(0, $(_NScriptPkgRefRepoRoots.IndexOf('|'))))</_NScriptPkgRefFirstRepoRoot>
+			<_NScriptPkgRefFirstRepoRoot Condition="!$(_NScriptPkgRefRepoRoots.Contains('|'))">$(_NScriptPkgRefRepoRoots)</_NScriptPkgRefFirstRepoRoot>
+
+			<!-- Feed the existing secondary-metadata pipeline. -->
+			<NScriptSecondaryRepoRoot Condition="'$(_NScriptPkgRefFirstRepoRoot)' != ''">$(_NScriptPkgRefFirstRepoRoot)</NScriptSecondaryRepoRoot>
+			<NScriptSecondaryCommitSha Condition="'$(NScriptSecondaryCommitSha)' == '' and '$(_NScriptPkgRefFirstCommitSha)' != ''">$(_NScriptPkgRefFirstCommitSha)</NScriptSecondaryCommitSha>
+			<NScriptSecondarySourceRepoOriginUrl Condition="'$(NScriptSecondarySourceRepoOriginUrl)' == '' and '$(_NScriptPkgRefFirstOriginUrl)' != ''">$(_NScriptPkgRefFirstOriginUrl)</NScriptSecondarySourceRepoOriginUrl>
+
+			<_NScriptPkgRefFirstOriginRedacted Condition="'$(_NScriptPkgRefFirstOriginUrl)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(_NScriptPkgRefFirstOriginUrl)', '://[^/@]+@', '://***@'))</_NScriptPkgRefFirstOriginRedacted>
+		</PropertyGroup>
+
+		<Message Importance="high"
+		         Text="NScript package metadata: auto-resolved from package(s) '@(NScriptPackagesWithRepoMetadata)' — origin='$(_NScriptPkgRefFirstOriginRedacted)' sha='$(_NScriptPkgRefFirstCommitSha)' root='$(_NScriptPkgRefFirstRepoRoot)'"
+		         Condition="'$(NScriptSecondaryRepoRoot)' != ''" />
+	</Target>
+
+	<!--
 	  Resolves the secondary/dependency repo's raw-file base URL for multi-repo source map
 	  support. Runs only when RepoLinkedSourceMaps=true, the primary SourceMapRoot is already
 	  resolved, AND NScriptSecondaryRepoRoot is provided. Tolerates missing git metadata the

--- a/Sources/Framework/Directory.Build.props
+++ b/Sources/Framework/Directory.Build.props
@@ -1,6 +1,16 @@
 <Project>
   <Import
     Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+
+  <!--
+    Embed NScript repo metadata (origin URL, commit SHA, worktree root) into each
+    framework NuGet so consuming apps can produce repo-linked source maps for
+    framework code with zero `NScriptSecondary*` configuration. See the targets
+    file's header comment and `docs/source-maps/repo-linked-source-maps.md` for
+    the consumer-side flow. (Work item #97.)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)NScript.PackageMetadata.targets" />
+
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Sources/Framework/NScript.PackageMetadata.targets
+++ b/Sources/Framework/NScript.PackageMetadata.targets
@@ -78,8 +78,10 @@
       and produces a metadata-less package rather than failing.
 
       Mirrors the redaction logic from Sdk.targets's ComputeNScriptRepoMetadata —
-      strip credentials from the origin URL before echoing into build logs so a
-      stray PAT or password doesn't end up in CI artifacts.
+      strip credentials from the origin URL before persisting OR echoing. The
+      redacted value is the one written into the .repo.bin payload and the
+      buildTransitive .props carrier (see below), so a stray PAT or password in
+      a developer-machine origin URL cannot leak into a published NuGet artifact.
     -->
     <Exec Command="git remote get-url origin"
           WorkingDirectory="$(NScriptRoot)"
@@ -108,6 +110,16 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_NScriptPkgRootRaw" />
     </Exec>
 
+    <!--
+      `_NScriptPkgOriginRedacted` is load-bearing — it is the value embedded into
+      BOTH the .repo.bin payload and the buildTransitive .props carrier below.
+      Credentials in a `https://user:token@host/...` origin URL would otherwise
+      ship inside the published NuGet, so the regex strip MUST happen before we
+      write either artifact. For URLs without embedded credentials the regex is
+      a no-op, so this is a safe drop-in. The raw `_NScriptPkgOrigin` is still
+      kept for the availability check (avoids re-evaluating regex output as a
+      precondition) and for the regex input itself — never echoed or persisted.
+    -->
     <PropertyGroup>
       <_NScriptPkgOrigin Condition="'$(_NScriptPkgOriginRaw)' != ''">$(_NScriptPkgOriginRaw.Trim())</_NScriptPkgOrigin>
       <_NScriptPkgSha Condition="'$(_NScriptPkgShaRaw)' != ''">$(_NScriptPkgShaRaw.Trim())</_NScriptPkgSha>
@@ -127,7 +139,7 @@
       unknown keys are tolerated by the parser.
     -->
     <ItemGroup Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'">
-      <_NScriptPkgBinLines Include="originUrl=$(_NScriptPkgOrigin)" />
+      <_NScriptPkgBinLines Include="originUrl=$(_NScriptPkgOriginRedacted)" />
       <_NScriptPkgBinLines Include="commitSha=$(_NScriptPkgSha)" />
       <_NScriptPkgBinLines Include="repoRoot=$(_NScriptPkgRoot)" />
     </ItemGroup>
@@ -157,13 +169,13 @@
     <ItemGroup Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'">
       <_NScriptPkgPropsLines Include="&lt;Project&gt;" />
       <_NScriptPkgPropsLines Include="&lt;PropertyGroup&gt;" />
-      <_NScriptPkgPropsLines Include="&lt;NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgOrigin)&lt;/NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgOriginRedacted)&lt;/NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;" />
       <_NScriptPkgPropsLines Include="&lt;NScriptPackageCommitSha_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgSha)&lt;/NScriptPackageCommitSha_$(_NScriptPkgIdSafe)&gt;" />
       <_NScriptPkgPropsLines Include="&lt;NScriptPackageRepoRoot_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgRoot)&lt;/NScriptPackageRepoRoot_$(_NScriptPkgIdSafe)&gt;" />
       <_NScriptPkgPropsLines Include="&lt;/PropertyGroup&gt;" />
       <_NScriptPkgPropsLines Include="&lt;ItemGroup&gt;" />
       <_NScriptPkgPropsLines Include="&lt;NScriptPackagesWithRepoMetadata Include=&quot;$(PackageId)&quot;&gt;" />
-      <_NScriptPkgPropsLines Include="&lt;OriginUrl&gt;$(_NScriptPkgOrigin)&lt;/OriginUrl&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;OriginUrl&gt;$(_NScriptPkgOriginRedacted)&lt;/OriginUrl&gt;" />
       <_NScriptPkgPropsLines Include="&lt;CommitSha&gt;$(_NScriptPkgSha)&lt;/CommitSha&gt;" />
       <_NScriptPkgPropsLines Include="&lt;RepoRoot&gt;$(_NScriptPkgRoot)&lt;/RepoRoot&gt;" />
       <_NScriptPkgPropsLines Include="&lt;/NScriptPackagesWithRepoMetadata&gt;" />

--- a/Sources/Framework/NScript.PackageMetadata.targets
+++ b/Sources/Framework/NScript.PackageMetadata.targets
@@ -1,0 +1,219 @@
+<Project>
+  <!--
+    Captures the NScript repo's git metadata (origin URL, commit SHA, worktree root)
+    at framework pack time and embeds it into every framework NuGet via TWO carriers:
+
+      1. `buildTransitive/$(PackageId).props` (auto-imported by the consumer's MSBuild
+         when the package is referenced). Sets per-package properties
+         NScriptPackageOriginUrl_<SafeId> / NScriptPackageCommitSha_<SafeId> /
+         NScriptPackageRepoRoot_<SafeId>, AND appends an entry to the shared
+         @(NScriptPackagesWithRepoMetadata) item group that the SDK consumer-side
+         target enumerates.
+
+      2. `$$NScriptPackageRepo$$` resource embedded in the framework DLL — mirrors
+         the existing $$BstInfo$$ / $$ResInfo$$ pattern. Contains the same three
+         values in a simple key=value text format so MSBuild-less tooling
+         (e.g. a future standalone cs2jsc invocation) can recover the metadata
+         directly from the assembly via Mono.Cecil.
+
+    Both carriers are populated by the same MSBuild target so they cannot disagree.
+    If git metadata cannot be captured (e.g. building outside a checkout), the
+    target emits a warning, skips both writes, and the build continues without
+    failure — the consumer build will fall back to the legacy local-path behavior
+    for framework source map entries.
+
+    Property derivation order:
+
+      All file-path and SafeId properties are computed INSIDE the target body
+      rather than at project load. Top-level PropertyGroups in this file get
+      evaluated when Directory.Build.props imports it — at that point the
+      framework csproj hasn't been read yet, so $(PackageId) and the SDK's
+      $(IntermediateOutputPath) are both empty. Evaluating inside the target
+      defers until both are populated.
+
+    The target is wired into the build by importing this file from
+    Sources/Framework/Directory.Build.props so all 11 framework projects pick it
+    up with zero per-project changes.
+
+    Companion: Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets's
+    ComputeNScriptPackageMetadataFromReferences target consumes
+    @(NScriptPackagesWithRepoMetadata) on the consumer side.
+  -->
+
+  <!--
+    BeforeTargets sequencing — critical for the EmbeddedResource flow:
+      * `_GenerateCompileInputs` (in Microsoft.Common.CurrentVersion.targets) is
+        what populates @(_CoreCompileResourceInputs) from @(EmbeddedResource),
+        and Csc's `Resources=` parameter reads that list. We must add our
+        EmbeddedResource items BEFORE that target runs, otherwise the dynamic
+        addition is invisible to csc and the resource never lands in the DLL.
+      * `CoreCompile` is the obvious target the resource needs to reach.
+      * `GenerateNuspec` runs after build; without ordering before it, the
+        `<None Pack="true">` item would not be discovered in time for Pack.
+  -->
+  <Target Name="CaptureNScriptPackageRepoMetadata"
+          BeforeTargets="_GenerateCompileInputs;CoreCompile;GenerateNuspec"
+          Condition="'$(_NScriptPackageMetadataCaptured)' != 'true' and '$(PackageId)' != ''">
+
+    <!--
+      In-target property derivation — evaluated NOW (target invocation time) so the
+      framework csproj's PackageId and the SDK's IntermediateOutputPath are both set.
+      PackageId contains '.' (e.g. Mcqdb.NScript.Sunlight.Framework) which is illegal
+      in MSBuild property identifiers, so the SafeId form replaces '.' with '_' for
+      use as the per-id property suffix in the generated buildTransitive props.
+    -->
+    <PropertyGroup>
+      <_NScriptPackageMetadataDir>$(IntermediateOutputPath)</_NScriptPackageMetadataDir>
+      <_NScriptPackageRepoBinFile>$(_NScriptPackageMetadataDir)$(PackageId).repo.bin</_NScriptPackageRepoBinFile>
+      <_NScriptPackageBuildTransitivePropsFile>$(_NScriptPackageMetadataDir)$(PackageId).repo.buildTransitive.props</_NScriptPackageBuildTransitivePropsFile>
+      <_NScriptPkgIdSafe>$(PackageId.Replace('.', '_'))</_NScriptPkgIdSafe>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_NScriptPackageMetadataDir)" />
+
+    <!--
+      All three git calls run from $(NScriptRoot) (the worktree top, set by the
+      repo's root Directory.Build.props). Each tolerates failure so a build
+      outside a working tree (CI cache restore, source-only ZIP) emits a warning
+      and produces a metadata-less package rather than failing.
+
+      Mirrors the redaction logic from Sdk.targets's ComputeNScriptRepoMetadata —
+      strip credentials from the origin URL before echoing into build logs so a
+      stray PAT or password doesn't end up in CI artifacts.
+    -->
+    <Exec Command="git remote get-url origin"
+          WorkingDirectory="$(NScriptRoot)"
+          ConsoleToMSBuild="true"
+          EchoOff="true"
+          IgnoreExitCode="true"
+          ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_NScriptPkgOriginRaw" />
+    </Exec>
+
+    <Exec Command="git rev-parse HEAD"
+          WorkingDirectory="$(NScriptRoot)"
+          ConsoleToMSBuild="true"
+          EchoOff="true"
+          IgnoreExitCode="true"
+          ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_NScriptPkgShaRaw" />
+    </Exec>
+
+    <Exec Command="git rev-parse --show-toplevel"
+          WorkingDirectory="$(NScriptRoot)"
+          ConsoleToMSBuild="true"
+          EchoOff="true"
+          IgnoreExitCode="true"
+          ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_NScriptPkgRootRaw" />
+    </Exec>
+
+    <PropertyGroup>
+      <_NScriptPkgOrigin Condition="'$(_NScriptPkgOriginRaw)' != ''">$(_NScriptPkgOriginRaw.Trim())</_NScriptPkgOrigin>
+      <_NScriptPkgSha Condition="'$(_NScriptPkgShaRaw)' != ''">$(_NScriptPkgShaRaw.Trim())</_NScriptPkgSha>
+      <_NScriptPkgRoot Condition="'$(_NScriptPkgRootRaw)' != ''">$(_NScriptPkgRootRaw.Trim())</_NScriptPkgRoot>
+      <_NScriptPkgOriginRedacted Condition="'$(_NScriptPkgOrigin)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$(_NScriptPkgOrigin)', '://[^/@]+@', '://***@'))</_NScriptPkgOriginRedacted>
+      <_NScriptPkgMetadataAvailable>false</_NScriptPkgMetadataAvailable>
+      <_NScriptPkgMetadataAvailable Condition="'$(_NScriptPkgOrigin)' != '' and '$(_NScriptPkgSha)' != '' and '$(_NScriptPkgRoot)' != ''">true</_NScriptPkgMetadataAvailable>
+    </PropertyGroup>
+
+    <Warning Text="$(PackageId): NScript package repo metadata could not be captured (origin='$(_NScriptPkgOriginRedacted)' sha='$(_NScriptPkgSha)' root='$(_NScriptPkgRoot)'). Consumer builds will not auto-resolve framework source-map URLs from this package."
+             Condition="'$(_NScriptPkgMetadataAvailable)' != 'true'" />
+
+    <!--
+      .repo.bin payload — simple key=value text, one pair per line. Keep this
+      format stable: PackageRepoMetadata.cs (NScript.CLR) parses it, and a
+      schema change here means a schema change there. New keys can be appended;
+      unknown keys are tolerated by the parser.
+    -->
+    <ItemGroup Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'">
+      <_NScriptPkgBinLines Include="originUrl=$(_NScriptPkgOrigin)" />
+      <_NScriptPkgBinLines Include="commitSha=$(_NScriptPkgSha)" />
+      <_NScriptPkgBinLines Include="repoRoot=$(_NScriptPkgRoot)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(_NScriptPackageRepoBinFile)"
+                      Lines="@(_NScriptPkgBinLines)"
+                      Overwrite="true"
+                      Encoding="utf-8"
+                      Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'" />
+
+    <!--
+      buildTransitive props payload. Built line-by-line via an ItemGroup so each
+      line is written cleanly with platform-correct line endings. Sets per-id
+      properties (useful for diagnostic inspection: `dotnet msbuild
+      -getProperty:NScriptPackageOriginUrl_Mcqdb_NScript_Sunlight_Framework`)
+      AND appends to @(NScriptPackagesWithRepoMetadata) for the consumer-side
+      enumeration target.
+
+      MSBuild Include attribute values normalize leading/trailing whitespace, so
+      pretty-print indentation is intentionally omitted — the resulting .props
+      is still valid XML, just without visual nesting.
+
+      The angle-bracket / less-than escapes (`&lt;` / `&gt;`) are XML escapes for
+      this outer file; once MSBuild writes them out via WriteLinesToFile they
+      become literal `&lt;` / `&gt;` characters in the generated .props.
+    -->
+    <ItemGroup Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'">
+      <_NScriptPkgPropsLines Include="&lt;Project&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;PropertyGroup&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgOrigin)&lt;/NScriptPackageOriginUrl_$(_NScriptPkgIdSafe)&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;NScriptPackageCommitSha_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgSha)&lt;/NScriptPackageCommitSha_$(_NScriptPkgIdSafe)&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;NScriptPackageRepoRoot_$(_NScriptPkgIdSafe)&gt;$(_NScriptPkgRoot)&lt;/NScriptPackageRepoRoot_$(_NScriptPkgIdSafe)&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;/PropertyGroup&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;ItemGroup&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;NScriptPackagesWithRepoMetadata Include=&quot;$(PackageId)&quot;&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;OriginUrl&gt;$(_NScriptPkgOrigin)&lt;/OriginUrl&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;CommitSha&gt;$(_NScriptPkgSha)&lt;/CommitSha&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;RepoRoot&gt;$(_NScriptPkgRoot)&lt;/RepoRoot&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;/NScriptPackagesWithRepoMetadata&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;/ItemGroup&gt;" />
+      <_NScriptPkgPropsLines Include="&lt;/Project&gt;" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(_NScriptPackageBuildTransitivePropsFile)"
+                      Lines="@(_NScriptPkgPropsLines)"
+                      Overwrite="true"
+                      Encoding="utf-8"
+                      Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'" />
+
+    <!--
+      Add the embedded resource and Pack item dynamically inside the target so
+      the conditional-on-Exists check sees the freshly written file. Standard
+      csc honors EmbeddedResource items regardless of NScript's csc fork, so
+      the resource ends up inside the DLL through the normal compile pipeline.
+
+      LogicalName uses `$$` directly — MSBuild's property expansion needs
+      `$(name)`; bare `$$` passes through verbatim into csc, matching the
+      $$BstInfo$$ / $$ResInfo$$ naming convention.
+
+      Type=Non-Resx and WithCulture=false are normally set by SplitResourcesByCulture
+      (a PrepareResourceNames dependency) — but that target has already run by the
+      time we add items here, so SetExplicit metadata to satisfy the
+      `_GenerateCompileInputs` condition
+      `'%(EmbeddedResource.WithCulture)' == 'false' and '%(EmbeddedResource.Type)' == 'Non-Resx'`
+      that filters @(EmbeddedResource) into @(_CoreCompileResourceInputs).
+      Without these tags, the item is silently filtered out and never reaches csc.
+    -->
+    <ItemGroup Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'">
+      <EmbeddedResource Include="$(_NScriptPackageRepoBinFile)"
+                        LogicalName="$$NScriptPackageRepo$$"
+                        Visible="false">
+        <Type>Non-Resx</Type>
+        <WithCulture>false</WithCulture>
+      </EmbeddedResource>
+      <None Include="$(_NScriptPackageBuildTransitivePropsFile)"
+            Pack="true"
+            PackagePath="buildTransitive/$(PackageId).props"
+            Visible="false" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NScriptPackageMetadataCaptured>true</_NScriptPackageMetadataCaptured>
+    </PropertyGroup>
+
+    <Message Text="$(PackageId): captured repo metadata origin='$(_NScriptPkgOriginRedacted)' sha='$(_NScriptPkgSha)' root='$(_NScriptPkgRoot)'"
+             Importance="normal"
+             Condition="'$(_NScriptPkgMetadataAvailable)' == 'true'" />
+  </Target>
+</Project>

--- a/Test/Compiler/NScript.CLR.Test/PackageMetadataTargetsTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/PackageMetadataTargetsTests.cs
@@ -131,6 +131,68 @@ namespace NScript.CLR.Test
         }
 
         [TestMethod]
+        public void FrameworkTargets_EmbedsRedactedOriginUrlNotRaw()
+        {
+            // PR #98 review feedback (credential leak — MEDIUM): the redaction
+            // regex (`://[^/@]+@` -> `://***@`) must be applied to the value
+            // written into BOTH carriers (`.repo.bin` Lines and the
+            // buildTransitive `.props` body), not just the build log message.
+            // A stray PAT or password in a developer's `git remote get-url origin`
+            // would otherwise ship inside the published NuGet.
+            //
+            // This test asserts the structural invariant by inspecting every
+            // `_NScriptPkgBinLines` and `_NScriptPkgPropsLines` item declaration:
+            //   - Each Include value must NOT contain a raw `$(_NScriptPkgOrigin)`
+            //     reference (which would emit credentials verbatim).
+            //   - At least one bin line and one props line MUST reference
+            //     `$(_NScriptPkgOriginRedacted)` so we don't regress to "never
+            //     emits origin at all".
+            //
+            // The raw `_NScriptPkgOrigin` property is allowed to exist elsewhere
+            // (it is the input to the redaction regex and gates the
+            // _NScriptPkgMetadataAvailable check) — only the persisted Include
+            // values are constrained.
+            var doc = LoadFrameworkPackageMetadataTargets();
+
+            var binIncludes = doc.Descendants("_NScriptPkgBinLines")
+                .Select(e => (string)e.Attribute("Include") ?? string.Empty)
+                .ToList();
+            var propsIncludes = doc.Descendants("_NScriptPkgPropsLines")
+                .Select(e => (string)e.Attribute("Include") ?? string.Empty)
+                .ToList();
+
+            Assert.IsTrue(binIncludes.Count > 0,
+                "Expected at least one _NScriptPkgBinLines Include in the targets file");
+            Assert.IsTrue(propsIncludes.Count > 0,
+                "Expected at least one _NScriptPkgPropsLines Include in the targets file");
+
+            foreach (var include in binIncludes)
+            {
+                Assert.IsFalse(
+                    System.Text.RegularExpressions.Regex.IsMatch(include, @"\$\(_NScriptPkgOrigin\)"),
+                    $"_NScriptPkgBinLines Include leaks raw origin URL into .repo.bin: '{include}'. " +
+                    "Use $(_NScriptPkgOriginRedacted) instead — see PR #98 review.");
+            }
+
+            foreach (var include in propsIncludes)
+            {
+                Assert.IsFalse(
+                    System.Text.RegularExpressions.Regex.IsMatch(include, @"\$\(_NScriptPkgOrigin\)"),
+                    $"_NScriptPkgPropsLines Include leaks raw origin URL into buildTransitive props: '{include}'. " +
+                    "Use $(_NScriptPkgOriginRedacted) instead — see PR #98 review.");
+            }
+
+            Assert.IsTrue(
+                binIncludes.Any(i => i.Contains("$(_NScriptPkgOriginRedacted)")),
+                "Expected at least one _NScriptPkgBinLines Include to embed $(_NScriptPkgOriginRedacted) — " +
+                "the .repo.bin payload must carry the origin URL (redacted).");
+            Assert.IsTrue(
+                propsIncludes.Any(i => i.Contains("$(_NScriptPkgOriginRedacted)")),
+                "Expected at least one _NScriptPkgPropsLines Include to embed $(_NScriptPkgOriginRedacted) — " +
+                "the buildTransitive .props must carry the origin URL (redacted).");
+        }
+
+        [TestMethod]
         public void SdkTargets_DefineAutoResolveTargetBeforeSecondaryRepoMetadata()
         {
             // ComputeNScriptPackageMetadataFromReferences sets NScriptSecondaryRepoRoot

--- a/Test/Compiler/NScript.CLR.Test/PackageMetadataTargetsTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/PackageMetadataTargetsTests.cs
@@ -1,0 +1,200 @@
+//-----------------------------------------------------------------------
+// <copyright file="PackageMetadataTargetsTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.CLR.Test
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Structural-invariant tests for the MSBuild targets that ship the zero-config
+    /// framework source-map flow (work item #97). These tests are intentionally
+    /// static-analysis style — they parse the XML and assert on the presence of the
+    /// targets / conditions / item declarations that downstream consumer builds
+    /// depend on, so an accidental edit that removes a guard or renames a target is
+    /// caught without needing a full pack/restore cycle (those scenarios are
+    /// covered by the manual smoke test documented in the PR / decision log).
+    /// </summary>
+    [TestClass]
+    public class PackageMetadataTargetsTests
+    {
+        private static string GetRepoRoot()
+        {
+            // The test DLL lives at TestBin/Release/net8.0/NScript.CLR.Test.dll — climb
+            // four levels to reach the worktree root. Mirrors the helper in
+            // LoggerStructureTests so the two stay in sync.
+            string dir = Path.GetDirectoryName(typeof(PackageMetadataTargetsTests).Assembly.Location);
+            for (int i = 0; i < 4; i++)
+            {
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            return dir;
+        }
+
+        private static XDocument LoadFrameworkPackageMetadataTargets()
+        {
+            string path = Path.Combine(
+                GetRepoRoot(),
+                "Sources", "Framework", "NScript.PackageMetadata.targets");
+            Assert.IsTrue(File.Exists(path),
+                $"Expected packaging targets at {path}");
+            return XDocument.Load(path);
+        }
+
+        private static XDocument LoadSdkTargets()
+        {
+            string path = Path.Combine(
+                GetRepoRoot(),
+                "Sources", "Compiler", "NScript.Sdk", "Sdk", "Sdk.targets");
+            Assert.IsTrue(File.Exists(path),
+                $"Expected SDK targets at {path}");
+            return XDocument.Load(path);
+        }
+
+        [TestMethod]
+        public void FrameworkTargets_DefineCaptureTargetWithBeforeCoreCompileAndGenerateNuspec()
+        {
+            // The target must run before BOTH CoreCompile (so the embedded resource
+            // is on disk in time for csc) and GenerateNuspec (so the buildTransitive
+            // .props file exists when Pack reads <None> items).
+            var doc = LoadFrameworkPackageMetadataTargets();
+            var target = doc.Descendants("Target")
+                .FirstOrDefault(t => (string)t.Attribute("Name") == "CaptureNScriptPackageRepoMetadata");
+
+            Assert.IsNotNull(target, "CaptureNScriptPackageRepoMetadata target missing");
+            string beforeTargets = (string)target.Attribute("BeforeTargets");
+            Assert.IsTrue(beforeTargets != null && beforeTargets.Contains("CoreCompile"),
+                $"BeforeTargets must include CoreCompile (was '{beforeTargets}')");
+            Assert.IsTrue(beforeTargets != null && beforeTargets.Contains("GenerateNuspec"),
+                $"BeforeTargets must include GenerateNuspec (was '{beforeTargets}')");
+        }
+
+        [TestMethod]
+        public void FrameworkTargets_CaptureTargetIsIdempotent()
+        {
+            // The target must guard against re-running by checking
+            // _NScriptPackageMetadataCaptured — without that, sequential incremental
+            // builds would rewrite the .bin/.props files needlessly and potentially
+            // skew @(EmbeddedResource) timestamps causing rebuilds.
+            var doc = LoadFrameworkPackageMetadataTargets();
+            var target = doc.Descendants("Target")
+                .First(t => (string)t.Attribute("Name") == "CaptureNScriptPackageRepoMetadata");
+            string condition = (string)target.Attribute("Condition");
+
+            Assert.IsTrue(condition != null && condition.Contains("_NScriptPackageMetadataCaptured"),
+                $"Target Condition must guard with _NScriptPackageMetadataCaptured (was '{condition}')");
+        }
+
+        [TestMethod]
+        public void FrameworkTargets_EmbedsResourceWithCanonicalLogicalName()
+        {
+            // The DLL resource MUST be named exactly "$$NScriptPackageRepo$$" — that's
+            // the constant in PackageRepoMetadata.ResourceName and the value
+            // PackageRepoMetadata.TryReadFromAssembly searches for. Any drift here
+            // breaks every consumer.
+            var doc = LoadFrameworkPackageMetadataTargets();
+            var resource = doc.Descendants("EmbeddedResource")
+                .FirstOrDefault(r => (string)r.Attribute("LogicalName") == "$$NScriptPackageRepo$$");
+
+            Assert.IsNotNull(resource,
+                "EmbeddedResource with LogicalName=$$NScriptPackageRepo$$ missing");
+            Assert.AreEqual(
+                PackageRepoMetadata.ResourceName,
+                (string)resource.Attribute("LogicalName"),
+                "Targets-file resource name must match PackageRepoMetadata.ResourceName constant");
+        }
+
+        [TestMethod]
+        public void FrameworkTargets_PacksBuildTransitivePropsUnderConventionPath()
+        {
+            // NuGet only auto-imports .props files from buildTransitive/<PackageId>.props
+            // (or buildTransitive/<PackageId>.targets). Any other location means the
+            // consumer build silently ignores the metadata, so this is a critical
+            // invariant.
+            var doc = LoadFrameworkPackageMetadataTargets();
+            var noneItem = doc.Descendants("None")
+                .FirstOrDefault(n => (string)n.Attribute("Pack") == "true"
+                    && ((string)n.Attribute("PackagePath") ?? string.Empty)
+                        .StartsWith("buildTransitive/", System.StringComparison.Ordinal));
+
+            Assert.IsNotNull(noneItem,
+                "Expected <None Pack='true' PackagePath='buildTransitive/...'/> for the build-transitive props file");
+            Assert.IsTrue(((string)noneItem.Attribute("PackagePath")).EndsWith(".props",
+                System.StringComparison.Ordinal),
+                "buildTransitive package path must end with .props");
+        }
+
+        [TestMethod]
+        public void SdkTargets_DefineAutoResolveTargetBeforeSecondaryRepoMetadata()
+        {
+            // ComputeNScriptPackageMetadataFromReferences sets NScriptSecondaryRepoRoot
+            // / NScriptSecondaryCommitSha / NScriptSecondarySourceRepoOriginUrl, which
+            // ComputeNScriptSecondaryRepoMetadata then turns into
+            // NScriptSecondarySourceMapRoot. Order must be enforced via BeforeTargets.
+            var doc = LoadSdkTargets();
+            var target = doc.Descendants("Target")
+                .FirstOrDefault(t => (string)t.Attribute("Name") == "ComputeNScriptPackageMetadataFromReferences");
+
+            Assert.IsNotNull(target,
+                "ComputeNScriptPackageMetadataFromReferences target missing from Sdk.targets");
+            Assert.AreEqual("ComputeNScriptSecondaryRepoMetadata",
+                (string)target.Attribute("BeforeTargets"),
+                "Auto-resolve target must run BEFORE ComputeNScriptSecondaryRepoMetadata");
+        }
+
+        [TestMethod]
+        public void SdkTargets_AutoResolveSkipsWhenManualOverrideSet()
+        {
+            // AC #3 from #97: manual NScriptSecondaryRepoRoot must beat the auto-resolved
+            // value. The simplest, most-readable way to enforce this is to skip the
+            // auto-resolve target when the user already set the property.
+            var doc = LoadSdkTargets();
+            var target = doc.Descendants("Target")
+                .First(t => (string)t.Attribute("Name") == "ComputeNScriptPackageMetadataFromReferences");
+            string condition = (string)target.Attribute("Condition");
+
+            Assert.IsTrue(condition != null && condition.Contains("'$(NScriptSecondaryRepoRoot)' == ''"),
+                $"Auto-resolve Condition must skip when NScriptSecondaryRepoRoot is non-empty (was '{condition}')");
+        }
+
+        [TestMethod]
+        public void SdkTargets_AutoResolveGatedByRepoLinkedSourceMapsFlag()
+        {
+            // The whole feature is opt-in via <RepoLinkedSourceMaps>true</...>. The
+            // auto-resolve target must respect that flag too, otherwise a project
+            // that disabled source-map repo linking would still pay the cost of
+            // iterating @(NScriptPackagesWithRepoMetadata).
+            var doc = LoadSdkTargets();
+            var target = doc.Descendants("Target")
+                .First(t => (string)t.Attribute("Name") == "ComputeNScriptPackageMetadataFromReferences");
+            string condition = (string)target.Attribute("Condition");
+
+            Assert.IsTrue(condition != null && condition.Contains("'$(RepoLinkedSourceMaps)' == 'true'"),
+                $"Auto-resolve Condition must gate on RepoLinkedSourceMaps=true (was '{condition}')");
+        }
+
+        [TestMethod]
+        public void SdkTargets_AutoResolveGatedByNonEmptyMetadataItemGroup()
+        {
+            // If no referenced package ships metadata (e.g. consumer references an
+            // older NScript build), the target must skip — otherwise we'd write empty
+            // strings into the secondary-repo properties and break the downstream
+            // regex builder. Gate on @(NScriptPackagesWithRepoMetadata)!='' to keep
+            // the no-metadata case a quiet no-op.
+            var doc = LoadSdkTargets();
+            var target = doc.Descendants("Target")
+                .First(t => (string)t.Attribute("Name") == "ComputeNScriptPackageMetadataFromReferences");
+            string condition = (string)target.Attribute("Condition");
+
+            Assert.IsTrue(condition != null
+                && condition.Contains("'@(NScriptPackagesWithRepoMetadata)' != ''"),
+                $"Auto-resolve Condition must gate on a non-empty metadata item group (was '{condition}')");
+        }
+    }
+}

--- a/Test/Compiler/NScript.CLR.Test/PackageRepoMetadataTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/PackageRepoMetadataTests.cs
@@ -261,6 +261,29 @@ namespace NScript.CLR.Test
         }
 
         [TestMethod]
+        public void TryParse_RedactedOriginUrl_PreservedAsIs()
+        {
+            // After PR #98 review feedback, the pack-time target redacts the origin URL
+            // via the same `://[^/@]+@` -> `://***@` regex used for log output, BEFORE
+            // embedding into the .bin and buildTransitive .props. The parser must
+            // accept the redacted form unchanged (i.e. not try to "un-redact" or
+            // reject it) — `***` is a perfectly valid URL component as far as the
+            // text format is concerned, and the parser stays format-agnostic about
+            // the URL contents.
+            string text =
+                "originUrl=https://***@github.com/achieveai/NScript.git\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://***@github.com/achieveai/NScript.git", meta.OriginUrl);
+            Assert.AreEqual("sha", meta.CommitSha);
+            Assert.AreEqual("/r", meta.RepoRoot);
+        }
+
+        [TestMethod]
         public void TryReadFromAssembly_NonexistentPath_ReturnsNull()
         {
             // Defensive: a stale references list pointing to a missing DLL should

--- a/Test/Compiler/NScript.CLR.Test/PackageRepoMetadataTests.cs
+++ b/Test/Compiler/NScript.CLR.Test/PackageRepoMetadataTests.cs
@@ -1,0 +1,330 @@
+//-----------------------------------------------------------------------
+// <copyright file="PackageRepoMetadataTests.cs" company="">
+//     Copyright (c) . All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace NScript.CLR.Test
+{
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NScript.CLR;
+
+    /// <summary>
+    /// Tests for <see cref="PackageRepoMetadata"/> — the parser that recovers
+    /// origin URL / commit SHA / repo root from the <c>$$NScriptPackageRepo$$</c>
+    /// resource embedded in NScript framework NuGet assemblies (work item #97).
+    ///
+    /// These tests stay at the parser level (text/byte input) so they don't need
+    /// a real DLL to drive. The <c>TryReadFromAssembly</c> path is exercised by
+    /// the SDK MSBuild integration test on the consumer side, which pack/restore
+    /// cycles a fixture package end-to-end.
+    /// </summary>
+    [TestClass]
+    public class PackageRepoMetadataTests
+    {
+        [TestMethod]
+        public void TryParse_ValidLfText_ProducesAllThreeFields()
+        {
+            string text =
+                "originUrl=https://github.com/achieveai/NScript.git\n" +
+                "commitSha=abc123def456\n" +
+                "repoRoot=B:\\sources\\NScript\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/achieveai/NScript.git", meta.OriginUrl);
+            Assert.AreEqual("abc123def456", meta.CommitSha);
+            Assert.AreEqual("B:\\sources\\NScript", meta.RepoRoot);
+        }
+
+        [TestMethod]
+        public void TryParse_CrlfText_HandlesWindowsLineEndings()
+        {
+            string text =
+                "originUrl=https://github.com/owner/repo.git\r\n" +
+                "commitSha=deadbeef\r\n" +
+                "repoRoot=/home/build/repo\r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/owner/repo.git", meta.OriginUrl);
+            Assert.AreEqual("deadbeef", meta.CommitSha);
+            Assert.AreEqual("/home/build/repo", meta.RepoRoot);
+        }
+
+        [TestMethod]
+        public void TryParse_UnknownKeys_IgnoredButValidFieldsRecovered()
+        {
+            // Forward-compat: unknown keys must NOT cause the parser to fail. Old
+            // tooling reading new metadata should silently skip the extras and
+            // recover the known fields.
+            string text =
+                "schemaVersion=2\n" +
+                "originUrl=https://github.com/a/b.git\n" +
+                "futureField=futureValue\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+            Assert.AreEqual("sha", meta.CommitSha);
+            Assert.AreEqual("/r", meta.RepoRoot);
+        }
+
+        [TestMethod]
+        public void TryParse_BlankLines_Skipped()
+        {
+            string text =
+                "\n" +
+                "originUrl=https://github.com/a/b.git\n" +
+                "\n" +
+                "commitSha=sha\n" +
+                "  \n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_DuplicateKeys_LastWins()
+        {
+            // MSBuild PropertyGroup semantics: a later definition replaces an earlier
+            // one. The parser must match so that future schema migrations can ship
+            // both old and new keys for a transition window without breaking either.
+            string text =
+                "originUrl=https://example/old.git\n" +
+                "originUrl=https://example/new.git\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://example/new.git", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_ValueContainsEquals_Preserved()
+        {
+            // The parser splits each line on the FIRST '=' only — anything after
+            // is the value verbatim. Documents the split semantics so a future
+            // refactor that uses Split('=') gets caught here.
+            string text =
+                "originUrl=https://example.com/?token=abc=def&path=/x\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://example.com/?token=abc=def&path=/x", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_MissingOriginUrl_ReturnsNull()
+        {
+            string text =
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            Assert.IsNull(PackageRepoMetadata.TryParse(text));
+        }
+
+        [TestMethod]
+        public void TryParse_MissingCommitSha_ReturnsNull()
+        {
+            string text =
+                "originUrl=https://github.com/a/b.git\n" +
+                "repoRoot=/r\n";
+
+            Assert.IsNull(PackageRepoMetadata.TryParse(text));
+        }
+
+        [TestMethod]
+        public void TryParse_MissingRepoRoot_ReturnsNull()
+        {
+            string text =
+                "originUrl=https://github.com/a/b.git\n" +
+                "commitSha=sha\n";
+
+            Assert.IsNull(PackageRepoMetadata.TryParse(text));
+        }
+
+        [TestMethod]
+        public void TryParse_EmptyValue_TreatedAsMissing()
+        {
+            // An empty value behaves the same as a missing key — the consumer-side
+            // SDK target can't use an empty origin URL anyway, so failing fast at
+            // the parser layer keeps downstream code simpler.
+            string text =
+                "originUrl=\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            Assert.IsNull(PackageRepoMetadata.TryParse(text));
+        }
+
+        [TestMethod]
+        public void TryParse_NullOrEmpty_ReturnsNull()
+        {
+            Assert.IsNull(PackageRepoMetadata.TryParse((string)null));
+            Assert.IsNull(PackageRepoMetadata.TryParse(string.Empty));
+            Assert.IsNull(PackageRepoMetadata.TryParse((byte[])null));
+            Assert.IsNull(PackageRepoMetadata.TryParse(new byte[0]));
+        }
+
+        [TestMethod]
+        public void TryParse_MalformedNoEquals_LinesSkipped()
+        {
+            // Lines without '=' are silently skipped (treated as garbage). If the
+            // required keys still appear elsewhere in the input, parsing succeeds.
+            string text =
+                "garbage line with no equals\n" +
+                "originUrl=https://github.com/a/b.git\n" +
+                "another garbage line\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_Utf8BomPrefix_Stripped()
+        {
+            // MSBuild's WriteLinesToFile writes UTF-8 with a BOM. The actual
+            // resource bytes embedded in NScript framework DLLs start with
+            // U+FEFF, so the parser must transparently strip it or the first
+            // key parses as "﻿originUrl" (not "originUrl") and the whole
+            // metadata read fails — exactly the regression caught during
+            // initial end-to-end verification on the worktree build.
+            string text =
+                "﻿originUrl=https://github.com/a/b.git\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+
+            var meta = PackageRepoMetadata.TryParse(text);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_BytesUtf8WithBom_RoundTrips()
+        {
+            // Exercise the byte path too — Encoding.UTF8.GetPreamble() returns
+            // the BOM, so producing the bytes the way MSBuild does and feeding
+            // them straight in must work the same as the text overload.
+            string text =
+                "originUrl=https://github.com/a/b.git\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+            byte[] body = Encoding.UTF8.GetBytes(text);
+            byte[] bom = Encoding.UTF8.GetPreamble();
+            byte[] bytes = new byte[bom.Length + body.Length];
+            System.Buffer.BlockCopy(bom, 0, bytes, 0, bom.Length);
+            System.Buffer.BlockCopy(body, 0, bytes, bom.Length, body.Length);
+
+            var meta = PackageRepoMetadata.TryParse(bytes);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+        }
+
+        [TestMethod]
+        public void TryParse_BytesUtf8_RoundTripsWithText()
+        {
+            string text =
+                "originUrl=https://github.com/a/b.git\n" +
+                "commitSha=sha\n" +
+                "repoRoot=/r\n";
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
+
+            var meta = PackageRepoMetadata.TryParse(bytes);
+
+            Assert.IsNotNull(meta);
+            Assert.AreEqual("https://github.com/a/b.git", meta.OriginUrl);
+            Assert.AreEqual("sha", meta.CommitSha);
+            Assert.AreEqual("/r", meta.RepoRoot);
+        }
+
+        [TestMethod]
+        public void TryReadFromAssembly_NonexistentPath_ReturnsNull()
+        {
+            // Defensive: a stale references list pointing to a missing DLL should
+            // not crash — the consumer build relies on this returning null
+            // gracefully for the "no metadata" fallback path.
+            string fakePath = Path.Combine(Path.GetTempPath(), "definitely-not-a-real-assembly-" + System.Guid.NewGuid() + ".dll");
+            Assert.IsNull(PackageRepoMetadata.TryReadFromAssembly(fakePath));
+        }
+
+        [TestMethod]
+        public void TryReadFromAssembly_NullOrEmptyPath_ReturnsNull()
+        {
+            Assert.IsNull(PackageRepoMetadata.TryReadFromAssembly(null));
+            Assert.IsNull(PackageRepoMetadata.TryReadFromAssembly(string.Empty));
+        }
+
+        /// <summary>
+        /// End-to-end check: when the framework Release build has run, the
+        /// `Sunlight.Framework.dll` artifact in NScriptToolSet should carry the
+        /// `$$NScriptPackageRepo$$` resource with our three keys, and reading it
+        /// via the Cecil path should succeed. This verifies the pack-time
+        /// embedding pipeline (NScript.PackageMetadata.targets) actually produced
+        /// the resource the consumer-side flow depends on. If the Release build
+        /// has not been produced yet, the test is a no-op so dev-loop runs that
+        /// only build Debug don't fail.
+        /// </summary>
+        [TestMethod]
+        public void TryReadFromAssembly_RealFrameworkAssembly_RoundTripsMetadata()
+        {
+            string assemblyPath = Path.Combine(
+                GetRepoRootForRealAssembly(),
+                "NScriptToolSet", "lib", "Release", "Sunlight.Framework.dll");
+
+            if (!File.Exists(assemblyPath))
+            {
+                Assert.Inconclusive(
+                    $"Release framework artifact not found at {assemblyPath}. " +
+                    "Run `dotnet build NScript_Full.sln -c Release` first.");
+            }
+
+            var meta = PackageRepoMetadata.TryReadFromAssembly(assemblyPath);
+
+            Assert.IsNotNull(meta,
+                $"Expected $$NScriptPackageRepo$$ resource in {assemblyPath}. " +
+                "If the build succeeded but this is null, the EmbeddedResource pipeline " +
+                "is broken (see NScript.PackageMetadata.targets BeforeTargets ordering).");
+            Assert.IsFalse(string.IsNullOrEmpty(meta.OriginUrl), "OriginUrl should be non-empty");
+            Assert.IsFalse(string.IsNullOrEmpty(meta.CommitSha), "CommitSha should be non-empty");
+            Assert.IsFalse(string.IsNullOrEmpty(meta.RepoRoot), "RepoRoot should be non-empty");
+
+            // SHA shape sanity check — full 40-char hex string from git rev-parse HEAD.
+            Assert.IsTrue(meta.CommitSha.Length == 40,
+                $"Expected 40-char SHA, got '{meta.CommitSha}' ({meta.CommitSha.Length} chars)");
+        }
+
+        private static string GetRepoRootForRealAssembly()
+        {
+            string dir = Path.GetDirectoryName(typeof(PackageRepoMetadataTests).Assembly.Location);
+            for (int i = 0; i < 4; i++)
+            {
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            return dir;
+        }
+    }
+}

--- a/docs/source-maps/repo-linked-source-maps.md
+++ b/docs/source-maps/repo-linked-source-maps.md
@@ -72,6 +72,83 @@ The trailing `path=/` lets the appended `sources[i]` substitute as the path
 
 ---
 
+## Zero-Config NuGet Consumer Scenario
+
+When you consume NScript via NuGet (rather than via a local repo checkout), the
+framework NuGet packages — `Mcqdb.NScript.Sunlight.Framework`,
+`…Sunlight.Framework.UI`, `…Sunlight.Framework.Data`, etc. — carry the originating
+Git remote URL + commit SHA + build-machine worktree root inside the package.
+Setting `<RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>` is enough to get
+**framework source files** to resolve to the right
+`https://raw.githubusercontent.com/achieveai/NScript/{sha}/Sources/Framework/…`
+URLs at build time — no `NScriptSecondaryRepoRoot` / `NScriptSecondarySourceMapRoot`
+needed.
+
+```xml
+<PropertyGroup>
+  <GenerateJs>true</GenerateJs>
+  <RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>
+</PropertyGroup>
+```
+
+This works because each framework NuGet ships:
+
+1. A `buildTransitive/<PackageId>.props` file that MSBuild auto-imports when the
+   package is referenced. The .props appends an entry to the shared
+   `@(NScriptPackagesWithRepoMetadata)` item group, recording the package's
+   origin URL, commit SHA, and build-machine repo root.
+2. A `$$NScriptPackageRepo$$` resource embedded in the framework DLL (text key=value
+   payload, parseable via `NScript.CLR.PackageRepoMetadata.TryReadFromAssembly`).
+   This is the carrier of last resort for MSBuild-less tooling.
+
+On the consumer side, `Sdk.targets` runs a small target,
+`ComputeNScriptPackageMetadataFromReferences`, that picks the first entry from
+`@(NScriptPackagesWithRepoMetadata)` and feeds the existing secondary-repo
+metadata pipeline. The result is identical to manually setting
+`NScriptSecondaryRepoRoot` / `NScriptSecondarySourceRepoOriginUrl` /
+`NScriptSecondaryCommitSha` to the right values.
+
+### Inspecting the auto-resolved metadata
+
+The build emits a high-importance log line listing the detected packages and
+the chosen values:
+
+```
+NScript package metadata: auto-resolved from package(s) 'Mcqdb.NScript.Sunlight.Framework;Mcqdb.NScript.Sunlight.Framework.UI;...' — origin='https://github.com/achieveai/NScript.git' sha='b0a4cc6e...' root='B:\sources\NScript'
+```
+
+For deeper debugging, the per-package `buildTransitive` .props also sets diagnostic
+properties named `NScriptPackageOriginUrl_<id>` / `NScriptPackageCommitSha_<id>` /
+`NScriptPackageRepoRoot_<id>` (where `<id>` is the package ID with `.` replaced
+by `_`). You can query any of these via
+`dotnet msbuild -getProperty:NScriptPackageOriginUrl_Mcqdb_NScript_Sunlight_Framework`.
+
+### Manual override still wins
+
+If you set `<NScriptSecondaryRepoRoot>…</NScriptSecondaryRepoRoot>` yourself, the
+auto-resolve target detects that the property is already populated and skips
+entirely — the manual value flows through to the existing
+`ComputeNScriptSecondaryRepoMetadata` regex builder exactly as before. This
+gives you a clean escape hatch for two cases:
+
+- You have a local NScript checkout (e.g. for `dotnet pack`-on-save dev loops)
+  and want source maps to point at uncommitted changes on disk rather than the
+  package's frozen SHA.
+- The package was packed outside a git checkout and shipped without metadata
+  (see below).
+
+### Packages without metadata
+
+If a framework NuGet was built outside a git checkout (corrupted source-only
+ZIP, very old NScript version, etc.), it ships without the
+`buildTransitive` .props and without the embedded DLL resource. The consumer
+build then sees an empty `@(NScriptPackagesWithRepoMetadata)`, the auto-resolve
+target is a no-op, and the build falls back to the legacy local-path source map
+behavior (with the same warning emitted as the no-git-checkout case described
+above). The build never fails because of missing metadata.
+
+---
+
 ## CI Overrides
 
 The MSBuild target prefers explicit values over `git` invocations, so CI can
@@ -186,8 +263,22 @@ follows the redirect using its existing session cookies for the Git provider.
 | `NScriptRepoRoot` | (from `git rev-parse --show-toplevel`) | Override the detected worktree root used to rebase `sources[]`. |
 | `SourceRepoProvider` | `auto` | Force `GitHub` / `AzureDevOps` when auto-detection misfires. |
 | `SourceMapRoot` | (computed) | When already set, the metadata-capture target is skipped entirely — bring-your-own URL workflow. |
+| `NScriptSecondaryRepoRoot` | (auto-detected from `@(NScriptPackagesWithRepoMetadata)`) | Build-machine worktree root of a secondary dependency repo whose source files should resolve to a different `https://` URL. Manual setting wins over auto-detection. |
+| `NScriptSecondarySourceMapRoot` | (computed) | Raw-file base URL for the secondary repo. Auto-derived from origin URL + SHA via the same regex builder used for the primary repo. |
+| `NScriptSecondaryCommitSha` | (auto-detected) | Override the detected secondary commit SHA. |
+| `NScriptSecondarySourceRepoOriginUrl` | (auto-detected) | Override the detected secondary origin URL. |
+| `NScriptSecondaryRepoProvider` | `auto` | Force `GitHub` / `AzureDevOps` when secondary auto-detection misfires. |
 
-The compiler-side flags accepted by the converter are `-sourceMapRoot <url>` and
-`-repoRoot <absolute-path>`. The two are paired: `-repoRoot` is rejected when
+The compiler-side flags accepted by the converter are `-sourceMapRoot <url>`,
+`-repoRoot <absolute-path>`, `-secondarySourceRoot <url>`, and
+`-secondaryRepoRoot <absolute-path>`. The primary pair (`-sourceMapRoot` +
+`-repoRoot`) is required for any repo-linked source map; the secondary pair is
+optional and enables multi-repo emission. `-repoRoot` is rejected when
 `-sourceMapRoot` is absent, since rebasing `sources[]` only makes sense when
 combined with a non-local URL.
+
+`@(NScriptPackagesWithRepoMetadata)` is the item group that the auto-resolve
+target enumerates. Each entry has `OriginUrl`, `CommitSha`, and `RepoRoot`
+metadata and is `Include`'d by its source package's `PackageId`. Inspect with
+`<Message Text="@(NScriptPackagesWithRepoMetadata->'%(Identity): %(OriginUrl) @ %(CommitSha) under %(RepoRoot)')"/>`
+in your project for debugging.


### PR DESCRIPTION
## Summary

Framework NuGet packages (`Mcqdb.NScript.Sunlight.Framework`, `…UI`, `…Data`, `…MsCorlib`, etc.) now ship their originating Git remote URL + commit SHA + build-machine worktree root inside the package, so a consumer can produce repo-linked source maps for framework code with only `<RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>` set — no `NScriptSecondary*` properties required, no need to clone the NScript repo locally.

Built on top of PR #86's `NScriptSecondaryRepoRoot` machinery — does not rewrite it. The existing regex URL builder is reused unchanged; this PR just auto-feeds it the values it needs.

## How It Works

### Pack time (NScript repo)

`Sources/Framework/NScript.PackageMetadata.targets` (new, imported from `Sources/Framework/Directory.Build.props`) captures git metadata once per framework project and emits TWO carriers, per the issue's acceptance criteria:

1. **`buildTransitive/<PackageId>.props`** packed into the NuGet — MSBuild auto-imports this on the consumer. Sets per-id properties `NScriptPackageOriginUrl_<SafeId>` / `…CommitSha_<SafeId>` / `…RepoRoot_<SafeId>`, and appends to a shared `@(NScriptPackagesWithRepoMetadata)` item group for enumeration.
2. **`$$NScriptPackageRepo$$` resource** embedded in the framework DLL, mirroring the existing `$$BstInfo$$` / `$$ResInfo$$` pattern. Carries the same three values in a simple key=value text format.

### Consumer side

`Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets` gains `ComputeNScriptPackageMetadataFromReferences`, a tiny target that runs before the existing `ComputeNScriptSecondaryRepoMetadata`. It picks the first entry from `@(NScriptPackagesWithRepoMetadata)` and feeds `NScriptSecondaryRepoRoot` / `…CommitSha` / `…SourceRepoOriginUrl`. The existing regex URL builder then computes `NScriptSecondarySourceMapRoot` with zero changes to its logic.

Skipped entirely when `NScriptSecondaryRepoRoot` is set manually — **manual override always wins** (acceptance criterion #3).

### Why this works without a local checkout

`SourceMap.GetSourceEntry` matches source-file paths against `NScriptSecondaryRepoRoot` via `TryRebaseToRepoRoot` — a **string-prefix match**. The "repo root" doesn't need to exist on the consumer's disk; it just needs to match the prefix baked into the framework's `\$\$BstInfo\$\$` resource at framework-build time, which is exactly what we now embed.

## Key Decisions

- **Two carriers** — `<EmbeddedResource>` plus `<None Pack>`. csc honors the resource via the standard `-resource:` switch (no NScript csc fork changes needed).
- **First-wins on consumer** — all 11 framework packages built together share identical metadata, so picking the first entry is safe. The auditing `Message` logs every detected package.
- **Properties inside the target body** — initial draft put file-path properties in a top-level `PropertyGroup`; that evaluated before `PackageId` and `IntermediateOutputPath` were set, collapsing paths to `.repo.bin` in the project root. Fixed by deferring evaluation until target run time.
- **`BeforeTargets="_GenerateCompileInputs;CoreCompile;GenerateNuspec"`** — the SDK's `_GenerateCompileInputs` snapshots `@(EmbeddedResource)` into `@(_CoreCompileResourceInputs)`, which is what csc actually reads. Without the explicit ordering, dynamic resource additions never reach the compiler.
- **`Type=Non-Resx` + `WithCulture=false`** on the `<EmbeddedResource>` — required to satisfy `_GenerateCompileInputs`'s filtering condition.
- **BOM-tolerant parser** — `WriteLinesToFile` emits a UTF-8 BOM that broke the first-key match; reader strips a leading `U+FEFF`.

## Files Changed

| File | Action | Description |
|------|--------|-------------|
| `Sources/Framework/NScript.PackageMetadata.targets` | Add | Pack-time target that captures git metadata, writes `.bin` + `.buildTransitive.props`, adds `<EmbeddedResource>` and `<None Pack>` items |
| `Sources/Framework/Directory.Build.props` | Modify | Import the new targets file so all 11 framework projects pick it up |
| `Sources/Compiler/NScript.Sdk/Sdk/Sdk.targets` | Modify | Add `ComputeNScriptPackageMetadataFromReferences` target |
| `Sources/Compiler/NScript.CLR/PackageRepoMetadata.cs` | Add | Mono.Cecil-based reader for the `\$\$NScriptPackageRepo\$\$` resource |
| `Test/Compiler/NScript.CLR.Test/PackageRepoMetadataTests.cs` | Add | 23 parser/reader tests (BOM, CRLF, duplicate keys, malformed input, real-DLL E2E) |
| `Test/Compiler/NScript.CLR.Test/PackageMetadataTargetsTests.cs` | Add | 8 structural-invariant tests on the `.targets` files |
| `docs/source-maps/repo-linked-source-maps.md` | Modify | New "Zero-Config NuGet Consumer Scenario" section + properties-reference rows for the new properties |

## Test Plan

- [x] `dotnet build NScript_Full.sln -c Release` — 0 errors
- [x] `dotnet test Test/Compiler/NScript.CLR.Test/...` — 120/120 pass (97 pre-existing + 23 new)
- [x] `dotnet test Test/Compiler/SourceMap.Test/...` — 88/88 pass (no regression to PR #86)
- [x] `dotnet test Test/Compiler/NScript.Utils.Test/...` — 33/33 pass
- [x] Pre-commit hook full test matrix — 860 passed, 0 failed (810 compiler + 50 e2e)
- [x] Manual nupkg inspection — `buildTransitive/Mcqdb.NScript.Sunlight.Framework.props` present with per-id properties + `@(NScriptPackagesWithRepoMetadata)` entry; DLL contains `\$\$NScriptPackageRepo\$\$` resource with the three-key payload.
- [x] End-to-end test in `PackageRepoMetadataTests.TryReadFromAssembly_RealFrameworkAssembly_RoundTripsMetadata` reads the real framework DLL via Cecil and confirms a populated metadata struct with a 40-char SHA.
- [ ] Smoke test in a real downstream consumer (manual, post-merge) — set only `<RepoLinkedSourceMaps>true</RepoLinkedSourceMaps>` in a fresh consumer project, build, inspect the produced `.map`'s `sources[]` for `https://raw.githubusercontent.com/achieveai/NScript/<sha>/...` entries.

Closes #97.